### PR TITLE
Update espressif32 6.9 -> 6.10

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@
 default_envs = esp32-c3-devkitc-02
 
 [env:esp32-c3-devkitc-02]
-platform = espressif32@6.9.0
+platform = espressif32@6.10.0
 board = esp32-c3-devkitc-02
 framework = arduino
 board_build.f_cpu = 80000000L


### PR DESCRIPTION
Noticed we were one rev out of date on the espressif framework.

It looks like there were no significant changes in [6.10](https://github.com/platformio/platform-espressif32/releases/tag/v6.10.0) (and it uses the same version of Arduino and IDF as [6.9](https://github.com/platformio/platform-espressif32/releases/tag/v6.9.0)). Tested on my device and it seems to work just fine.