### PR TITLE
Multiple WiFi Network Support

### DIFF
--- a/lib/wificaptive/src/WifiCaptive.cpp
+++ b/lib/wificaptive/src/WifiCaptive.cpp
@@ -314,22 +314,15 @@ bool WifiCaptive::isSaved()
     return _savedWifis[0].ssid != "";
 }
 
-void WifiCaptive::readWifiCredentials(int index)
+void WifiCaptive::readWifiCredentials()
 {
     Preferences preferences;
     preferences.begin("wificaptive", true);
 
-    if (index >= 0 && index < WIFI_MAX_SAVED_CREDS) {
-        // Read only the specified index
-        _savedWifis[index].ssid = preferences.getString(WIFI_SSID_KEY(index), "");
-        _savedWifis[index].pswd = preferences.getString(WIFI_PSWD_KEY(index), "");
-    } else {
-        // Read all credentials (original behavior)
-        for (int i = 0; i < WIFI_MAX_SAVED_CREDS; i++)
-        {
-            _savedWifis[i].ssid = preferences.getString(WIFI_SSID_KEY(i), "");
-            _savedWifis[i].pswd = preferences.getString(WIFI_PSWD_KEY(i), "");
-        }
+    for (int i = 0; i < WIFI_MAX_SAVED_CREDS; i++)
+    {
+        _savedWifis[i].ssid = preferences.getString(WIFI_SSID_KEY(i), "");
+        _savedWifis[i].pswd = preferences.getString(WIFI_PSWD_KEY(i), "");
     }
 
     preferences.end();

--- a/lib/wificaptive/src/WifiCaptive.cpp
+++ b/lib/wificaptive/src/WifiCaptive.cpp
@@ -314,7 +314,7 @@ bool WifiCaptive::isSaved()
     return _savedWifis[0].ssid != "";
 }
 
-void WifiCaptive::readWifiCredentials(int index = -1)
+void WifiCaptive::readWifiCredentials(int index)
 {
     Preferences preferences;
     preferences.begin("wificaptive", true);
@@ -556,7 +556,6 @@ bool WifiCaptive::autoConnect()
             if (WiFi.status() == WL_CONNECTED)
             {
                 Log.info("Connected to %s\r\n", network.ssid.c_str());
-                saveLastUsed(network.ssid, network.pswd);
                 return true;
             }
             WiFi.disconnect();

--- a/lib/wificaptive/src/WifiCaptive.cpp
+++ b/lib/wificaptive/src/WifiCaptive.cpp
@@ -357,6 +357,7 @@ void WifiCaptive::saveWifiCredentials(String ssid, String pass)
         preferences.putString(WIFI_SSID_KEY(i), _savedWifis[i].ssid);
         preferences.putString(WIFI_PSWD_KEY(i), _savedWifis[i].pswd);
     }
+    preferences.putInt(WIFI_LAST_INDEX, 0);
     preferences.end();
 }
 

--- a/lib/wificaptive/src/WifiCaptive.cpp
+++ b/lib/wificaptive/src/WifiCaptive.cpp
@@ -362,7 +362,6 @@ void WifiCaptive::saveWifiCredentials(String ssid, String pass)
     preferences.end();
 }
 
