### PR TITLE
Increase timeout for HTTPClient to 15 seconds during downloadAndShow

### DIFF
--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -500,6 +500,10 @@ static https_request_err_e downloadAndShow()
   { // Add a scoping block for HTTPClient https to make sure it is destroyed before WiFiClientSecure *client is
 
     HTTPClient https;
+
+    // Set a more generous timeout than the default of 5000.
+    https.setTimeout(15000);
+
     Log.info("%s [%d]: RSSI: %d\r\n", __FILE__, __LINE__, WiFi.RSSI());
     Log.info("%s [%d]: [HTTPS] begin /api/display/ ...\r\n", __FILE__, __LINE__);
     char new_url[200];


### PR DESCRIPTION
I believe this should resolve #82. Sets the timeout to 15 seconds.

I've chosen 15 seconds to try and get a balance between not waiting too long, but also giving plenty of time for dynamically generated content to be generated on cheap servers.

The reasoning is that the Images are going to be displayed on the device for quite a while so waiting a few extra seconds for them when fetching isn't an issue. By increasing the timeout it allows users to use cheaper, slower servers to generate their TRMNL screens.