### PR TITLE
Add support for ETag header

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -22,6 +22,7 @@
 #define PREFERENCES_LAST_SLEEP_TIME "last_sleep"
 #define PREFERENCES_CONNECT_API_RETRY_COUNT "retry_count"
 #define PREFERENCES_CONNECT_WIFI_RETRY_COUNT "wifi_retry"
+#define PREFERENCES_ETAG "etag"
 
 #define WIFI_CONNECTION_RSSI (-100)
 

--- a/include/config.h
+++ b/include/config.h
@@ -22,7 +22,7 @@
 #define PREFERENCES_LAST_SLEEP_TIME "last_sleep"
 #define PREFERENCES_CONNECT_API_RETRY_COUNT "retry_count"
 #define PREFERENCES_CONNECT_WIFI_RETRY_COUNT "wifi_retry"
-#define PREFERENCES_ETAG "etag"
+#define PREFERENCES_ETAG_KEY "etag"
 
 #define WIFI_CONNECTION_RSSI (-100)
 

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -207,7 +207,12 @@ void bl_init(void)
     need_to_refresh_display = 1;
     preferences.putBool(PREFERENCES_DEVICE_REGISTRED_KEY, false);
     Log.info("%s [%d]: Display TRMNL logo end\r\n", __FILE__, __LINE__);
+
+    // We're displaying the logo on the screen, so we reset the
+    // two preferences specifying the previous filename and the previous ETag
+    // to ensure we refresh this time to remove the logo.
     preferences.putString(PREFERENCES_FILENAME_KEY, "");
+    preferences.putString(PREFERENCES_ETAG_KEY, "");
   }
 
   // Mount SPIFFS
@@ -1049,11 +1054,6 @@ static https_request_err_e downloadAndShow()
     {
       status = false;
 
-      String currentEtag = preferences.getString(PREFERENCES_ETAG, "");
-      if (currentEtag.length() > 0) {
-        https.addHeader("If-None-Match", currentEtag);
-      }
-
       Log.info("%s [%d]: [HTTPS] Request to %s\r\n", __FILE__, __LINE__, filename);
       if (!https.begin(*client, filename)) // HTTPS
       {
@@ -1063,8 +1063,20 @@ static https_request_err_e downloadAndShow()
 
         return HTTPS_UNABLE_TO_CONNECT;
       }
+
+      // If we have an ETag, add it to the request.
+      String currentEtag = preferences.getString(PREFERENCES_ETAG_KEY, "");
+      if (currentEtag.length() > 0) {
+        https.addHeader("If-None-Match", currentEtag);
+      }
+
       Log.info("%s [%d]: [HTTPS] GET..\r\n", __FILE__, __LINE__);
       Log.info("%s [%d]: RSSI: %d\r\n", __FILE__, __LINE__, WiFi.RSSI());
+      
+      // Ensure we look for the ETag header in the response.
+      const char* headerKeys[] = {"ETag", "Content-Type"};
+      https.collectHeaders(headerKeys, 2);
+
       // start connection and send HTTP header
       int httpCode = https.GET();
 
@@ -1084,14 +1096,18 @@ static https_request_err_e downloadAndShow()
 
       if (httpCode == HTTP_CODE_NOT_MODIFIED)
       {
+        // The server used the ETag to determine that the content hasn't changed
+        // for this device and so returned a 304 Not Modified response.
+        // We don't need to update the screen.
         Log.info("%s [%d]: Not modified. No need to download\r\n", __FILE__, __LINE__);
         return HTTPS_SUCCES;
       }
     
       if (https.hasHeader("ETag")) {
+        // The server sent back an ETag header. Save it to include in the next request.
         String etag = https.header("ETag");
         Log.info("%s [%d]: ETag: %s\r\n", __FILE__, __LINE__, etag.c_str());
-        preferences.putString(PREFERENCES_ETAG, etag);
+        preferences.putString(PREFERENCES_ETAG_KEY, etag);
       }
       
       // file found at server


### PR DESCRIPTION
Resolves #83.

This commit adds ETag support when requesting the `image_url` returned by the `/api/display` call.

- If an ETag was previously received it is added to the request headers.
- If the server returns 304 Not Modified, it doesn't fetch the body or refresh the display.
- If the server returns an ETag then it is saved to include in the next `image_url` request.
- If the logo is displayed on the screen (due to refreshing via the back button) the ETag is cleared to ensure we draw the latest returned image.

If the server doesn't support ETags then the there are no significant changes in behaviour.

Tested on my device.