-
 void WifiCaptive::saveLastUsed(String ssid, String pass)
 {
     _lastUsed.ssid = ssid;

--- a/lib/wificaptive/src/WifiCaptive.h
+++ b/lib/wificaptive/src/WifiCaptive.h
@@ -32,6 +32,8 @@
 #define WIFI_SSID_KEY(i) ("wifi_" + String(i) + "_ssid").c_str()
 #define WIFI_PSWD_KEY(i) ("wifi_" + String(i) + "_pswd").c_str()
 
+#define WIFI_LAST_INDEX "wifi_last_index"
+
 class WifiCaptive
 {
 private:
@@ -65,7 +67,8 @@ private:
     uint8_t waitForConnectResult();
     void readWifiCredentials();
     void saveWifiCredentials(String ssid, String pass);
-    void saveLastUsed(String ssid, String pass);
+    void saveLastUsedWifiIndex(int index);
+    int readLastUsedWifiIndex();
     void saveApiServer(String url);
     std::vector<WifiCredentials> matchNetworks(std::vector<Network> &scanResults, WifiCaptive::WifiCredentials wifiCredentials[]);
     std::vector<Network> getScannedUniqueNetworks(bool runScan);

--- a/lib/wificaptive/src/WifiCaptive.h
+++ b/lib/wificaptive/src/WifiCaptive.h
@@ -63,7 +63,7 @@ private:
     uint8_t connect(String ssid, String pass);
     uint8_t waitForConnectResult(uint32_t timeout);
     uint8_t waitForConnectResult();
-    void readWifiCredentials(int index);
+    void readWifiCredentials(int index = -1);
     void saveWifiCredentials(String ssid, String pass);
     void saveLastUsed(String ssid, String pass);
     void saveApiServer(String url);

--- a/lib/wificaptive/src/WifiCaptive.h
+++ b/lib/wificaptive/src/WifiCaptive.h
@@ -63,7 +63,7 @@ private:
     uint8_t connect(String ssid, String pass);
     uint8_t waitForConnectResult(uint32_t timeout);
     uint8_t waitForConnectResult();
-    void readWifiCredentials(int index = -1);
+    void readWifiCredentials();
     void saveWifiCredentials(String ssid, String pass);
     void saveLastUsed(String ssid, String pass);
     void saveApiServer(String url);

--- a/lib/wificaptive/src/WifiCaptive.h
+++ b/lib/wificaptive/src/WifiCaptive.h
@@ -31,8 +31,6 @@
 
 #define WIFI_SSID_KEY(i) ("wifi_" + String(i) + "_ssid").c_str()
 #define WIFI_PSWD_KEY(i) ("wifi_" + String(i) + "_pswd").c_str()
-#define WIFI_LAST_USED_SSID_KEY "wifi_ssid"
-#define WIFI_LAST_USED_PSWD_KEY "wifi_pswd"
 
 class WifiCaptive
 {
@@ -59,14 +57,13 @@ private:
     std::function<void()> _resetcallback;
 
     WifiCredentials _savedWifis[WIFI_MAX_SAVED_CREDS];
-    WifiCredentials _lastUsed;
 
     void setUpDNSServer(DNSServer &dnsServer, const IPAddress &localIP);
     void setUpWebserver(AsyncWebServer &server, const IPAddress &localIP);
     uint8_t connect(String ssid, String pass);
     uint8_t waitForConnectResult(uint32_t timeout);
     uint8_t waitForConnectResult();
-    void readWifiCredentials();
+    void readWifiCredentials(int index);
     void saveWifiCredentials(String ssid, String pass);
     void saveLastUsed(String ssid, String pass);
     void saveApiServer(String url);

--- a/platformio.ini
+++ b/platformio.ini
@@ -44,12 +44,11 @@ check_flags =
 
 [env:local]
 extends = env:esp32-c3-devkitc-02
-monitor_speed = 115200
 # serial logging
 build_flags =
 	-D ARDUINO_USB_MODE=1
 	-D ARDUINO_USB_CDC_ON_BOOT=1
-	-D CORE_DEBUG_LEVEL=4
+	-D CORE_DEBUG_LEVEL=0
 	-D WAIT_FOR_SERIAL=1
 	-D ARDUINOJSON_ENABLE_ARDUINO_STRING=1
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -44,11 +44,12 @@ check_flags =
 
 [env:local]
 extends = env:esp32-c3-devkitc-02
+monitor_speed = 115200
 # serial logging
 build_flags =
 	-D ARDUINO_USB_MODE=1
 	-D ARDUINO_USB_CDC_ON_BOOT=1
-	-D CORE_DEBUG_LEVEL=0
+	-D CORE_DEBUG_LEVEL=4
 	-D WAIT_FOR_SERIAL=1
 	-D ARDUINOJSON_ENABLE_ARDUINO_STRING=1
 


### PR DESCRIPTION
Issue #71
- Remove `_lastUsed`, will shift all network credentials in the array so that last used wifi is `_savedWifis[0]`
- On failed connection to last used WiFi network, loop over all saved credentials in the array
- No longer saves duplicate networks in the array