### PR TITLE
Upgrade ArduinoJSON

### DIFF
--- a/lib/trmnl/src/parse_response_api_setup.cpp
+++ b/lib/trmnl/src/parse_response_api_setup.cpp
@@ -1,4 +1,3 @@
-
 #include <ArduinoJson.h>
 #include "api_response_parsing.h"
 #include <trmnl_log.h>
@@ -14,7 +13,7 @@ ApiSetupResponse parseResponse_apiSetup(String &payload)
     return {.outcome = ApiSetupOutcome::DeserializationError};
   }
 
-  if (doc["status"] != 200)
+  if (doc["status"].as<int>() != 200)
   {
     Log_info("status FAIL.");
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -24,15 +24,15 @@ board_build.partitions = min_spiffs.csv
 board_build.filesystem = spiffs
 ;board_build.partitions = custom_partition.csv
 upload_speed = 460800
-build_flags = 
+build_flags =
 	-D ARDUINO_USB_MODE=0
 	-D ARDUINO_USB_CDC_ON_BOOT=0
 	-D CORE_DEBUG_LEVEL=0
 lib_ldf_mode=deep
-lib_deps = 
+lib_deps =
 	;WiFiManager@^2.0.16-rc.2
 	ESP32Async/ESPAsyncWebServer@3.7.1
-	bblanchon/ArduinoJson@7.2.1
+	bblanchon/ArduinoJson@^7.3.1
 	https://github.com/thijse/Arduino-Log.git#3f4fcf5a345c1d542e56b88c0ffcb2bd2a5b0bd0
 
 debug_tool = esp-builtin
@@ -56,7 +56,7 @@ build_flags =
 platform = native
 test_framework = unity
 lib_deps =
-	bblanchon/ArduinoJson@7.2.1
+	bblanchon/ArduinoJson@^7.3.1
 	fabiobatsilva/ArduinoFake@^0.4.0
 build_flags =
 	-D ARDUINOJSON_ENABLE_ARDUINO_STRING=1


### PR DESCRIPTION
We had to pin ArduinoJSON in de6a88d8eb6d8be8ddc3dcc971ae68783d5ec205. this fixes the compliation error and allows ArduinoJSON to be upgraded.
The error and fix is explained here https://arduinojson.org/v7/proxy-non-copyable/