### PR TITLE
Version updates

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@
 default_envs = esp32-c3-devkitc-02
 
 [env:esp32-c3-devkitc-02]
-platform = espressif32@6.8.1
+platform = espressif32@6.9.0
 board = esp32-c3-devkitc-02
 framework = arduino
 ; set frequency to 80 MHz
@@ -31,7 +31,7 @@ build_flags =
 lib_ldf_mode=deep
 lib_deps = 
 	;WiFiManager@^2.0.16-rc.2
-	esphome/ESPAsyncWebServer-esphome@^3.2.2
+	esphome/ESPAsyncWebServer-esphome@3.3.0
 	bblanchon/ArduinoJson@^7.1.0
 	https://github.com/thijse/Arduino-Log.git#3f4fcf5a345c1d542e56b88c0ffcb2bd2a5b0bd0
 


### PR DESCRIPTION
- update espressif32 to 6.9.0
- pin ESPAsyncWebServer to 3.3.0

I haven't tested this on a device yet, but will follow up when I get to it.