### PR TITLE
Pin ArduinoJson 7.2.1 to fix build

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -32,7 +32,7 @@ lib_ldf_mode=deep
 lib_deps = 
 	;WiFiManager@^2.0.16-rc.2
 	esphome/ESPAsyncWebServer-esphome@3.3.0
-	bblanchon/ArduinoJson@^7.1.0
+	bblanchon/ArduinoJson@7.2.1
 	https://github.com/thijse/Arduino-Log.git#3f4fcf5a345c1d542e56b88c0ffcb2bd2a5b0bd0
 
 debug_tool = esp-builtin
@@ -56,7 +56,7 @@ build_flags =
 platform = native
 test_framework = unity
 lib_deps =
-	bblanchon/ArduinoJson@^7.1.0
+	bblanchon/ArduinoJson@7.2.1
 	fabiobatsilva/ArduinoFake@^0.4.0
 build_flags =
 	-D ARDUINOJSON_ENABLE_ARDUINO_STRING=1


### PR DESCRIPTION
A new version of ArduinoJson (7.3.0) [broke CI](https://github.com/usetrmnl/firmware/actions/runs/12550275963/job/34992874761). This PR doesn't fix the new error, but pins an older version of the library to avoid it for now.

If only this ecosystem had lockfiles and deterministic package installs! 🤨 