### PR TITLE
Log macro

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -27,7 +27,7 @@ upload_speed = 460800
 build_flags = 
 	-D ARDUINO_USB_MODE=0
 	-D ARDUINO_USB_CDC_ON_BOOT=0
-    -D CORE_DEBUG_LEVEL=0
+	-D CORE_DEBUG_LEVEL=0
 lib_ldf_mode=deep
 lib_deps = 
 	;WiFiManager@^2.0.16-rc.2
@@ -42,6 +42,13 @@ check_tool = clangtidy
 check_flags =
   clangtidy: --checks=bugprone-*,portability-*,clang-analyzer-*,google-*,-google-readability-*
 
+[env:local]
+extends = env:esp32-c3-devkitc-02
+# serial logging
+build_flags =
+	-D ARDUINO_USB_MODE=1
+	-D ARDUINO_USB_CDC_ON_BOOT=1
+	-D CORE_DEBUG_LEVEL=0
 
 [env:native]
 platform = native

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -19,6 +19,7 @@
 #include <Update.h>
 #include <math.h>
 #include <filesystem.h>
+#include "log.h"
 
 bool pref_clear = false;
 
@@ -74,8 +75,8 @@ void bl_init(void)
 
   Serial.begin(115200);
   Log.begin(LOG_LEVEL_VERBOSE, &Serial);
-  Log.info("%s [%d]: BL init success\r\n", __FILE__, __LINE__);
-  Log.info("%s [%d]: Firware version %d.%d.%d\r\n", __FILE__, __LINE__, FW_MAJOR_VERSION, FW_MINOR_VERSION, FW_PATCH_VERSION);
+  Log_info("BL init success");
+  Log_info("Firware version %d.%d.%d", FW_MAJOR_VERSION, FW_MINOR_VERSION, FW_PATCH_VERSION);
   pins_init();
   button_timer = millis();
 
@@ -93,7 +94,7 @@ void bl_init(void)
       if (res)
         Log.info("%s [%d]: preferences cleared success\r\n", __FILE__, __LINE__);
       else
-        Log.fatal("%s [%d]: preferences clearing error\r\n", __FILE__, __LINE__);
+        Log_fatal("preferences clearing error");
     }
   }
   else
@@ -187,7 +188,7 @@ void bl_init(void)
     }
     else
     {
-      Log.error("%s [%d]: SF not saved\r\n", __FILE__, __LINE__);
+      Log_error("SF not saved");
     }
   }
   // EPD init

--- a/src/log.h
+++ b/src/log.h
@@ -1,0 +1,7 @@
+#include <ArduinoLog.h>
+
+#define Log_info(format, ...) Log.info("%s [%d]: " format "\r\n", __FILE__, __LINE__, ##__VA_ARGS__)
+
+#define Log_error(format, ...) Log.error("%s [%d]: " format "\r\n", __FILE__, __LINE__, ##__VA_ARGS__)
+
+#define Log_fatal(format, ...) Log.fatal("%s [%d]: " format "\r\n", __FILE__, __LINE__, ##__VA_ARGS__)


### PR DESCRIPTION
 - Add another env to platformio.ini, so that you can use the "local" environment when you want serial logging.
 - Add new wrapper for Log.info / Log.error / Log.fatal, to tidy up the call sites a bit. I haven't updated all the existing log calls yet, but am happy to do so if it's a good time.