### PR TITLE
Static analysis

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: build
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,3 +28,6 @@ jobs:
 
       - name: test
         run: pio test -e native
+
+      - name: static analysis
+        run: pio check --skip-packages --fail-on-defect high

--- a/include/ImageData.h
+++ b/include/ImageData.h
@@ -29,8 +29,8 @@
 
 ******************************************************************************/
 
-#ifndef _IMAGEDATA_H_
-#define _IMAGEDATA_H_
+#ifndef IMAGEDATA_H_
+#define IMAGEDATA_H_
 
 #include <Arduino.h>
 

--- a/include/config.h
+++ b/include/config.h
@@ -17,7 +17,7 @@
 
 #define WIFI_CONNECTION_ATTEMPTS 5
 #define WIFI_PORTAL_TIMEOUT 120
-#define WIFI_CONNECTION_RSSI -100
+#define WIFI_CONNECTION_RSSI (-100)
 
 #define DISPLAY_BMP_IMAGE_SIZE 48062 // in bytes - 62 bytes - header; 48000 bytes - bitmap (480*800 1bpp) / 8
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -36,6 +36,9 @@ lib_deps =
 debug_tool = esp-builtin
 debug_init_break = break setup
 build_type = debug      ;build in debug mode instead of release mode
+check_tool = clangtidy
+check_flags =
+  clangtidy: --checks=bugprone-*,portability-*,clang-analyzer-*,google-*,-google-readability-*
 
 [env:native]
 platform = native


### PR DESCRIPTION
- Run a few [clang-tidy](https://docs.platformio.org/en/latest/advanced/static-code-analysis/tools/clang-tidy.html) checks in CI.
- Address a couple of the warnings it was producing.
- Run CI on PRs