### PR TITLE
Avoid false png error

### DIFF
--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -1374,7 +1374,7 @@ static https_request_err_e downloadAndShow()
         }
       
 
-      if (png_res != PNG_NO_ERR)
+      if (isPNG && png_res != PNG_NO_ERR)
       {
         filesystem_file_delete("/current.png");
         submit_log("error parsing image file - %s", error.c_str());


### PR DESCRIPTION
My device was reporting an error like this:

```
I: src/api-client/submit_log.cpp [27]: [HTTPS] begin /api/log ...
I: src/api-client/submit_log.cpp [39]: [HTTPS] POST...
I: src/api-client/submit_log.cpp [45]: Send log - {"log":{"logs_array":[{"creation_timestamp":1744392197,"device_status_stamp":{"wifi_rssi_level":-70,"wifi_status":"connected","refresh_rate":902,"time_since_last_sleep_start":91,"current_fw_version":"1.5.0","special_function":"none","battery_voltage":4.776,"wakeup_reason":"powercycle","free_heap_size":117024},"log_id":264,"log_message":"error parsing image file - could not decode png image","log_codeline":1380,"log_sourcefile":"src/bl.cpp","additional_info":{"retry_attempt":10}}]}}
```

I think I tracked down why!

The global `png_res` is initialized to an error value:

https://github.com/usetrmnl/firmware/blob/76813028651efd05e24791109b87a23da44b0bfc/src/bl.cpp#L40

So when we get down to here, even if `png_res` was never touched (because the device was sent a .bmp), we'll report it as an error:

https://github.com/usetrmnl/firmware/blob/76813028651efd05e24791109b87a23da44b0bfc/src/bl.cpp#L1377-L1383

Long-term this area could be restructured (and avoid globals), but for now here's a quick fix.