### PR TITLE
Interpret image_url_timeout as seconds rather than milliseconds

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -32,6 +32,8 @@
 #define SLEEP_TIME_WHILE_NOT_CONNECTED 5       /* Time ESP32 will go to sleep (in seconds) */
 #define SLEEP_TIME_WHILE_PLUGIN_NOT_ATTACHED 5 /* Time ESP32 will go to sleep (in seconds) */
 
+#define MS_TO_S_FACTOR 1000                    /* Conversion factor for milliseconds to seconds */
+
 enum API_CONNECT_RETRY_TIME // Time to sleep before trying to connect to the API (in seconds)
 {
     API_FIRST_RETRY = 5,

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -1053,6 +1053,9 @@ static https_request_err_e downloadAndShow()
       // Otherwise, we set the requested timeout.
       uint32_t requestedTimeout = apiResponse.image_url_timeout;
       if (requestedTimeout > 0) {
+        // Convert from seconds to milliseconds.
+        // A uint32_t should be large enough not to worry about overflow for any reasonable timeout.
+        requestedTimeout *= 1000;
         if (requestedTimeout > UINT16_MAX) {
           // To avoid surprising behaviour if the server returned a timeout of more than 65 seconds
           // we will send a log message back to the server and truncate the timeout to the maximum.


### PR DESCRIPTION
This PR changes the interpretation of the `image_url_timeout` field in the `/api/display` response to be in seconds rather than milliseconds, for consistency with `refresh_rate`.

Because the `image_url_timeout` in milliseconds has already been deployed with both the 0.4.0 version of Terminus, and the 1.4.8 version of the firmware, this has some implications:

- Any device running a firmware prior to 1.4.8 is unaffected, as these ignore `image_url_timeout`.

- Any user who has not manually configured `image_url_timeout` will be unaffected. 
  - This means basically all users will be unaffected. Only users who are dynamically generating images during the `image_url` call, and whose images take several seconds to generate, would need to change this setting. As far as I know my server is the only one doing this, and it won't be released for another month.

If the user _has_ manually configured `image_url_timeout` then:

- If the device is updated to a firmware containing this PR, and the server still returns `image_url_timeout` in milliseconds, then the device will truncate the timeout to the maximum value of 65 seconds, and will send a log to the server indicating that it has done this. The user can take corrective action. This is not particularly problematic.

- If the device is running 1.4.8 and the server returns `image_url_timeout` in seconds, say `10`, then the 1.4.8 firmware will  interpret this as 10ms and will potentially cause issues for the user. However:
  - If the server checks the firmware version and instructs the device to update its firmware, it will not be an issue.
  - If the BYOS server does not support updating the firmware, it could still use the firmware version in the `/api/display` request header to return the timeout in milliseconds for 1.4.8 only.

Overall I think it's worth changing this to make `image_url_timeout` and `refresh_rate` use consistent units, reducing user confusion going forwards, and if we're going to change this then the sooner the better. Apologies for creating the confusion in the first place by releasing `image_url_timeout` in milliseconds.
