### PR TITLE
Add ID header to /api/log call

### DIFF
--- a/src/api-client/submit_log.cpp
+++ b/src/api-client/submit_log.cpp
@@ -38,6 +38,7 @@ bool submitLogToApi(LogApiInput &input, const char *api_url)
       { // HTTPS
         Log_info("[HTTPS] POST...");
 
+        https.addHeader("ID", WiFi.macAddress());
         https.addHeader("Accept", "application/json");
         https.addHeader("Access-Token", input.api_key);
         https.addHeader("Content-Type", "application/json");


### PR DESCRIPTION
This adds the ID header to the `/api/log` call.

Reasoning:
- It improves consistency, as both `/api/setup` and `/api/display` currently receive the device ID.
- It allows you to identify a device which has a bad or expired API key from `/api/log` calls.
- It allows looking up a device by ID on all API calls.

Resolves #80

Tested on device.