### PR TITLE
FIxed some build warnings

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -19,8 +19,6 @@
 #define PREFERENCES_FILENAME_KEY "filename"
 #define PREFERENCES_CONNECT_RETRY_COUNT "retry_count"
 
-#define WIFI_CONNECTION_ATTEMPTS 5
-#define WIFI_PORTAL_TIMEOUT 120
 #define WIFI_CONNECTION_RSSI (-100)
 
 #define DISPLAY_BMP_IMAGE_SIZE 48062 // in bytes - 62 bytes - header; 48000 bytes - bitmap (480*800 1bpp) / 8

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -199,6 +199,7 @@ bool filesystem_file_rename(const char *old_name, const char *new_name)
         }
         else
             Log.error("%s [%d]: file %s wasn't renamed.\r\n", __FILE__, __LINE__, old_name);
+            return false;
     }
     else
     {


### PR DESCRIPTION
- Fixed redefinition of WIFI_CONNECTION_ATTEMPTS
- Fixed "control reaches end of non-void function" in filesystem_file_rename function
- Deleted unused "WIFI_PORTAL_TIMEOUT" define