### PR TITLE
Mac and Windows CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,15 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        os: [ubuntu-latest, macos-15, windows-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v4
@@ -20,8 +28,18 @@ jobs:
         with:
           python-version: "3.11"
 
+      - uses: maxim-lobanov/setup-xcode@v1
+        if: matrix.os == 'macos-15'
+        with:
+          xcode-version: latest-stable
+
       - name: Install PlatformIO Core
         run: pip install --upgrade platformio
+
+      - name: Display PlatformIO Information
+        run: |
+          pio system info
+          g++ --version
 
       - name: build
         run: pio run


### PR DESCRIPTION
This PR:
 - ~~makes a couple small changes in platform.ini to allow `pio test -e native` to work with MacOS' current C/++ compiler.~~
 - adds CI jobs to build and test on MacOS and Windows.