### PR TITLE
Small optimizations

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -3,7 +3,8 @@
 #include <display.h>
 #include <ArduinoLog.h>
 #include "DEV_Config.h"
-#include "EPD.h"
+#include "utility/EPD_7in5_V2.h"
+#include  "utility/Debug.h"
 #include "GUI_Paint.h"
 #include <config.h>
 #include <ImageData.h>
@@ -82,26 +83,23 @@ void display_show_image(uint8_t *image_buffer, bool reverse, bool isPNG)
     Paint_NewImage(BlackImage, width, height, 0, WHITE);
 
     Log.info("%s [%d]: show image for array\r\n", __FILE__, __LINE__);
-    Paint_SelectImage(BlackImage);
-    Paint_Clear(WHITE);
     if (reverse)
     {
         Log.info("%s [%d]: inverse the image\r\n", __FILE__, __LINE__);
-        for (size_t i = 0; i < DISPLAY_BMP_IMAGE_SIZE; i++)
+        for (size_t i = 0; i < Imagesize; i++)
         {
-            image_buffer[i] = ~image_buffer[i];
+            image_buffer[i + 62] = ~image_buffer[i + 62];
         }
     }
     if(isPNG == true)
     {
-        Log.info("Drawing PNG\n");
-        flip_image(image_buffer, width, height);
-        horizontal_mirror(image_buffer,width,height);
-        Paint_DrawBitMap(image_buffer);
+        Log.info("Drawing PNG\n");    
     }
     else{
+        flip_image(image_buffer, width, height);
         Paint_DrawBitMap(image_buffer + 62);
     }
+    memcpy(Paint.Image, image_buffer, Imagesize);
     EPD_7IN5_V2_Display(BlackImage);
     Log.info("%s [%d]: display\r\n", __FILE__, __LINE__);
 
@@ -342,5 +340,5 @@ void display_show_msg(uint8_t *image_buffer, MSG message_type, String friendly_i
 void display_sleep(void)
 {
     Log.info("%s [%d]: Goto Sleep...\r\n", __FILE__, __LINE__);
-    EPD_7IN5B_V2_Sleep();
+    EPD_7IN5_V2_Sleep();
 }

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -4,7 +4,7 @@
 #include <ArduinoLog.h>
 #include "DEV_Config.h"
 #include "utility/EPD_7in5_V2.h"
-#include  "utility/Debug.h"
+#include "utility/Debug.h"
 #include "GUI_Paint.h"
 #include <config.h>
 #include <ImageData.h>
@@ -132,9 +132,10 @@ void display_show_msg(uint8_t *image_buffer, MSG message_type)
     Paint_NewImage(BlackImage, width, height, 0, WHITE);
 
     Log.info("%s [%d]: show image for array\r\n", __FILE__, __LINE__);
-    Paint_SelectImage(BlackImage);
-    Paint_Clear(WHITE);
-    Paint_DrawBitMap(image_buffer + 62);
+         // what if it is PNG ?
+    // we could copy and swap at the same time...
+    flip_image(BlackImage, width, height);
+    memcpy(BlackImage, image_buffer + 62, Imagesize);
     switch (message_type)
     {
     case WIFI_CONNECT:

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -285,9 +285,10 @@ void display_show_msg(uint8_t *image_buffer, MSG message_type, String friendly_i
     Paint_NewImage(BlackImage, width, height, 0, WHITE);
 
     Log.info("%s [%d]: show image for array\r\n", __FILE__, __LINE__);
-    Paint_SelectImage(BlackImage);
-    Paint_Clear(WHITE);
-    Paint_DrawBitMap(image_buffer + 62);
+    // what if it is PNG ?
+    // we could copy and swap at the same time...
+    flip_image(BlackImage, width, height);
+    memcpy(BlackImage, image_buffer + 62, Imagesize);
     switch (message_type)
     {
     case FRIENDLY_ID:


### PR DESCRIPTION
the Paint_XXX functions are an abstraction but manipulate the memory pointed by Paint.Image
Either you use Paint_NewImage to  initialise it or you set it directly with Paint_SelectImage

Then most Paint_XXX are high level functions that call Paint_SetPixel internally.

Example Paint_DrawString() -> Paint_DrawChar() -> Paint_SetPixel() thousand of times

each Paint_SetPixel computes the byte location (with possible rotation, mirroring, scaling) for each and every pixel then  use byte arithmetic o set it to 0 or 1 ; this can be horribly inefficient an the TRML firmware does not use mirroring, scaling or rotation (but this is for very small bitmaps usually).

The memory in Paint.Image for the TRMNL device, and passed to EPD_7IN5_V2_Display for effective display is in fact 
exactly the same as a 800x480 BMP, that is 100 bytes x 480 rows.
This is not the case for any width because of 32 bit padding but for most (all) panel dimensions it fits.
BMP data when height is positive are bottom-up, so you need either to swap vertically or change the 
EPD_7IN5_V2_Display loop to 

 for (UDOUBLE j = 0; j < Height; j++)
    {
        for (UDOUBLE i = 0; i < Width; i++)
        {
            EPD_SendData(~blackimage[i + (Height - j -1) * Width]);
        }
    }

PNG data is top-down and happens to be the same data for 1bit greyscale than 1bit BMP, but vertically swapped,
padding is on nearest byte, so 0 padding gives  stride = Width = 100 also for pixel width = 800; 

The conclusion is that the data in Paint.Image can be manipulated directly, so the current PNG branch code that
swaps horizontally then vertically (but horizontal also swaps vertically - see PNG-flip.c !) is not necessary, the PNG data can be used directly as well as the BMP data if you revert it when receiving it as a payload (I kept bottom-up BMPs in my PR, so revert is done when drawing).

You can also get rid of most Paint_Clear() for the same reasons.

It should even be possible not to allocate new data (BlackImage) and work directly on image_data
(with a 62 byte offset for BMPs :-)


I also #include only the needed driver instead of all possible panels.

While simple these changes need to be tested because I did not flashed them...

There is some gain in firmware size and I hope also a small one in performance
Changes are limited to display.cpp and very limited in scope.

If this kind of optimizations matter (it might not really for the TRMNL, but for real-time display it could) it should be possible to speed-up all Paint_DrawString, using 8 pixel alignment and byte copy instead of Paint_SetPixel each pixel.

Most of these ideas might become obsolete for the next generation TRMNL but some of then can be of some value, can save a few ms of wakeup time.

The most promising one that I did not implement here is the direct manuplulation of a single memory zone, with no need for a temporary one. 