### PR TITLE
Scalable contents (SVG like pathes support)

### DIFF
--- a/lib/gfxDraw/LICENSE
+++ b/lib/gfxDraw/LICENSE
@@ -1,0 +1,28 @@
+BSD 3-Clause License
+
+Copyright (c) 2024, Matthias Hertel
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/lib/gfxDraw/README.md
+++ b/lib/gfxDraw/README.md
@@ -1,0 +1,340 @@
+# Drawing Vector Graphics on Arduino GFX displays
+
+GFXDraw is a powerful and easy-to-use GUI library for Arduino.  It offers simple elements, powerful path-based vector
+drawings, ready to use widgets and visual effects.  The library is made especially for displays that support pixel-based
+drawing attached to a board that has enough CPU power and memory to run complex drawing algorithms.
+
+**Note: This is an early version of a new Arduino library.**  
+**Publishing was required to link other work to this library at this time.**  
+
+The GFXDraw library is published as an Arduino Library using GitHub.  It can be installed via the Arduino IDE Library
+Manager.  You can download the latest version of GFXDraw from GitHub and copy it to Arduino's library folder.
+
+Note that you need to choose a board powerful enough to run GFXDraw and a GFX library supporting the specific hardware.
+The drawing algorithms can use GFX libraries as the low-level interface to various displays.  There are various GFX
+libraries available in the Arduino Community that support many differend displays.  It is recommended to use a ESP32-S3
+chip as first choice.
+
+There are examples that demonstrate how to use the
+
+* [Adafruit GFX](https://github.com/adafruit/Adafruit-GFX-Library)
+* [GFX Library for Arduino](https://github.com/moononournation/Arduino_GFX).
+
+as the GFX libraries are only used for sending the pixel values to the displays.
+
+Beyond this the GFXDraw library is not chip specific and it will also compile and run on other hardware.  A Project to
+run on Windows creating PNG files by using the Visual Code compiler is also included and can be used for more efficient
+development and direct debugging.
+
+The most important part of this library is the capability to draw and transform vectorized based graphics specified by a
+path of lines, arcs and curves using the svg path notation and a set of high-level classes to draw typical widgets.
+This enables complex figures to be drawn and you are no longer limited by the typical built-in graphics of a GFX
+library.
+
+In contrast to the rasterization implementations used in Desktop programs or browsers this library is dedicated to
+microprocessor conditions with typically limited memory and cpu power. The library avoids arithmetic floating point calculations for many algorithms and doesn't support anti-aliased drawing.
+
+There is still some room for improvement in some drawing algoriothm that is left for further updates.
+
+
+## Software Architecture
+
+This is a short high level overview on the way how the gfxDraw library is used by sketches or examples, how it works
+internally and how the GFX libraries are linked for low level drawing.
+
+The library uses the Namespace `gfxDraw` to implement the types, functions and the classes to avoid conflicts with other
+libraries.
+
+![architecture](docs/architecture.drawio.svg)
+
+**Primitives** -- The simple drawing functionality available is covering **lines**, **rectangles**, **arcs**, **circles**, **bezier
+curves** and some direct usable combinations like rounded rectangles.  These function "only" calculate the points that
+make up the primitive and use callback function to hand them over to further processing or drawing.
+
+**Filling** -- One of the further processing function available is the filling algorithm that can find out what pixels
+are inside a closed area and also pass them for further processing or drawing.
+
+**Path** -- For drawings with a more complex border paths with the syntax from svg can be used for defining the border
+lines.  Paths can be transformed, resized and rotated.  See further details below.
+
+**Widgets** -- The Widget classes offers defining parameters for drawing of complex functionality like **gauges**.
+
+
+### General Library Implementation Rules
+
+This library aims to support graphics implementations that are used in microprocessors like ESP32 based boards with
+pixel oriented graphic displays.
+
+The functions are optimized for low resolution pixel displays. They do not implement antialiasing and have minimized use of float
+and arc arithmetics.  
+
+The library supports up to 16 bit (-32760 ... +32760) display resolutions.
+
+By design the drawing functionionality is independent of the color depth.
+
+The Widget Classes and the internal Bitmap Class supports drawing using a 32-bit (or less) color setup using RGB+Alpha
+for a specific pixel.
+
+The output of the drawing routined in the library is prvided by a callback function.
+This can be "plugged" not ony to the GFX library for drawing but some "filters" are available also to
+support functionality like saving the output in memory or filling a widget with a gradient.
+
+
+## Drawing on a display
+
+The easiest way to use the output of the drawing routines is by using helper function for drawing a fixed color.
+This function then calls the effective drawPixel function of the GFX library.
+
+Then a rectagle  with no border and a SILVER fill color or any other algorithm can be drawn using this callback function:
+
+```cpp
+using namespace gfxDraw; // use gfxDraw library namespace
+
+// a callback function implementing the fSetPixel parameters 
+drawSilver(int16_t x, int16_t y) {
+  gfx->drawPixel(x, y, SILVER);
+})
+
+// draw a background rectangle
+gfxDraw::drawRect(8, 8, 60, 40, nullptr, drawSilver);
+
+// A SVG path defining the shape of a heard
+const char *heardPath = "M43 7 a1 1 0 00-36 36l36 36 36-36a1 1 0 00-36-36z";
+
+gfxDraw::pathByText(heardPath, 8, 8, 100, nullptr, drawSilver);
+```
+
+A more flexible way is by providing a factory function that returns a fSetPixel function that draws the color given by
+an argument:
+
+```cpp
+std::function<void(int16_t x, int16_t y)> drawColor(uint32_t color) {
+  return [color](int16_t x, int16_t y) {
+    gfx->drawPixel(x, y, color);
+  };
+}
+
+// A SVG path defining the shape of a heard
+const char *heardPath = "M43 7 a1 1 0 00-36 36l36 36 36-36a1 1 0 00-36-36z";
+
+gfxDraw::pathByText(heardPath, 8, 8, 100, drawColor(RED), drawColor(YELLOW));
+```
+
+When using Widgets the colors are given by the widget implementation to a different function that takes the color as an
+additional parameter:
+
+```cpp
+void draw(int16_t x, int16_t y, gfxDraw::ARGB color) {
+  gfx->drawPixel(x, y, col565(color));
+}
+
+// assemble the configuration for the widget including colors
+_gConfig = new gfxDraw::gfxDrawGaugeConfig();
+_gConfig->pointerColor = ARGB_BLACK;
+_gConfig->segmentColor = ARGB_SILVER;
+
+// create the widget
+_gWidget = new gfxDraw::gfxDrawGaugeWidget(_gConfig);
+
+// draw
+_gWidget->draw(draw);
+```
+
+
+## Widget classes
+
+The Widget classes offers further functionionality and espacially can handle a fixed color for stroke and fill.
+
+By creating a instance on a class the basic configuration can be passed to the constructor and parameters can be
+changed by using methods.
+
+```cpp
+using namespace gfxDraw; // use gfxDraw library namespace
+
+// A SVG path defining the shape of a heard
+const char *heardPath = "M43 7 a1 1 0 00-36 36l36 36 36-36a1 1 0 00-36-36z";
+
+// use red fill and yellow border color
+gfxDraw::gfxDrawPathConfig conf = {
+  .strokeColor = gfxDraw::ARGB_YELLOW,
+  .fillColor = gfxDraw::ARGB_RED
+};
+
+drawCallback(int16_t x, int16_t y, uint32_t color) {
+  gfx->setPixel(x, y, color);
+})
+
+gfxDraw::gfxDrawPathWidget *heardWidget = new gfxDraw::gfxDrawPathWidget();
+heardWidget->setConfig(&conf);
+heardWidget->setPath(heardPath);
+heardWidget->rotate(45);
+heardWidget->move(8, 8);
+heardWidget->draw(drawCallback);
+```
+
+See [Path Widgets Class](docs/path-widget.md).
+
+
+## SVG Path Syntax
+
+Drawing using paths is used by some of the widgets to customize e.g.  the pointers for a clock.
+
+To create a vector (array) of segments that build the borders of the vector graphics object the `path` syntax from the
+SVG standard is used.  
+
+There are helpful web applications to create or edit such paths definitions:
+
+* The [SVG Path Editor](https://yqnn.github.io/svg-path-editor/) with source available in
+  [Github/Yqnn](https://github.com/Yqnn/svg-path-editor) from Yann Armelin
+
+* The [SVG Path Editor](https://aydos.com/svgedit/) with source available in
+  [Github/aydos](https://github.com/aydos/svgpath) from Fahri Aydos.
+
+Both tools let you directly change the individual segments of paths and also offer some graphical view or even edit
+capabilities.  You can also use full SVG editors and extract the path from there.
+
+For using paths with pixel oriented displays is is important to use integer based coordinates and scalar values only.
+Better to use larger numbers as scaling the result down to a smaller size is possible.
+
+
+Examples for paths are:
+
+* Simple Line: `"M 0,0 L 30,40"`
+* Rectange: `"M 10,10 h40 v30 h-40 z"`
+* Bezier Curve: `"M16 12c5 0 5 7 0 7"`
+* Smiley:  
+    `"M12,2h64c4,0 8,4 8,8v48c0,4 -4,8 -8,8h-64c-4,0 -8,-4 -8,-8v-48c0,-4 4,-8 8,-8z"`  
+    `"M12,10 h60v20h-60z"`  
+    `"M24,36c6,0 12,6 12,12 0,6 -6,12 -12,12-6,0 -12,-6 -12,-12 0,-6 6,-12 12,-12z"`  
+
+More details about the implementation can be found in
+
+[Line Command](docs/line_command.md)
+[Bezier Arc Command](docs/bezier_command.md)
+[Elliptical Arc Command](docs/elliptical_arc_command.md)
+[Filling Paths](docs/filling.md)
+
+Implemented Widgets
+
+[Path Widget](docs/path-widget.md)
+[Gauge Widget](docs/gauge-widget.md)
+
+
+## Debugging and logging
+
+In case something is not going as expected it is recommended to enable the optional TRACE output of the library.  This
+can be done using one of these approaches:
+
+All source code files (*.cpp) contain a definition of a `GFXDRAWTRACE` macro that can easily be enabled to print to the
+Serial port.  To enable all Trace ouput in one place the `GFXDRAWTRACE` macro in gfxdraw.h can be enabled too.  Please
+not that this may cause massive performance impacts and I/O that may hurt your application.
+
+
+* <https://github.com/lvgl/lvgl>
+* <https://docs.lvgl.io/latest/en/html/index.html>
+* <https://docs.lvgl.io/master/details/integration/framework/arduino.html>
+
+
+## Contributions
+
+Contributions are welcome.  Please use GitHub Issues for discussing and Pull Request.  Need more -- just ask.
+
+
+## The Examples
+
+The examples that come with this library demonstrate on how to use gfxdraw in several situations and project setup.
+
+* using Adafruit GFX
+* using the GFX Library for Arduino
+* draw primitives
+* path drawing and transformation functions
+
+<!-- ### Adafruit GFX Example
+
+This example demonstrates how to use gfxDraw with the
+[Adafruit GFX Library](https://github.com/adafruit/Adafruit-GFX-Library) that is on of the most often used GFX libraries
+for Arduino. -->
+
+
+### Moon GFX Example
+
+This example demonstrates how to use gfxDraw with the
+[GFX Library for Arduino](https://github.com/moononournation/Arduino_GFX) that has some excellent support for devices
+based on the ESP32 chips and graphics displays.
+
+The example shows various drawing outputs in a loop.
+
+
+### VSCode PNG Example
+
+In the `examples/png` folder you can find a implementation for using the library by a windows executable to produce
+several png files with test images.
+
+This example is especially helpful while engineering the library with fast turn-around cycles and debugging
+capabilities.
+
+
+<!-- ### gfxprimitives Example
+
+To draw the paths the primitive functions for drawing lines, arc and curves are part of the library and also can be used directly. -->
+
+
+<!-- ### gfxsegments Example
+
+After parsing the path syntax a list (vector) of segments is created than can be used for transformations and drawing.
+
+This example shows how to draw using these functions. They are also used by the gfxDrawWidget implementation. -->
+
+## Fonts and Text output
+
+The fonts provided with this library can be loaded from program memory.
+
+<!-- or as files from a filesystem.  -->
+
+The drawing functionality for fonts was re-implemented to ensure that all characters of the same font have the same
+baseline and total height.  Positioning of the text is done by providing the upper left pixel as a starting point.
+
+Drawing text is not supporting a background color.
+
+
+## Copyright for Adafruit_GFX
+
+This library uses the font defintions from the Adafruit_GFX library that can be found at
+<https://github.com/adafruit/Adafruit-GFX-Library>.  Therefore the compatible fonts can be used.
+
+The Adafruit_GFX library was publised by also using the BSD license:
+
+> Software License Agreement (BSD License)
+>
+> Copyright (c) 2012 Adafruit Industries.  All rights reserved.
+>
+> Redistribution and use in source and binary forms, with or without
+> modification, are permitted provided that the following conditions are met:
+>
+> * Redistributions of source code must retain the above copyright notice,
+>   this list of conditions and the following disclaimer.
+> * Redistributions in binary form must reproduce the above copyright notice,
+>   this list of conditions and the following disclaimer in the documentation
+>   and/or other materials provided with the distribution.
+>
+> THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+> AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+> IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+> ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+> LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+> CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+> SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+> INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+> CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+> ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+> POSSIBILITY OF SUCH DAMAGE.
+
+
+## See also
+
+* [Bresenham efficient drawing functions](http://members.chello.at/easyfilter/bresenham.html)
+* [Wikipedia Bresenham Algorithm](https://de.wikipedia.org/wiki/Bresenham-Algorithmus)
+* [Wikipedia Scanline Rendering](https://en.wikipedia.org/wiki/Scanline_rendering)
+* [Math background for using transformation matrixes in 2D drawings](https://www.matheretter.de/wiki/homogene-koordinaten)
+* [SVG Game Icons](https://game-icons.net/)
+* [SVG IoT Icons](https://github.com/HomeDing/WebFiles/tree/master/i)

--- a/lib/gfxDraw/src/gfxDraw.h
+++ b/lib/gfxDraw/src/gfxDraw.h
@@ -1,0 +1,71 @@
+// - - - - -
+// GFXDraw - A Arduino library for drawing shapes on a GFX display using paths describing the borders.
+// gfxDraw.h: Library header file
+//
+// Copyright (c) 2024-2024 by Matthias Hertel, http://www.mathertel.de
+// This work is licensed under a BSD style license. See http://www.mathertel.de/License.aspx
+//
+// These pixel oriented drawing functions are implemented to use callback functions for the effective drawing
+// to make them independent from an specific canvas or GFX implementation and can be used for drawing and un-drawing.
+//
+// The functions have minimized use of float and arc arithmetics.
+// Path drawing is supporting on any given path.
+// Filled paths are supported on closed paths only.
+//
+// CHANGELOG:
+// 15.05.2024  creation of the GFXDraw library.
+// 09.06.2024  extended gfxDrawPathWidget
+//
+// - - - - -
+
+#pragma once
+
+#ifdef ARDUINO
+#include <Arduino.h>
+#endif
+
+#include <functional>
+#include <vector>
+#include <algorithm>
+
+#include <cctype>
+#include <string.h>
+
+#define _USE_MATH_DEFINES
+#include <math.h>
+
+// Alpha+RGB Color implementation
+#include "gfxDrawColors.h"
+
+// Points, Trigonometric functions
+#include "gfxDrawCommon.h"
+
+// Lines
+#include "gfxDrawLine.h"
+
+// Rectanges
+//#include "gfxDrawRect.h"
+
+// Circles and arcs
+#include "gfxDrawCircle.h"
+
+// Bezier curves
+#include "gfxDrawBezier.h"
+
+// Paths combining all of the above, filling algorithm
+#include "gfxDrawPath.h"
+
+// Text
+//#include "gfxDrawText.h"
+
+#ifdef ARDUINO
+#define GFXDRAWTRACE(fmt, ...) Serial.printf(fmt "\n" __VA_OPT__(, ) __VA_ARGS__)
+#else
+#define GFXDRAWTRACE(fmt, ...) printf(fmt "\n" __VA_OPT__(, ) __VA_ARGS__)
+#endif
+
+// un-comment GFX_TRACE globally here to enable all tracing
+
+// #define GFX_TRACE(...) GFXDRAWTRACE(__VA_ARGS__)
+
+// End.

--- a/lib/gfxDraw/src/gfxDrawBezier.cpp
+++ b/lib/gfxDraw/src/gfxDrawBezier.cpp
@@ -1,0 +1,84 @@
+// - - - - -
+// GFXDraw - A Arduino library for drawing shapes on a GFX display using paths describing the borders.
+// gfxDrawBezier.cpp: Library implementation file for functions to calculate all points of a cubic bezier curve.
+//
+// Copyright (c) 2024-2024 by Matthias Hertel, http://www.mathertel.de
+// This work is licensed under a BSD style license. See http://www.mathertel.de/License.aspx
+//
+// Changelog: See gfxDrawBezier.h and documentation files in this library.
+//
+// - - - - -
+
+#include "gfxDraw.h"
+
+#ifndef GFX_TRACE
+#define GFX_TRACE(...)  // GFXDRAWTRACE(__VA_ARGS__)
+#endif
+
+
+#define SCALEFACTOR 1024
+#define SCALESHIFT 10
+#define SCALEUP(v) (v << SCALESHIFT)
+#define SCALEDOWN(v) ((v + SCALEFACTOR / 2) >> SCALESHIFT)
+
+namespace gfxDraw {
+
+// This implementation of cubic bezier curve with a start and an end point given and by using 2 control points.
+// C x1 y1, x2 y2, x y
+
+void drawCubicBezier(int16_t x0, int16_t y0, int16_t x1, int16_t y1, int16_t x2, int16_t y2, int16_t x3, int16_t y3, fSetPixel cbDraw) {
+  // GFX_TRACE("cubicBezier: %d/%d %d/%d %d/%d %d/%d", x0, y0, x1, y1, x2, y2, x3, y3);
+
+  // Line 1 is x0/y0 to x1/y1, dx1/dy1 is the relative vector from x0/y0 to x1/y1
+  int16_t dx1 = (x1 - x0);
+  int16_t dy1 = (y1 - y0);
+  int16_t dx2 = (x2 - x1);
+  int16_t dy2 = (y2 - y1);
+  int16_t dx3 = (x3 - x2);
+  int16_t dy3 = (y3 - y2);
+
+  // heuristic: calc the number of steps we need
+  uint16_t steps = (abs(dx1) + abs(dy1) + abs(dx2) + abs(dy2) + abs(dx3) + abs(dy3));  // p0 - 1 - 2 - 3 - 4 - p3
+                                                                                       // GFX_TRACE("steps:%d", steps);
+  proposePixel(x0, y0, cbDraw);
+
+  for (uint16_t n = 1; n <= steps; n++) {
+    int32_t f = (SCALEFACTOR * n) / steps;
+    // 3 points and 3 deltas in 1000 units
+    int32_t x4 = SCALEUP(x0) + (f * dx1);
+    int32_t y4 = SCALEUP(y0) + (f * dy1);
+    int32_t x5 = SCALEUP(x1) + (f * dx2);
+    int32_t y5 = SCALEUP(y1) + (f * dy2);
+    int32_t x6 = SCALEUP(x2) + (f * dx3);
+    int32_t y6 = SCALEUP(y2) + (f * dy3);
+    int32_t dx5 = (x5 - x4);
+    int32_t dy5 = (y5 - y4);
+    int32_t dx6 = (x6 - x5);
+    int32_t dy6 = (y6 - y5);
+
+    // 2 points
+    int32_t x7 = x4 + SCALEDOWN(f * dx5);
+    int32_t y7 = y4 + SCALEDOWN(f * dy5);
+    int32_t x8 = x5 + SCALEDOWN(f * dx6);
+    int32_t y8 = y5 + SCALEDOWN(f * dy6);
+    int32_t dx8 = (x8 - x7);
+    int32_t dy8 = (y8 - y7);
+
+    // 1 point
+    int32_t x9 = x7 + SCALEDOWN(f * dx8);
+    int32_t y9 = y7 + SCALEDOWN(f * dy8);
+
+    int16_t nextX = SCALEDOWN(x9);
+    int16_t nextY = SCALEDOWN(y9);
+
+    proposePixel(nextX, nextY, cbDraw);
+  }  // for
+  proposePixel(x3, y3, cbDraw);
+
+  // flush all Pixels
+  proposePixel(0, POINT_BREAK_Y, cbDraw);
+};  // drawCubicBezier()
+
+}  // gfxDraw:: namespace
+
+// End.

--- a/lib/gfxDraw/src/gfxDrawBezier.h
+++ b/lib/gfxDraw/src/gfxDrawBezier.h
@@ -1,0 +1,37 @@
+// - - - - -
+// GFXDraw - A Arduino library for drawing shapes on a GFX display using paths describing the borders.
+// gfxDrawBezier.h: Header file for functions to calculate all points of a cubic bezier curve.
+//
+// Copyright (c) 2024-2024 by Matthias Hertel, http://www.mathertel.de
+// This work is licensed under a BSD style license. See http://www.mathertel.de/License.aspx
+//
+// These pixel oriented drawing functions are implemented to use callback functions for the effective drawing
+// to make them independent from an specific canvas or GFX implementation and can be used for drawing and un-drawing.
+//
+// The functions have minimized use of float and arc arithmetics.
+// Path drawing is supporting on any given path.
+// Filled paths are supported on closed paths only.
+//
+// Changelog:
+// * 29.05.2024 creation
+//
+// - - - - -
+
+#pragma once
+
+#include "gfxDraw.h"
+
+
+namespace gfxDraw {
+
+// This implementation of cubic bezier curve with a start and an end point given and by using 2 control points.
+// C x1 y1, x2 y2, x y
+// good article for reading: <https://pomax.github.io/bezierinfo/>
+// Here the Casteljau's algorithm approach is used.
+
+void drawCubicBezier(int16_t x0, int16_t y0, int16_t x1, int16_t y1, int16_t x2, int16_t y2, int16_t x3, int16_t y3, fSetPixel cbDraw);
+
+}  // gfxDraw:: namespace
+
+
+// End.

--- a/lib/gfxDraw/src/gfxDrawCircle.cpp
+++ b/lib/gfxDraw/src/gfxDrawCircle.cpp
@@ -1,0 +1,289 @@
+// - - - - -
+// GFXDraw - A Arduino library for drawing shapes on a GFX display using paths describing the borders.
+// gfxdrawCircle.cpp: Library implementation file for functions to calculate all points of a circle, circle quadrant and circle segment.
+//
+// Copyright (c) 2024-2024 by Matthias Hertel, http://www.mathertel.de
+// This work is licensed under a BSD style license. See http://www.mathertel.de/License.aspx
+//
+// Changelog: See gfxdrawCircle.h and documentation files in this library.
+//
+// - - - - -
+
+#include "gfxDraw.h"
+
+#ifndef GFX_TRACE
+#define GFX_TRACE(...)  // GFXDRAWTRACE(__VA_ARGS__)
+#endif
+
+namespace gfxDraw {
+
+// ===== internal class definitions =====
+
+// draw a circle
+// the draw function is not called in order of the pixels on the circle.
+
+
+// from: http://members.chello.at/easyfilter/bresenham.html
+
+/// @brief Draw the circle quadrant with the pixels in the given order.
+/// @param radius radius of the circle
+/// @param q number of quadrant (see header file)
+/// @param cbDraw will be called for all pixels in the Circle Quadrant
+void drawCircleQuadrant(int16_t radius, int16_t q, fSetPixel cbDraw) {
+  GFX_TRACE("drawCircleQuadrant(r=%d)", radius);
+
+  int16_t x = -radius, y = 0;
+  int16_t err = 2 - 2 * radius; /* II. Quadrant */
+
+  do {
+    if (q == 0) {
+      cbDraw(-x, y);
+    } else if (q == 1) {
+      cbDraw(-y, -x);
+    } else if (q == 2) {
+      cbDraw(x, -y);
+    } else if (q == 3) {
+      cbDraw(y, x);
+    }
+    radius = err;
+    if (radius <= y) err += ++y * 2 + 1;            // y step and error adjustment
+    if (radius > x || err > y) err += ++x * 2 + 1;  // x step and error adjustment
+  } while (x <= 0);
+}  // drawCircleQuadrant()
+
+
+/// @brief draw a circle segment
+void drawCircleSegment(Point center, int16_t radius, Point startPoint, Point endPoint, ArcFlags flags, fSetPixel cbDraw) {
+  GFX_TRACE("drawCircleSegment(%d/%d r=%d)  (%d/%d) -> (%d/%d)", center.x, center.y, radius, startPoint.x, startPoint.y, endPoint.x, endPoint.y);
+
+  int16_t xm = center.x;
+  int16_t ym = center.y;
+
+  if ((startPoint == endPoint) && (flags & ArcFlags::LongPath)) {
+    // draw a full circle
+    for (int16_t q = 0; q < 4; q++)
+      drawCircleQuadrant(radius, q, [&](int16_t x, int16_t y) {
+        cbDraw(xm + x, ym + y);
+      });
+    return;
+  }
+
+  if (!(flags & ArcFlags::Clockwise)) {
+    // flip vertically and adjust angles to use clockwise processing.
+    int16_t ym2 = 2 * center.y;
+    drawCircleSegment(
+      center, radius,
+      Point(startPoint.x, ym2 - startPoint.y),
+      Point(endPoint.x, ym2 - endPoint.y),
+      (ArcFlags)(flags | ArcFlags::Clockwise),
+      [&](int16_t x, int16_t y) {
+        cbDraw(x, ym2 - y);
+      });
+    return;
+  }  // if (! clockwise)
+
+
+  // Clockwise processing only from here.
+
+  // Draw from startPoint to endPoint using Quadrants
+  startPoint = startPoint - center;
+  endPoint = endPoint - center;
+
+  uint16_t sQ = Point::circleQuadrant(startPoint);
+  uint16_t eQ = Point::circleQuadrant(endPoint);
+
+  if (sQ == eQ) {
+    if (Point::compareCircle(endPoint, startPoint)) {
+      eQ += 4;
+    }
+
+  } else if (sQ > eQ) {
+    eQ += 4;
+  }
+
+  // s=1: before the start
+  // s=2: draw pixels
+  // s=3: after the end
+  uint16_t s = 1;
+
+  for (uint16_t q = sQ; q <= eQ; q++) {
+    drawCircleQuadrant(radius, q % 4, [&](int16_t x, int16_t y) {
+      if (s == 1) {
+        if (Point::compareCircle(startPoint, Point(x, y))) {
+          // start drawing the points
+          s = 2;
+        }
+
+      } else if (s == 2) {
+        if (q != eQ) {
+          // draw
+
+        } else if (q == eQ) {
+          if (Point::compareCircle(endPoint, Point(x, y))) {
+            // stop drawing the points
+            s = 3;
+          }
+        }
+      }
+
+      if (s == 2) {
+        cbDraw(xm + x, ym + y);
+      }
+    });
+  }  // for()
+  // } while (q <= eQ);
+
+};  // drawCircleSegment()
+
+
+// Draw a whole circle. The draw function is not called in order of the pixels on the circle.
+void drawCircle(Point center, int16_t radius, fSetPixel cbStroke, fSetPixel cbFill) {
+  int16_t xm = center.x;
+  int16_t ym = center.y;
+  int16_t line = -radius;
+
+  drawCircleQuadrant(radius, 3, [&](int16_t x, int16_t y) {
+    // GFX_TRACE(" x=%d y=%d", x, y);
+    cbStroke(xm - x, ym + y);
+    if ((cbFill) && (y != line)) {
+      for (int16_t l = xm - x + 1; l < xm + x; l++) {
+        cbFill(l, ym + y);
+      }
+    }
+    cbStroke(xm + x, ym + y);
+
+    if (y < 0) {
+      cbStroke(xm - x, ym - y);
+      if ((cbFill) && (y != line)) {
+        for (int16_t l = xm - x + 1; l < xm + x; l++) {
+          cbFill(l, ym - y);
+        }
+      }
+      cbStroke(xm + x, ym - y);
+    }
+    line = y;
+  });
+}  // drawCircle()
+
+/// @brief Calculate the center parameterization for an arc from endpoints
+/// The radius values may be scaled up when there is no arc possible.
+void arcCenter(int16_t x1, int16_t y1, int16_t x2, int16_t y2, int16_t &rx, int16_t &ry, int16_t phi, int16_t flags, int32_t &cx256, int32_t &cy256) {
+  // Conversion from endpoint to center parameterization
+  // see also http://www.w3.org/TR/SVG11/implnote.html#ArcImplementationNotes
+
+  // <https://github.com/canvg/canvg/blob/937668eced93e0335c67a255d0d2277ea708b2cb/src/Document/PathElement.ts#L491>
+
+  double sinphi = sin(phi);
+  double cosphi = cos(phi);
+
+  // middle of (x1/y1) to (x2/y2)
+  double xMiddle = (x1 - x2) / 2;
+  double yMiddle = (y1 - y2) / 2;
+
+  double xTemp = (cosphi * xMiddle) + (sinphi * yMiddle);
+  double yTemp = (-sinphi * xMiddle) + (cosphi * yMiddle);
+
+  // adjust x & y radius when too small
+  if (rx == 0 || ry == 0) {
+    double dist = sqrt(((x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2)));
+    rx = ry = (int16_t)(dist / 2);
+    GFX_TRACE("rx=ry= %d", rx);
+
+  } else {
+    double dist2 = (xTemp * xTemp) / (rx * rx) + (yTemp * yTemp) / (ry * ry);
+
+    if (dist2 > 1) {
+      double dist = sqrt(dist2);
+      rx = static_cast<int16_t>(std::lround(rx * dist));
+      ry = static_cast<int16_t>(std::lround(ry * dist));
+    }
+    GFX_TRACE("rx=%d ry=%d ", rx, ry);
+  }
+
+  // center calculation
+  double centerDist = 0;
+  double distNumerator = ((rx * rx) * (ry * ry) - (rx * rx) * (yTemp * yTemp) - (ry * ry) * (xTemp * xTemp));
+  if (distNumerator > 0) {
+    centerDist = sqrt(distNumerator / ((rx * rx) * (yTemp * yTemp) + (ry * ry) * (xTemp * xTemp)));
+  }
+
+  if ((flags == 0x00) || (flags == 0x03)) {
+    centerDist = -centerDist;
+  }
+
+  double cX = (centerDist * rx * yTemp) / ry;
+  double cY = (centerDist * -ry * xTemp) / rx;
+
+  double centerX = (cosphi * cX) - (sinphi * cY) + (x1 + x2) / 2;
+  double centerY = (sinphi * cX) + (cosphi * cY) + (y1 + y2) / 2;
+
+  cx256 = std::lround(256 * centerX);
+  cy256 = std::lround(256 * centerY);
+}  // arcCenter()
+
+
+/// Calculate the angle of a vector in degrees.
+int16_t vectorAngle(int16_t dx, int16_t dy) {
+  // GFX_TRACE("vectorAngle(%d, %d)", dx, dy);
+  double rad = atan2(dy, dx);
+  int16_t angle = static_cast<int16_t>(std::lround(rad * 180 / M_PI));
+  if (angle < 0) angle = 360 + angle;
+  return (angle % 360);
+}  // vectorAngle()
+
+
+/// @brief Draw an arc according to svg path arc parameters.
+/// @param x1 Starting Point X coordinate.
+/// @param y1 Starting Point Y coordinate.
+/// @param x2 Ending Point X coordinate.
+/// @param y2 Ending Point Y coordinate.
+/// @param rx
+/// @param ry
+/// @param phi  rotation of the ellipsis
+/// @param flags
+/// @param cbDraw Callback with coordinates of line pixels.
+void drawArc(int16_t x1, int16_t y1, int16_t x2, int16_t y2,
+             int16_t rx, int16_t ry,
+             int16_t phi, int16_t flags,
+             fSetPixel cbDraw) {
+  GFX_TRACE("drawArc(%d/%d)-(%d/%d)", x1, y1, x2, y2);
+
+  int32_t cx256, cy256;
+
+  arcCenter(x1, y1, x2, y2, rx, ry, phi, flags, cx256, cy256);
+
+  GFX_TRACE("  flags   = 0x%02x", flags);
+  GFX_TRACE("  center = %d/%d", SCALE256(cx256), SCALE256(cy256));
+  GFX_TRACE("  radius = %d/%d", rx, ry);
+
+  proposePixel(x1, y1, cbDraw);
+  if (rx == ry) {
+    // draw a circle segment faster. ellipsis rotation can be ignored.
+    gfxDraw::drawCircleSegment(gfxDraw::Point(SCALE256(cx256), SCALE256(cy256)), rx,
+                               gfxDraw::Point(x1, y1),
+                               gfxDraw::Point(x2, y2),
+                               (gfxDraw::ArcFlags)(flags & gfxDraw::ArcFlags::Clockwise),
+                               [&](int16_t x, int16_t y) {
+                                 proposePixel(x, y, cbDraw);
+                               });
+  } else {
+    int startAngle = vectorAngle(256 * x1 - cx256, 256 * y1 - cy256);
+    int endAngle = vectorAngle(256 * x2 - cx256, 256 * y2 - cy256);
+    int stepAngle = (flags & 0x02) ? 1 : 359;
+
+    // Iterate through the ellipse
+    for (int16_t angle = startAngle; angle != endAngle; angle = (angle + stepAngle) % 360) {
+      int16_t x = SCALE256(cx256 + (rx * gfxDraw::cos256(angle)));
+      int16_t y = SCALE256(cy256 + (ry * gfxDraw::sin256(angle)));
+      proposePixel(x, y, cbDraw);
+    }
+  }
+  proposePixel(x2, y2, cbDraw);
+
+  proposePixel(0, POINT_BREAK_Y, cbDraw);
+
+}  // drawArc()
+
+}  // gfxDraw:: namespace
+
+// End.

--- a/lib/gfxDraw/src/gfxDrawCircle.h
+++ b/lib/gfxDraw/src/gfxDrawCircle.h
@@ -1,0 +1,85 @@
+// - - - - -
+// GFXDraw - A Arduino library for drawing shapes on a GFX display using paths describing the borders.
+// gfxdrawCircle.h: Header file for functions to calculate all points of a circle, circle quadrant and circle segment.
+//
+// Copyright (c) 2024-2024 by Matthias Hertel, http://www.mathertel.de
+// This work is licensed under a BSD style license. See http://www.mathertel.de/License.aspx
+//
+// These pixel oriented drawing functions are implemented to use callback functions for the effective drawing
+// to make them independent from an specific canvas or GFX implementation and can be used for drawing and un-drawing.
+//
+// The functions have minimized use of float and arc arithmetics.
+// Path drawing is supporting on any given path.
+// Filled paths are supported on closed paths only.
+//
+// Changelog:
+// * 22.05.2024 creation 
+// * 01.11.2024 full circle with fill 
+//
+// - - - - -
+
+#pragma once
+
+#include "gfxDraw.h"
+
+namespace gfxDraw {
+
+enum ArcFlags : uint16_t {
+  CounterClockwise = 0x00,
+  Clockwise = 0x02,
+  // ShortPath = 0x00
+  LongPath = 0x10,
+
+  FullCircle = LongPath | Clockwise
+};
+
+inline ArcFlags operator|(ArcFlags a, ArcFlags b) {
+  return static_cast<ArcFlags>(static_cast<int>(a) | static_cast<int>(b));
+}
+
+
+/// ===== Basic draw functions with callback =====
+
+/// @brief draw a whole circle. The draw function is not called in order of the pixels on the circle.
+/// @param center center of the circle
+/// @param radius radius of the circle
+/// @param cbDraw SetPixel callback
+void drawCircle(Point center, int16_t radius, fSetPixel cbStroke, fSetPixel cbFill = nullptr);
+
+
+/// @brief Calculate all points on the specified quadrant of a circle with center 0/0.
+/// @param radius radius of the circle
+/// @param q number of quadrant (see header file)
+/// @param cbDraw will be called for all pixels in the Circle Quadrant
+void drawCircleQuadrant(int16_t radius, int16_t q, fSetPixel cbDraw);
+
+
+/// @brief draw a circle segment or a whole circle.
+/// @param center center of the circle
+/// @param radius radius of the circle
+/// @param startPoint first point of the arc
+/// @param endPoint last point of the arc
+/// @param clockwise order of pixel drawing.
+/// @param cbDraw SetPixel callback
+void drawCircleSegment(Point center, int16_t radius, Point startPoint, Point endPoint, ArcFlags flags, fSetPixel cbDraw);
+
+
+/// @brief Draw an arc using the most efficient algorithm
+void drawArc(int16_t x1, int16_t y1, int16_t x2, int16_t y2, int16_t rx, int16_t ry, int16_t phi, int16_t flags, fSetPixel cbDraw);
+
+
+/// ====== internally used functions - maybe helpful for generating paths
+
+/// @brief Calculate the angle of a vector in degrees
+/// @param dx x value of the vector
+/// @param dy y value of the vector
+/// @return the angle n range 0...359
+int16_t vectorAngle(int16_t dx, int16_t dy);
+
+
+}  // gfxDraw:: namespace
+
+
+
+
+// End.

--- a/lib/gfxDraw/src/gfxDrawColors.cpp
+++ b/lib/gfxDraw/src/gfxDrawColors.cpp
@@ -1,0 +1,93 @@
+// - - - - -
+// GFXDraw - A Arduino library for drawing shapes on a GFX display using paths describing the borders.
+// gfxDrawColors.cpp: Library implementation for handling Color values.
+//
+// Copyright (c) 2024-2024 by Matthias Hertel, http://www.mathertel.de
+// This work is licensed under a BSD style license. See http://www.mathertel.de/License.aspx
+//
+// Changelog: See gfxDrawColors.h and documentation files in this library.
+//
+// - - - - -
+
+
+#include "gfxDrawColors.h"
+
+#ifndef GFX_TRACE
+#define GFX_TRACE(...)  // GFXDRAWTRACE(__VA_ARGS__)
+#endif
+
+
+namespace gfxDraw {
+
+// ===== ARGB class members =====
+
+ARGB::ARGB() : raw(0) {};
+
+// RGB+A Color
+ARGB::ARGB(uint8_t r, uint8_t g, uint8_t b, uint8_t a)
+  : Red(r), Green(g), Blue(b), Alpha(a){};
+
+// raw 32 bit color with no transparency
+ARGB::ARGB(uint32_t color)
+  : raw(color) {
+  Alpha = 0xFF;
+};
+
+bool ARGB::operator==(ARGB const &col2) {
+  return (raw == col2.raw);
+}
+
+bool ARGB::operator!=(ARGB const &col2) {
+  return (raw != col2.raw);
+}
+
+/// @brief Convert into a 3*8 bit value using #RRGGBB.
+/// @return color value.
+uint32_t ARGB::toColor24() {
+  return (raw & 0x0FFFFFF);
+}
+
+// Convert into a 16 bit value using 5(R)+6(G)+5(B)
+uint16_t ARGB::toColor16() {
+  return ((((Red) & 0xF8) << 8) | (((Green) & 0xFC) << 3) | ((Blue) >> 3));
+}
+
+// c lang-format off
+ARGB const ARGB_BLACK (    0,    0,    0);
+ARGB const ARGB_SILVER( 0xDD, 0xDD, 0xDD);
+ARGB const ARGB_GRAY  ( 0xCC, 0xCC, 0xCC);
+ARGB const ARGB_RED   ( 0xFF,    0,    0);
+ARGB const ARGB_ORANGE( 0xE9, 0x76,    0);
+ARGB const ARGB_YELLOW( 0xF6, 0xC7,    0);
+ARGB const ARGB_GREEN (    0, 0x80,    0);
+ARGB const ARGB_LIME  ( 0x32, 0xCD, 0x32);
+ARGB const ARGB_BLUE  (    0,    0, 0xFF);
+ARGB const ARGB_CYAN  (    0, 0xFF, 0xFF);
+ARGB const ARGB_PURPLE( 0x99, 0x46, 0x80);
+ARGB const ARGB_WHITE ( 0xFF, 0xFF, 0xFF);
+
+ARGB const ARGB_TRANSPARENT( 0x00, 0x00, 0x00, 0x00);
+// c lang-format on
+
+// ===== gfxDraw helper functions =====
+
+void dumpColor(const char *name, ARGB col) {
+  GFX_TRACE(" %-12s: %02x.%02x.%02x.%02x #%06lx", name, col.Alpha, col.Red, col.Green, col.Blue, col.toColor24());
+}
+
+void dumpColorTable() {
+  GFX_TRACE("        Color: A  R  G  B  #col24");
+  dumpColor("Red", gfxDraw::ARGB_RED);
+  dumpColor("Green", gfxDraw::ARGB_GREEN);
+  dumpColor("Blue", gfxDraw::ARGB_BLUE);
+  dumpColor("Orange", gfxDraw::ARGB_ORANGE);
+  dumpColor("Transparent", gfxDraw::ARGB_TRANSPARENT);
+}
+
+
+
+
+
+}  // gfxDraw:: namespace
+
+// End.

--- a/lib/gfxDraw/src/gfxDrawColors.h
+++ b/lib/gfxDraw/src/gfxDrawColors.h
@@ -1,0 +1,100 @@
+// Pre-defined drawing Colors
+// use color picker: <https://www.w3schools.com/colors/colors_picker.asp?colorhex=4060a0>
+
+#pragma once
+
+#ifdef ARDUINO
+#include <Arduino.h>
+#endif
+
+#include <stdint.h>
+
+namespace gfxDraw {
+
+#pragma pack(push, 1)
+/// @brief The ARGB class is used to define the opacity and color for a single abstract pixel.
+/// using 32-bits per pixel for Alpha, Red, Green, Blue
+/// The layout of this class is to also have a raw 32-bit value in format #aaRRGGBB
+/// and conversions to 16-bit values using 0brrrrrggggggbbbbb.
+
+class ARGB {
+public:
+  ARGB();
+
+  /// create color by components.
+  ARGB(uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255);
+
+  /// create opaque color.
+  ARGB(uint32_t raw);
+
+  union {
+    struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+      uint8_t Blue;
+      uint8_t Green;
+      uint8_t Red;
+      uint8_t Alpha;
+#else
+      uint8_t Alpha;
+      uint8_t Red;
+      uint8_t Green;
+      uint8_t Blue;
+#endif
+    };
+    uint32_t raw;  // equals #AArrggbb
+  };
+
+  /// @brief Compare two colors.
+  /// @param col2 the color to compare with.
+  /// @return true if the colors are equal.
+  bool operator==(ARGB const &col2);
+
+  /// @brief Compare two colors.
+  /// @param col2 the color to compare with.
+  /// @return true if the colors are not equal.  
+   bool operator!=(ARGB const &col2);
+
+  // conversions to uint32_t can be implicit
+
+  operator uint32_t() const {
+    return (raw);
+  };
+
+  ARGB &operator=(uint32_t v) {
+    raw = v;
+    return *this;
+  };
+
+  /// @brief Convert into a 3*8 bit value using #rrggbb.
+  /// @return color value.
+  uint32_t toColor24();
+
+  /// @brief Convert into a 16 bit value using 5(R)+6(G)+5(B) .
+  /// @return color value.
+  uint16_t toColor16();
+};
+#pragma pack(pop)
+
+
+// Some useful constants for simple colors
+
+extern ARGB const ARGB_BLACK;
+extern ARGB const ARGB_SILVER;
+extern ARGB const ARGB_GRAY;
+extern ARGB const ARGB_RED;
+extern ARGB const ARGB_ORANGE;
+extern ARGB const ARGB_YELLOW;
+extern ARGB const ARGB_GREEN;
+extern ARGB const ARGB_LIME;
+extern ARGB const ARGB_BLUE;
+extern ARGB const ARGB_CYAN;
+extern ARGB const ARGB_PURPLE;
+extern ARGB const ARGB_WHITE;
+
+extern ARGB const ARGB_TRANSPARENT;
+
+void dumpColorTable();
+
+}  // namespace gfxDraw
+
+// End.

--- a/lib/gfxDraw/src/gfxDrawCommon.cpp
+++ b/lib/gfxDraw/src/gfxDrawCommon.cpp
@@ -1,0 +1,153 @@
+// - - - - -
+// GFXDraw - A Arduino library for drawing shapes on a GFX display using paths describing the borders.
+// gfxDrawCommon.cpp: Library implementation for common functionality.
+//
+// Copyright (c) 2024-2024 by Matthias Hertel, http://www.mathertel.de
+// This work is licensed under a BSD style license. See http://www.mathertel.de/License.aspx
+//
+// Changelog: See gfxDrawCommon.h and documentation files in this library.
+//
+// - - - - -
+
+#include "gfxDraw.h"
+#include "gfxDrawCommon.h"
+
+#ifndef GFX_TRACE
+#define GFX_TRACE(...)  // GFXDRAWTRACE(__VA_ARGS__)
+#endif
+
+
+namespace gfxDraw {
+
+// Proposes a next pixel of the path.
+
+void proposePixel(int16_t x, int16_t y, fSetPixel cbDraw) {
+  static Point lastPoints[3];
+
+  GFX_TRACE("proposePixel(%d, %d)", x, y);
+
+  if ((x == lastPoints[0].x) && (y == lastPoints[0].y)) {
+    // don't collect duplicates
+    GFX_TRACE("  duplicate!");
+
+  } else if (y == POINT_BREAK_Y) {
+    // draw all remaining points and invalidate lastPoints
+    GFX_TRACE("  flush!");
+    for (int n = 2; n >= 0; n--) {
+      if (lastPoints[n].y != POINT_INVALID_Y)
+        cbDraw(lastPoints[n].x, lastPoints[n].y);
+      lastPoints[n].y = POINT_INVALID_Y;
+    }  // for
+
+  } else if (lastPoints[0].y == POINT_BREAK_Y) {
+    lastPoints[0].x = x;
+    lastPoints[0].y = y;
+
+  } else {
+    // draw oldest point and shift new point in
+    if (lastPoints[2].y != POINT_INVALID_Y)
+      cbDraw(lastPoints[2].x, lastPoints[2].y);
+    lastPoints[2] = lastPoints[1];
+    lastPoints[1] = lastPoints[0];
+    lastPoints[0].x = x;
+    lastPoints[0].y = y;
+
+    if (lastPoints[1].y != POINT_INVALID_Y) {
+      bool delFlag = false;
+
+      // don't draw "corner" points
+      if ((lastPoints[0].y == lastPoints[1].y) && (abs(lastPoints[0].x - lastPoints[1].x) == 1)) {
+        delFlag = (lastPoints[1].x == lastPoints[2].x);
+      } else if ((lastPoints[0].x == lastPoints[1].x) && (abs(lastPoints[0].y - lastPoints[1].y) == 1)) {
+        delFlag = (lastPoints[1].y == lastPoints[2].y);
+      }
+
+      // draw between unconnected points
+      if (!delFlag) {
+        if ((abs(lastPoints[0].x - lastPoints[1].x) <= 1) && (abs(lastPoints[0].y - lastPoints[1].y) <= 1)) {
+          // points are connected -> no additional draw required
+
+        } else if ((abs(lastPoints[0].x - lastPoints[1].x) <= 2) && (abs(lastPoints[0].y - lastPoints[1].y) <= 2)) {
+          // simple interpolate new lastPoints[1]
+          // GFX_TRACE("  gap!");
+          if (lastPoints[2].y != POINT_INVALID_Y)
+            cbDraw(lastPoints[2].x, lastPoints[2].y);
+          lastPoints[2] = lastPoints[1];
+          lastPoints[1].x = (lastPoints[0].x + lastPoints[1].x) / 2;
+          lastPoints[1].y = (lastPoints[0].y + lastPoints[1].y) / 2;
+        } else if ((abs(lastPoints[0].x - lastPoints[1].x) > 2) || (abs(lastPoints[0].y - lastPoints[1].y) > 2)) {
+          // GFX_TRACE("  big gap!");
+
+          // draw a streight line from lastPoints[1] to lastPoints[0]
+          if (lastPoints[2].y != POINT_INVALID_Y)
+            cbDraw(lastPoints[2].x, lastPoints[2].y);
+          drawLine(lastPoints[1].x, lastPoints[1].y, lastPoints[0].x, lastPoints[0].y, cbDraw);
+          lastPoints[2].y = POINT_INVALID_Y;
+          lastPoints[1].y = POINT_INVALID_Y;
+          // lastPoints[0] stays.
+        }
+      }
+
+      if (delFlag) {
+        // remove lastPoints[1];
+        lastPoints[1] = lastPoints[2];
+        lastPoints[2].y = POINT_INVALID_Y;
+      }
+    }
+  }
+};
+
+// ===== Fast but non-precise sin / cos functions
+
+const int32_t tab_sin256[] = {
+  0, 4, 9, 13, 18, 22, 27, 31, 35, 40, 44,
+  49, 53, 57, 62, 66, 70, 75, 79, 83, 87,
+  91, 96, 100, 104, 108, 112, 116, 120, 124, 128,
+  131, 135, 139, 143, 146, 150, 153, 157, 160, 164,
+  167, 171, 174, 177, 180, 183, 186, 190, 192, 195,
+  198, 201, 204, 206, 209, 211, 214, 216, 219, 221,
+  223, 225, 227, 229, 231, 233, 235, 236, 238, 240,
+  241, 243, 244, 245, 246, 247, 248, 249, 250, 251,
+  252, 253, 253, 254, 254, 254, 255, 255, 255, 255
+};
+
+
+
+/// @brief table drive sin(degree) function
+/// @param degree Degree in ruan 0...360
+/// @return non-precise sin value as integer in range 0...256
+int32_t sin256(int32_t degree) {
+  degree = ((degree % 360) + 360) % 360;  // Math. Modulo Operator
+  if (degree <= 90) {
+    return (tab_sin256[degree]);
+  } else if (degree <= 180) {
+    return (tab_sin256[90 - (degree - 90)]);
+  } else if (degree <= 270) {
+    return (-tab_sin256[degree - 180]);
+  } else {
+    return (-tab_sin256[90 - (degree - 270)]);
+  }
+}
+
+int32_t cos256(int32_t degree) {
+  return (sin256(degree + 90));
+}
+
+// ===== Debug helping functions... =====
+
+void dumpPoints(std::vector<Point> &points) {
+  GFX_TRACE("\nPoints:");
+  size_t size = points.size();
+  for (size_t i = 0; i < size; i++) {
+    if (i % 10 == 0) {
+      if (i > 0) { GFX_TRACE(""); }
+      GFX_TRACE("  p%02d:", i);
+    }
+    GFX_TRACE(" (%2d/%2d)", points[i].x, points[i].y);
+  }
+  GFX_TRACE("");
+}
+
+}  // gfxDraw:: namespace
+
+// End.

--- a/lib/gfxDraw/src/gfxDrawCommon.h
+++ b/lib/gfxDraw/src/gfxDrawCommon.h
@@ -1,0 +1,185 @@
+// - - - - -
+// GFXDraw - A Arduino library for drawing shapes on a GFX display using paths describing the borders.
+// gfxdrawCommon.h: Library header file
+//
+// Copyright (c) 2024-2024 by Matthias Hertel, http://www.mathertel.de
+// This work is licensed under a BSD style license. See http://www.mathertel.de/License.aspx
+//
+// These pixel oriented drawing functions are implemented to use callback functions for the effective drawing
+// to make them independent from an specific canvas or GFX implementation and can be used for drawing and un-drawing.
+//
+// The functions have minimized use of float and arc arithmetics.
+// Path drawing is supporting on any given path.
+// Filled paths are supported on closed paths only.
+//
+// CHANGELOG:
+// 15.05.2024  creation of the GFXDraw library.
+//
+// - - - - -
+
+#pragma once
+
+#ifdef ARDUINO
+#include <Arduino.h>
+#endif
+
+#include <functional>
+
+namespace gfxDraw {
+
+/// @brief Callback function definition to address a pixel on a display
+typedef std::function<void(int16_t x, int16_t y)> fSetPixel;
+
+/// @brief Callback function definition to change a pixel on a display by applying the given color.
+typedef std::function<void(int16_t x, int16_t y, ARGB color)> fDrawPixel;
+
+/// @brief Callback function definition to change a pixel on a display by applying the given color.
+typedef std::function<ARGB(ARGB color)> fMapColor;
+
+
+/// @brief Callback function to transform all points in the segments
+typedef std::function<void(int16_t &x, int16_t &y)> fTransform;
+
+/// @brief Callback function definition to read a pixel from a display
+// typedef std::function<ARGB(int16_t x, int16_t y)> fReadPixel;
+
+
+
+
+/// ===== Points =====
+
+/// POINT_BREAK_Y marks the end of a path when pixels are streamed through a fSetPixel callback.
+#define POINT_BREAK_Y INT16_MAX
+
+/// POINT_INVALID_Y marks ivalid pixels that must be ignored for drawing.
+#define POINT_INVALID_Y INT16_MAX - 1
+
+
+/// @brief A Point holds a pixel position and provides some useful static methods.
+/// There are 2 "special" locations when the Y value is about INT16_MAX and INT16_MAX-1
+/// that cannot be used for drawing.
+class Point {
+public:
+  Point()
+    : x(0), y(POINT_INVALID_Y) {};
+
+  Point(int16_t _x, int16_t _y)
+    : x(_x), y(_y) {};
+
+  /// @brief X coordinate of the Point
+  int16_t x;
+
+  /// @brief Y coordinate of the Point
+  int16_t y;
+
+  /// @brief compare function for std::sort to sort points by (y) and ascending (x)
+  /// @param p1 first point
+  /// @param p2 second point
+  /// @return when p1 is lower than p2
+  static bool compare(const Point &p1, const Point &p2) {
+    if (p1.y != p2.y)
+      return (p1.y < p2.y);
+    return (p1.x < p2.x);
+  };
+
+  friend bool operator==(const Point &p1, const Point &p2) {
+    return ((p1.x == p2.x) && (p1.y == p2.y));
+  };  // operator=
+
+
+  /// @brief Add 2 point vectors or move a point by a vector.
+  /// @param p1 Point 1
+  /// @param p2 Point 2
+  /// @return Sum of the 2 point vectors.
+  friend Point operator+(const Point &p1, const Point &p2) {
+    Point p(p1.x + p2.x, p1.y + p2.y);
+    return (p);
+  };  // operator+
+
+  /// @brief subtract 2 point vectors or move a point by a opposite vector.
+  /// @param p1 Point 1
+  /// @param p2 Point 2
+  /// @return Difference of the 2 point vectors.
+  friend Point operator-(const Point &p1, const Point &p2) {
+    Point p(p1.x - p2.x, p1.y - p2.y);
+    return (p);
+  };  // operator-
+
+
+  // ===== Circle related functions.
+
+  // Quadrants
+  //      y
+  //    2 | 3
+  //  x---|--->
+  //    1 | 0
+  //      v
+
+  // return Quadrant of a vector
+  static int16_t circleQuadrant(const Point &p) {
+    if ((p.x > 0) && (p.y >= 0)) { return (0); }
+    if ((p.x <= 0) && (p.y > 0)) { return (1); }
+    if ((p.x < 0) && (p.y <= 0)) { return (2); }
+    if ((p.x >= 0) && (p.y < 0)) { return (3); }
+    return (0);
+  }
+
+
+  /// @brief Compare 2 points on a circle in clockwise direction.
+  /// @param p1 Point #1
+  /// @param p2 Point #2
+  /// @return true if the first is less than the second.
+  static bool compareCircle(Point p1, Point p2) {
+
+    if (p1 == p2) return (false);
+
+    int16_t q1 = circleQuadrant(p1);
+    int16_t q2 = circleQuadrant(p2);
+
+    if (q1 < q2) return (true);
+    if (q1 > q2) return (false);
+
+    if (q1 == 0) {
+      return ((p1.x > p2.x) || (p1.y < p2.y));
+    } else if (q1 == 1) {
+      return ((p1.x > p2.x) || (p1.y > p2.y));
+    } else if (q1 == 2) {
+      return ((p1.x < p2.x) || (p1.y > p2.y));
+    } else if (q1 == 3) {
+      return ((p1.x < p2.x) || (p1.y < p2.y));
+    }
+    return (false);
+  }
+};
+
+
+/// @brief Propose a next pixel of the path.
+/// @param x X value of the pixel
+/// @param y Y value of the pixel
+/// @param cbDraw callback function for the effective pixels of the path.
+///
+/// @details
+/// This function buffers up to 3 pixels and analysis for pixel unwanted sequences and missing pixels.
+/// * ignore duplicates
+/// * remove corner-type pixels
+/// * fill missing 1-pixel
+/// * draw streight line when more pixels are missing.
+void proposePixel(int16_t x, int16_t y, fSetPixel cbDraw);
+
+/// @brief Print a vector of Points on the output.
+/// @param points vector of Points.
+void dumpPoints(std::vector<Point> &points);
+
+// ===== Fast but non-precise sin / cos functions
+
+int32_t sin256(int32_t degree);
+
+int32_t cos256(int32_t degree);
+
+#define SCALE256(v) ((v + 127) >> 8)
+
+
+}  // gfxDraw:: namespace
+
+
+// End.

--- a/lib/gfxDraw/src/gfxDrawLine.cpp
+++ b/lib/gfxDraw/src/gfxDrawLine.cpp
@@ -1,0 +1,77 @@
+// - - - - -
+// GFXDraw - A Arduino library for drawing shapes on a GFX display using paths describing the borders.
+// gfxDrawLine.cpp: Library implementation file for functions to calculate all points of a staight line.
+//
+// Copyright (c) 2024-2024 by Matthias Hertel, http://www.mathertel.de
+// This work is licensed under a BSD style license. See http://www.mathertel.de/License.aspx
+//
+// Changelog: See gfxDrawLine.h and documentation files in this library.
+//
+// - - - - -
+
+#include "gfxDrawLine.h"
+
+#ifndef GFX_TRACE
+#define GFX_TRACE(...)  // GFXDRAWTRACE(__VA_ARGS__)
+#endif
+
+
+namespace gfxDraw {
+
+void drawLine(Point &p1, Point &p2, fSetPixel cbDraw) {
+  drawLine(p1.x, p1.y, p2.x, p2.y, cbDraw);
+}
+
+
+/// @brief Draw a line using the most efficient algorithm
+/// @param x0 Starting Point X coordinate.
+/// @param y0 Starting Point Y coordinate.
+/// @param x1 Ending Point X coordinate.
+/// @param y1 Ending Point Y coordinate.
+/// @param cbDraw Callback with coordinates of line pixels.
+void drawLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1, fSetPixel cbDraw) {
+  GFX_TRACE("Draw Line (%d/%d)--(%d/%d)", x0, y0, x1, y1);
+
+  int16_t delta_x = abs(x1 - x0);
+  int16_t delta_y = abs(y1 - y0);
+  int16_t step_x = (x0 < x1) ? 1 : -1;
+  int16_t step_y = (y0 < y1) ? 1 : -1;
+
+  if (x0 == x1) {
+    // fast draw vertical lines
+    int16_t endY = y1 + step_y;
+    for (int16_t y = y0; y != endY; y += step_y) {
+      cbDraw(x0, y);
+    }
+
+  } else if (y0 == y1) {
+    // fast draw horizontal lines
+    int16_t endX = x1 + step_x;
+    for (int16_t x = x0; x != endX; x += step_x) {
+      cbDraw(x, y0);
+    }
+
+  } else {
+    int16_t err = delta_x - delta_y;
+
+    while (true) {
+      cbDraw(x0, y0);
+      if ((x0 == x1) && (y0 == y1)) break;
+
+      int16_t err2 = err << 1;
+
+      if (err2 > -delta_y) {
+        err -= delta_y;
+        x0 += step_x;
+      }
+      if (err2 < delta_x) {
+        err += delta_x;
+        y0 += step_y;
+      }
+    }
+  }
+};
+
+}  // gfxDraw:: namespace
+
+// End.

--- a/lib/gfxDraw/src/gfxDrawLine.h
+++ b/lib/gfxDraw/src/gfxDrawLine.h
@@ -1,0 +1,41 @@
+// - - - - -
+// GFXDraw - A Arduino library for drawing shapes on a GFX display using paths describing the borders.
+// gfxDrawLine.h: Header file for functions to calculate all points of a staight line.
+//
+// Copyright (c) 2024-2024 by Matthias Hertel, http://www.mathertel.de
+// This work is licensed under a BSD style license. See http://www.mathertel.de/License.aspx
+//
+// These pixel oriented drawing functions are implemented to use callback functions for the effective drawing
+// to make them independent from an specific canvas or GFX implementation and can be used for drawing and un-drawing.
+//
+// Changelog:
+// * 18.08.2024 creation
+//
+// - - - - -
+
+#pragma once
+
+#include "gfxDraw.h"
+
+namespace gfxDraw {
+
+/// @brief Draw a line using the most efficient algorithm
+/// @param x0 Starting Point X coordinate.
+/// @param y0 Starting Point Y coordinate.
+/// @param x1 Ending Point X coordinate.
+/// @param y1 Ending Point Y coordinate.
+/// @param cbDraw Callback with coordinates of line pixels.
+/// @param w Width of line.
+void drawLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1, fSetPixel cbDraw);
+
+
+/// @brief Draw a line using the most efficient algorithm
+/// @param p1 Starting Point
+/// @param p2 Ending Point
+/// @param cbDraw Callback with coordinates of line pixels.
+void drawLine(Point &p1, Point &p2, fSetPixel cbDraw);
+
+}  // gfxDraw:: namespace
+
+
+// End.

--- a/lib/gfxDraw/src/gfxDrawPath.cpp
+++ b/lib/gfxDraw/src/gfxDrawPath.cpp
@@ -1,0 +1,748 @@
+// - - - - -
+// GFXDraw - A Arduino library for drawing shapes on a GFX display using paths describing the borders.
+// gfxDrawPath.cpp: Library implementation file for functions to calculate all points of a staight line.
+//
+// Copyright (c) 2024-2024 by Matthias Hertel, http://www.mathertel.de
+// This work is licensed under a BSD style license. See http://www.mathertel.de/License.aspx
+//
+// Changelog: See gfxDrawPath.h and documentation files in this library.
+//
+// - - - - -
+
+#include "gfxDraw.h"
+#include "gfxDrawPath.h"
+
+#ifndef GFX_TRACE
+#define GFX_TRACE(...)  // GFXDRAWTRACE(__VA_ARGS__)
+#endif
+
+
+#define SLOPE_UNKNOWN 0
+#define SLOPE_FALLING 1
+#define SLOPE_RAISING 2
+#define SLOPE_HORIZONTAL 3
+
+namespace gfxDraw {
+// ===== internal class definitions =====
+
+
+// ===== Segments implementation =====
+
+Segment::Segment(Type _type, int16_t p1, int16_t p2) {
+  type = _type;
+  p[0] = p1;
+  p[1] = p2;
+}
+
+Segment Segment::createMove(int16_t x, int16_t y) {
+  return (Segment(Type::Move, x, y));
+}
+
+Segment Segment::createMove(Point p) {
+  return (Segment(Type::Move, p.x, p.y));
+}
+
+Segment Segment::createLine(int16_t x, int16_t y) {
+  return (Segment(Type::Line, x, y));
+}
+
+Segment Segment::createLine(Point p) {
+  return (Segment(Type::Line, p.x, p.y));
+}
+
+Segment Segment::createClose() {
+  Segment s;
+  s.type = Close;
+  return (s);
+}
+
+Segment Segment::createArc(int16_t radius, bool f1, bool f2, int16_t xEnd, int16_t yEnd) {
+  Segment s;
+  s.type = Arc;
+  s.rx = s.ry = radius;
+  s.rotation = 0;
+  s.f1f2 = (f1 ? 0x01 : 0x00) + (f2 ? 0x02 : 0x00);  // flags
+  s.xEnd = xEnd;
+  s.yEnd = yEnd;
+  return (s);
+};
+
+
+void dumpSegments(std::vector<Segment> &vSeg) {
+  GFX_TRACE("\nSegments: %zu", vSeg.size());
+
+  for (Segment &seg : vSeg) {
+    const char *s = "";
+    if (seg.type == Segment::Type::Move) s = "M";
+    if (seg.type == Segment::Type::Line) s = "L";
+    if (seg.type == Segment::Type::Arc) s = "A";
+    if (seg.type == Segment::Type::Close) s = "Z";
+    if (seg.type == Segment::Type::Curve) s = "C";
+    GFX_TRACE("  %s(0x%04x) - %d/%d", s, seg.type, seg.p[0], seg.p[1]);
+  }
+}
+
+// ===== Segment transformation functions =====
+
+/// @brief Scale the points of a path by factor
+/// @param segments
+/// @param f100
+void scaleSegments(std::vector<Segment> &segments, int16_t factor, int16_t base) {
+  if (factor != base) {
+    transformSegments(segments, [&](int16_t &x, int16_t &y) {
+      x = ((x * factor) + (base / 2)) / base;
+      y = ((y * factor) + (base / 2)) / base;
+    });
+  }
+}  // scaleSegments()
+
+
+/// @brief move all points by the given offset in x and y.
+/// @param segments Segment vector to be changed
+/// @param dx X-Offset
+/// @param dy Y-Offset
+void moveSegments(std::vector<Segment> &segments, int16_t dx, int16_t dy) {
+  if ((dx != 0) || (dy != 0)) {
+    transformSegments(segments, [&](int16_t &x, int16_t &y) {
+      x += dx;
+      y += dy;
+    });
+  }
+}  // moveSegments()
+
+
+/// @brief move all points by the given offset in x and y.
+/// @param segments Segment vector to be changed
+/// @param moveVector X- and Y- Offset as Point-Vector.
+void moveSegments(std::vector<Segment> &segments, Point moveVector) {
+  moveSegments(segments, moveVector.x, moveVector.y);
+};
+
+
+void rotateSegments(std::vector<Segment> &segments, int16_t angle) {
+  if (angle != 0) {
+
+    double radians = (angle * M_PI) / 180;
+
+    int32_t sinFactor1000 = std::lround(sin(radians) * 1000);
+    int32_t cosFactor1000 = std::lround(cos(radians) * 1000);
+
+    transformSegments(segments, [&](int16_t &x, int16_t &y) {
+      int32_t tx = cosFactor1000 * x - sinFactor1000 * y;
+      int32_t ty = sinFactor1000 * x + cosFactor1000 * y;
+      x = (tx / 1000);
+      y = (ty / 1000);
+    });
+  }
+}  // rotateSegments()
+
+
+/// @brief transform all points in the segment list.
+/// @param segments Segment vector to be changed
+void transformSegments(std::vector<Segment> &segments, fTransform cbTransform) {
+  int16_t p0_x, p0_y, p1_x, p1_y;
+  int16_t angle;
+  int32_t scale1000;
+  bool scaleKnown = false;
+
+  for (Segment &pSeg : segments) {
+
+    switch (pSeg.type) {
+      case Segment::Type::Move:
+      case Segment::Type::Line:
+        cbTransform(pSeg.p[0], pSeg.p[1]);
+        break;
+
+      case Segment::Type::Curve:
+        cbTransform(pSeg.p[0], pSeg.p[1]);
+        cbTransform(pSeg.p[2], pSeg.p[3]);
+        cbTransform(pSeg.p[4], pSeg.p[5]);
+        break;
+
+      case Segment::Type::Arc:
+        if (!scaleKnown) {
+          // extract scale and rotation from transforming (0,0)-(1000,0) once for the whole sement vector.
+          p0_x = p0_y = p1_y = 0;
+          p1_x = 1000;  // length = 1000
+
+          cbTransform(p0_x, p0_y);
+          cbTransform(p1_x, p1_y);
+
+          // ignore any translation
+          p1_x -= p0_x;
+          p1_y -= p0_y;
+
+          if (p1_y == 0) {
+            // simplify for non rotated or 180° rotated transformations
+            if (p1_x > 0) {
+              scale1000 = p1_x;
+              angle = 0;
+            } else {
+              scale1000 = -p1_x;
+              angle = 180;
+            }
+
+          } else {
+            double p1_length = sqrt((p1_x * p1_x) + (p1_y * p1_y));
+            scale1000 = std::lround(p1_length);
+            angle = vectorAngle(p1_x, p1_y);
+          }
+          scaleKnown = true;
+        }
+
+        // scale x & y radius
+        pSeg.p[0] = static_cast<int16_t>((pSeg.p[0] * scale1000 + 500) / 1000);
+        pSeg.p[1] = static_cast<int16_t>((pSeg.p[1] * scale1000 + 500) / 1000);
+
+        // rotate ellipsis rotation
+        pSeg.p[2] += angle;
+
+        // transform endpoint
+        cbTransform(pSeg.p[4], pSeg.p[5]);  // endpoint
+        break;
+
+      case Segment::Type::Circle:
+        // TODO:
+        GFX_TRACE("Transform circle is missing.");
+        break;
+
+      case Segment::Type::Close:
+        break;
+
+      default:
+        GFX_TRACE("unknown segment-%04x", pSeg.type);
+        break;
+    }
+  }  // for
+};
+
+
+// ===== Edge functionality =====
+
+/// @brief The _Edge class holds a horizontal pixel sequence for path boundaries and provides some useful static methods.
+class _Edge : public Point {
+public:
+  _Edge(int16_t _x, int16_t _y)
+    : Point(_x, _y), len(1) {};
+
+  uint16_t len;
+
+  /// @brief compare function for std::sort to sort points by (y) and ascending (x)
+  /// @param p1 first Edge-point
+  /// @param p2 second Edge-point
+  /// @return when p1 is lower than p2
+  static bool compare(const _Edge &p1, const _Edge &p2) {
+    if (p1.y != p2.y)
+      return (p1.y < p2.y);
+    if (p1.x != p2.x)
+      return (p1.x < p2.x);
+    return (p1.len < p2.len);
+  };
+
+  /// @brief add another point or Edge to the Edge
+  /// @param p2
+  /// @return true when this Edge could be expanded.
+  bool expand(_Edge p2) {
+    if (y == p2.y) {
+      if (x > p2.x + p2.len) {
+        // no
+        return (false);
+      } else if (x + len < p2.x) {
+        // no
+        return (false);
+
+      } else {
+        // overlapping or joining edges
+        int16_t left = (x < p2.x ? x : p2.x);
+        int16_t right = (x + len > p2.x + p2.len ? x + len : p2.x + p2.len);
+        x = left;
+        len = right - left;
+        return (true);
+      }
+    }
+    return (false);
+  };
+};
+
+
+// find local extreme sequences and mark them with a double-edge
+size_t slopeEdges(std::vector<_Edge> &edges, size_t start, size_t end) {
+  int prevSlope;  // slope before any horizontal border points.
+
+  if (edges[end].y < edges[start].y) {
+    prevSlope = SLOPE_RAISING;
+  } else {
+    prevSlope = SLOPE_FALLING;
+  }
+
+  _Edge *prevEdge = &edges[end];
+  int16_t prevY = edges[end].y;
+
+  size_t n = start;
+  while (n <= end) {
+    int16_t thisY = edges[n].y;
+
+    if (thisY > prevY) {
+      if (prevSlope == SLOPE_FALLING) {
+        // maximum extreme ends here: duplicate previous point
+        GFX_TRACE("  ins %d", n);
+        edges.insert(edges.begin() + n, *prevEdge);
+        edges[n].len = 0;
+        n++;
+        end++;
+        prevSlope = SLOPE_RAISING;
+      }
+
+    } else if (thisY < prevY) {
+      if (prevSlope == SLOPE_RAISING) {
+        // minimum extreme ends here: duplicate previous point
+        GFX_TRACE("  ins %d", n);
+        edges.insert(edges.begin() + n, *prevEdge);
+        edges[n].len = 0;
+        n++;
+        end++;
+        prevSlope = SLOPE_FALLING;
+      }
+    }
+
+    prevEdge = &edges[n];
+    prevY = prevEdge->y;
+    n++;
+  }
+
+  // last edge is extreme ?
+  if (edges[start].y > prevY) {
+    if (prevSlope == SLOPE_FALLING) {
+      // maximum extreme ends here: duplicate previous point
+      GFX_TRACE("  ins+ %d", n);
+      edges.insert(edges.begin() + n, *prevEdge);
+      edges[n].len = 0;
+      end++;
+    }
+
+  } else if (edges[start].y < prevY) {
+    if (prevSlope == SLOPE_RAISING) {
+      // minimum extreme ends here: duplicate previous point
+      GFX_TRACE("  ins+ %d", n);
+      edges.insert(edges.begin() + n, *prevEdge);
+      edges[n].len = 0;
+      end++;
+    }
+  }
+
+  return (end);
+}  // slopeEdges()
+
+
+// send all edges in readably format to the trace output
+void dumpEdges(std::vector<_Edge> &edges) {
+  size_t size = edges.size();
+  GFX_TRACE("\nEdges: %zu", size);
+
+  for (size_t i = 0; i < size; i++) {
+    if (i % 10 == 0) {
+      if (i > 0) { GFX_TRACE(""); }
+    }
+    GFX_TRACE(" (%3d/%3d) - %2d", edges[i].x, edges[i].y, edges[i].len);
+  }
+  GFX_TRACE("");
+}  // dumpEdges()
+
+// =====
+
+/// @brief Scan and parset a path text with the svg/path/d syntax to create a vector(array) of Segments.
+/// @param pathText path definition as String
+/// @return Vector with Segments.
+/// @example pathText="M4 8l12-6l10 10h-8v4h-6z"
+std::vector<Segment> parsePath(const char *pathText) {
+  GFX_TRACE("parsePath: '%s'", pathText);
+  char command = '-';
+
+  char *path = (char *)pathText;
+  int16_t lastX = 0, lastY = 0;
+
+  /// A lambda function to parse a numeric parameter from the inputText.
+  auto getNumParam = [&]() {
+    while (isspace(*path) || (*path == ',')) { path++; }
+    int16_t p = static_cast<int16_t>(strtol(path, &path, 10));
+    return (p);
+  };
+
+  /// A lambda function to parse a flag parameter from the inputText.
+  auto getBoolParam = [&]() {
+    while (isspace(*path) || (*path == ',')) { path++; }
+    bool flag = (*path++ == '1');
+    return (flag);
+  };
+
+  Segment Seg;
+  std::vector<Segment> vSeg;
+
+  while (path && *path) {
+
+    if (isspace(*path)) {
+      path++;
+
+    } else {
+      if (strchr("MmLlCcZHhVvAazO", *path))
+        command = *path++;
+
+      memset(&Seg, 0, sizeof(Seg));
+      bool f1, f2;  // flags
+
+      switch (command) {
+        case 'M':
+          Seg.type = Segment::Type::Move;
+          lastX = Seg.p[0] = getNumParam();
+          lastY = Seg.p[1] = getNumParam();
+          break;
+
+        case 'm':
+          // convert to absolute coordinates
+          Seg.type = Segment::Type::Move;
+          lastX = Seg.p[0] = lastX + getNumParam();
+          lastY = Seg.p[1] = lastY + getNumParam();
+          break;
+
+        case 'L':
+          Seg.type = Segment::Type::Line;
+          lastX = Seg.p[0] = getNumParam();
+          lastY = Seg.p[1] = getNumParam();
+          break;
+
+        case 'l':
+          // convert to absolute coordinates
+          Seg.type = Segment::Type::Line;
+          lastX = Seg.p[0] = lastX + getNumParam();
+          lastY = Seg.p[1] = lastY + getNumParam();
+          break;
+
+        case 'C':
+          // curve defined with absolute points - no convertion required
+          Seg.type = Segment::Type::Curve;
+          Seg.p[0] = getNumParam();
+          Seg.p[1] = getNumParam();
+          Seg.p[2] = getNumParam();
+          Seg.p[3] = getNumParam();
+          lastX = Seg.p[4] = getNumParam();
+          lastY = Seg.p[5] = getNumParam();
+          break;
+
+        case 'c':
+          // curve defined with relative points - convert to absolute coordinates
+          Seg.type = Segment::Type::Curve;
+          Seg.p[0] = lastX + getNumParam();
+          Seg.p[1] = lastY + getNumParam();
+          Seg.p[2] = lastX + getNumParam();
+          Seg.p[3] = lastY + getNumParam();
+          lastX = Seg.p[4] = lastX + getNumParam();
+          lastY = Seg.p[5] = lastY + getNumParam();
+          break;
+
+        case 'H':
+          // Horizontal line with absolute horizontal end point coordinate - convert to absolute line
+          Seg.type = Segment::Type::Line;
+          lastX = Seg.p[0] = getNumParam();
+          Seg.p[1] = lastY;  // stay;
+          break;
+
+        case 'h':
+          // Horizontal line with relative horizontal end-point coordinate - convert to absolute line
+          Seg.type = Segment::Type::Line;
+          lastX = Seg.p[0] = lastX + getNumParam();
+          Seg.p[1] = lastY;  // stay;
+          break;
+
+        case 'V':
+          // Vertical line with absolute vertical end point coordinate - convert to absolute line
+          Seg.type = Segment::Type::Line;
+          Seg.p[0] = lastX;  // stay;
+          lastY = Seg.p[1] = getNumParam();
+          break;
+
+        case 'v':
+          // Vertical line with relative horizontal end-point coordinate - convert to absolute line
+          Seg.type = Segment::Type::Line;
+          Seg.p[0] = lastX;  // stay;
+          lastY = Seg.p[1] = lastY + getNumParam();
+          break;
+
+        case 'A':
+          // Ellipsis arc with absolute end-point coordinates.
+          Seg.type = Segment::Type::Arc;
+          Seg.p[0] = getNumParam();  // rx
+          Seg.p[1] = getNumParam();  // ry
+          Seg.p[2] = getNumParam();  // rotation
+          f1 = getBoolParam();
+          f2 = getBoolParam();
+          Seg.p[3] = (f1 ? 0x01 : 0x00) + (f2 ? 0x02 : 0x00);  // flags
+          lastX = Seg.p[4] = getNumParam();
+          lastY = Seg.p[5] = getNumParam();
+          break;
+
+        case 'a':
+          // Ellipsis arc with relative end-point coordinates.
+          Seg.type = Segment::Type::Arc;
+          Seg.p[0] = getNumParam();  // rx
+          Seg.p[1] = getNumParam();  // ry
+          Seg.p[2] = getNumParam();  // rotation
+          f1 = getBoolParam();
+          f2 = getBoolParam();
+          Seg.p[3] = (f1 ? 0x01 : 0x00) + (f2 ? 0x02 : 0x00);  // flags
+          lastX = Seg.p[4] = lastX + getNumParam();
+          lastY = Seg.p[5] = lastY + getNumParam();
+          break;
+
+        case 'z':
+        case 'Z':
+          Seg.type = Segment::Type::Close;
+          break;
+
+          // non svg path types:
+        case 'O':
+          // Draw a whole circle by center and radius
+          Seg.type = Segment::Type::Circle;
+          Seg.p[0] = getNumParam();  // Center.x
+          Seg.p[1] = getNumParam();  // Center.y
+          Seg.p[2] = getNumParam();  // radius
+          lastX = lastY = 0;
+          break;
+      }
+      vSeg.push_back(Seg);
+      // } else { GFX_TRACE("unknown segment '%c'", *path);
+    }
+  }
+
+  // GFX_TRACE("  scanned: %d segments", vSeg.size());
+  // for (Segment &seg : vSeg) {
+  //   GFX_TRACE("  %04x - %d %d", seg.type, seg.p[0], seg.p[1]);
+  // }
+
+  return (vSeg);
+}
+
+// ===== Segment drawing functions =====
+
+// Draw a path (no fill).
+void drawSegments(std::vector<Segment> &segments, fSetPixel cbDraw) {
+  GFX_TRACE("drawSegments()");
+  int16_t startPosX = 0;
+  int16_t startPosY = 0;
+  int16_t posX = 0;
+  int16_t posY = 0;
+  int16_t endPosX = 0;
+  int16_t endPosY = 0;
+
+  if (segments.size()) {
+    for (Segment &pSeg : segments) {
+      switch (pSeg.type) {
+        case Segment::Type::Move:
+          startPosX = endPosX = pSeg.x1;
+          startPosY = endPosY = pSeg.y1;
+          break;
+
+        case Segment::Type::Line:
+          endPosX = pSeg.x1;
+          endPosY = pSeg.y1;
+          gfxDraw::drawLine(posX, posY, endPosX, endPosY, cbDraw);
+          break;
+
+        case Segment::Type::Curve:
+          endPosX = pSeg.p[4];
+          endPosY = pSeg.p[5];
+          gfxDraw::drawCubicBezier(
+            posX, posY,
+            pSeg.p[0], pSeg.p[1],
+            pSeg.p[2], pSeg.p[3],
+            endPosX, endPosY, cbDraw);
+          break;
+
+        case Segment::Type::Arc:
+          endPosX = pSeg.p[4];
+          endPosY = pSeg.p[5];
+          gfxDraw::drawArc(posX, posY,            // start-point
+                           endPosX, endPosY,      // end-point
+                           pSeg.p[0], pSeg.p[1],  // x & y radius
+                           pSeg.p[2],             // phi, ellipsis rotation
+                           pSeg.p[3],             // flags
+                           cbDraw);
+          break;
+
+        case Segment::Type::Circle:
+          if (1) {
+            Point pCenter(pSeg.p[0], pSeg.p[1]);
+            Point pStart(pSeg.p[0] + pSeg.p[2], pSeg.p[1]);
+
+            // drawCircle(gfxDraw::Point(30, 190), 20, gfxDraw::Point(30 + 20, 190), gfxDraw::Point(30 + 20, 190), true, bmpSet(gfxDraw::RED));
+            // The simplified drawCircleSegment cannot be used as for filling the circle the pixels must be in order.
+            gfxDraw::drawCircleSegment(pCenter, pSeg.p[2], pStart, pStart, ArcFlags::Clockwise | ArcFlags::LongPath, cbDraw);
+          }
+          break;
+
+        case Segment::Type::Close:
+          endPosX = startPosX;
+          endPosY = startPosY;
+          if ((posX != endPosX) || (posY != endPosY)) {
+            gfxDraw::drawLine(posX, posY, endPosX, endPosY, cbDraw);
+          }
+          cbDraw(0, POINT_BREAK_Y);
+          break;
+
+        default:
+          GFX_TRACE("unknown segment-%04x", pSeg.type);
+          break;
+      }
+
+      posX = endPosX;
+      posY = endPosY;
+    }  // for
+    cbDraw(0, POINT_BREAK_Y);
+  }
+}  // drawSegments()
+
+
+/// @brief Draw a path with filling.
+void fillSegments(std::vector<Segment> &segments, fSetPixel cbBorder, fSetPixel cbFill) {
+  GFX_TRACE("fillSegments()");
+  std::vector<_Edge> edges;
+  _Edge *lastEdge = nullptr;
+
+  size_t n;
+  fSetPixel cbStroke = cbBorder ? cbBorder : cbFill;  // use cbFill when no cbBorder is given.
+
+  // dumpSegments(segments);
+
+  // create the path and collect edges
+  drawSegments(segments,
+               [&](int16_t x, int16_t y) {
+                 //  GFX_TRACE("    P(%d/%d)", x, y);
+                 if ((lastEdge) && (lastEdge->expand(_Edge(x, y)))) {
+                   // fine
+                 } else {
+                   // first in sequence on on new line.
+                   edges.push_back(_Edge(x, y));
+                   lastEdge = &edges.back();
+                 }
+               });
+  // dumpEdges(edges);
+
+  // sub-paths are separated by (0/POINT_BREAK_Y) points;
+  size_t eSize = edges.size();
+
+  size_t eStart = 0;
+  n = eStart;
+  while (n < eSize) {
+    if (edges[n].y != POINT_BREAK_Y) {
+      // mark the end of the path or sub-path
+      n++;
+    } else {
+      if (eStart < n - 1) {
+
+        // Normalize (*2) sub-path for fill algorithm.
+        // GFX_TRACE("  sub-paths %d ... %d", eStart, n - 1);
+
+        if (edges[eStart].expand(edges[n - 1])) {
+          // last point is in first edge
+          edges.erase(edges.begin() + n - 1);
+          GFX_TRACE("  del %d", n - 1);
+          n--;
+        }
+        // dumpEdges(edges);
+
+        n = slopeEdges(edges, eStart, n - 1) + 1;
+        // dumpEdges(edges);
+
+        GFX_TRACE("  sub-paths %d ... %d", eStart, n - 1);
+
+      }  // if
+
+      n = eStart = n + 1;
+      eSize = edges.size();
+    }
+  }
+
+  // sort edges by ascending lines (y)
+  GFX_TRACE(" ... sort");
+  std::sort(edges.begin(), edges.end(), _Edge::compare);
+  // dumpEdges(edges);
+
+  GFX_TRACE(" ...a");
+
+  int16_t y = INT16_MAX;
+  int16_t x = INT16_MAX;
+
+  bool isInside = false;
+
+  // Draw borderpoints and lines on inner segments
+  for (_Edge &p : edges) {
+
+    // if (p.y == 38) {
+    //   GFX_TRACE("  P %d/%d-%d", p.x, p.y, p.len);
+    // };
+
+    if (p.y != y) {
+      // start a new line
+      isInside = false;
+      y = p.y;
+    }
+
+    if (y == POINT_BREAK_Y) continue;
+
+    if (p.len == 0) {
+      // don't draw, it is just an marker for a extreme sequence.
+
+    } else {
+      // draw the border
+      for (uint16_t l = 0; l < p.len; l++) {
+        cbStroke(p.x + l, y);
+      }
+    }
+
+    // draw the fill
+    if (isInside) {
+      while (x < p.x) {
+        cbFill(x++, y);
+      }
+    }
+    isInside = (!isInside);
+    // if (p.x + p.len > x)
+    x = p.x + p.len;
+  }
+}
+
+
+
+/// @brief draw a path using a border and optional fill drawing function.
+/// @param path The path definition using SVG path syntax.
+/// @param x Starting Point X coordinate.
+/// @param y Starting Point Y coordinate.
+/// @param scale scaling factor * 100.
+/// @param cbBorder Draw function for border pixels. cbFill is used when cbBorder is null.
+/// @param cbFill Draw function for filling pixels.
+void pathByText(const char *pathText, int16_t x, int16_t y, int16_t scale100, fSetPixel cbBorder, fSetPixel cbFill) {
+  std::vector<Segment> vSeg = parsePath(pathText);
+  if (scale100 != 100)
+    gfxDraw::scaleSegments(vSeg, scale100);
+
+  if ((x != 0) || (y != 0))
+    gfxDraw::moveSegments(vSeg, x, y);
+
+  if (cbFill) {
+    fillSegments(vSeg, cbBorder, cbFill);
+  } else {
+    drawSegments(vSeg, cbBorder);
+  }
+}
+
+
+
+// /// @brief draw the a path.
+// /// @param path The path definition using SVG path syntax.
+// /// @param cbDraw Draw function for border pixels. cbFill is used when cbBorder is null.
+// void drawPath(const char *pathText, fSetPixel cbDraw) {
+//   std::vector<Segment> vSeg = parsePath(pathText);
+//   drawSegments(vSeg, cbDraw);
+// }
+
+
+}  // gfxDraw:: namespace

--- a/lib/gfxDraw/src/gfxDrawPath.h
+++ b/lib/gfxDraw/src/gfxDrawPath.h
@@ -1,0 +1,147 @@
+// - - - - -
+// GFXDraw - A Arduino library for drawing shapes on a GFX display using paths describing the borders.
+// gfxdrawPath.h: Header file for functions to calculate all points of a path segment.
+//
+// Copyright (c) 2024-2024 by Matthias Hertel, http://www.mathertel.de
+// This work is licensed under a BSD style license. See http://www.mathertel.de/License.aspx
+//
+// These pixel oriented drawing functions are implemented to use callback functions for the effective drawing
+// to make them independent from an specific canvas or GFX implementation and can be used for drawing and un-drawing.
+//
+// Filled paths are supported on closed paths only.
+//
+// The functions have minimized use of float and arc arithmetics.
+//
+// Changelog:
+// * 27.11.2024 creation
+//
+// - - - - -
+
+#pragma once
+
+#include "gfxDraw.h"
+
+namespace gfxDraw {
+
+// All internal path processing and drawing is based on a vector of Segments `std::vector<Segment>`
+// that can be constructed by creating individual segments and adding them to the vector using
+//
+// * createMove(...);
+// * createLine(...);
+// * createArc(...);
+// * createClose(...);
+//
+// or by passing textual path definitions to
+//
+// * parsePath(...)
+
+
+/// @brief The Segment struct holds all information about a segment of a path.
+class Segment {
+public:
+  enum Type : uint16_t {
+    Move = 0x0100 + 2,
+    Line = 0x0200 + 2,
+    Curve = 0x0300 + 6,
+    Arc = 0x0400 + 7,
+    Circle = 0x0800 + 3,
+    Close = 0xFF00 + 0,
+  };
+
+  Segment() = default;
+  Segment(Type _type, int16_t x = 0, int16_t y = 0);
+
+  Type type;
+
+  union {
+    int16_t p[6];  // for parameter scanning
+
+    struct {  // x,y for Lines, and move
+      int16_t x1;
+      int16_t y1;
+    };
+
+    struct {  // for Arcs
+      int16_t rx;
+      int16_t ry;
+      int16_t rotation;
+      int16_t f1f2;
+      int16_t xEnd;
+      int16_t yEnd;
+    };
+  };
+
+  static Segment createMove(int16_t x, int16_t y);
+  static Segment createMove(Point p);
+
+  static Segment createLine(int16_t x, int16_t y);
+  static Segment createLine(Point p);
+
+  static Segment createClose();
+  static Segment createArc(int16_t radius, bool f1, bool f2, int16_t xEnd, int16_t yEnd);
+};
+
+// ===== create and manipulate segments
+
+/// @brief Scan a path using the svg/path/d syntax to create a vector(array) of Segments.
+/// @param pathText path definition as String
+/// @return Vector with Segments.
+/// @example pathText="M4 8l12-6l10 10h-8v4h-6z"
+std::vector<Segment> parsePath(const char *pathText);
+
+
+/// @brief Draw the border line of a path.
+// void kath(const char *pathText, fSetPixel cbDraw);
+
+/// @brief scale all points by factor / base.
+/// @param segments Segment vector to be changed
+/// @param factor scaling factor
+/// @param base scaling base, defaults to 100.
+void scaleSegments(std::vector<Segment> &segments, int16_t factor, int16_t base = 100);
+
+/// @brief rotate all points by the given angle.
+/// @param segments Segment vector to be changed
+/// @param angle angle 0...360
+void rotateSegments(std::vector<Segment> &segments, int16_t angle);
+
+/// @brief move all points by the given offset in x and y.
+/// @param segments Segment vector to be changed
+/// @param dx X-Offset
+/// @param dy Y-Offset
+void moveSegments(std::vector<Segment> &segments, int16_t dx, int16_t dy);
+
+/// @brief move all points by the given offset in x and y.
+/// @param segments Segment vector to be changed
+/// @param moveVector X- and Y- Offset as Point-Vector.
+void moveSegments(std::vector<Segment> &segments, Point moveVector);
+
+
+/// @brief Transform all points in the segments
+void transformSegments(std::vector<Segment> &segments, fTransform cbTransform);
+
+
+/// @brief Draw a path without filling.
+/// @param segments Vector of the segments of the path.
+/// @param cbDraw Callback with coordinates of line pixels.
+void drawSegments(std::vector<Segment> &segments, fSetPixel cbDraw);
+
+/// @brief Draw a path with filling.
+// void fillSegments(std::vector<Segment> &segments, int16_t dx, int16_t dy, fSetPixel cbBorder, fSetPixel cbFill = nullptr);
+void fillSegments(std::vector<Segment> &segments, fSetPixel cbBorder, fSetPixel cbFill = nullptr);
+
+
+/// @brief draw a path using a border and optional fill drawing function.
+/// @param path The path definition using SVG path syntax.
+/// @param x Starting Point X coordinate.
+/// @param y Starting Point Y coordinate.
+/// @param scale scaling factor * 100.
+/// @param cbBorder Draw function for border pixels. cbFill is used when cbBorder is null.
+/// @param cbFill Draw function for filling pixels.
+void pathByText(const char *pathText, int16_t x, int16_t y, int16_t scale100, fSetPixel cbBorder, fSetPixel cbFill);
+
+
+
+}  // gfxDraw:: namespace
+
+
+// End.

--- a/lib/trmnl/include/draw_scalable.h
+++ b/lib/trmnl/include/draw_scalable.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "GUI_Paint.h"
+
+void draw_scalable(const char *svgPath, int16_t pathX, int16_t pathY,
+                   int16_t pathWidth, uint16_t pathHeight, int16_t centerX,
+                   int16_t centerY, int16_t width, UWORD fillColor = BLACK, UWORD strokeColor = WHITE, float rotation = 0.0);
+
+void drawLogo(int16_t centerX, int16_t centerY, int16_t width, float rotation = 0.0);
+
+void drawTRMNL(int16_t centerX, int16_t centerY, int16_t width, float rotation = 0.0);
+
+void drawFullLogo(int16_t centerX, int16_t centerY, int16_t width, float rotation = 0.0);

--- a/lib/trmnl/src/draw_scalable.cpp
+++ b/lib/trmnl/src/draw_scalable.cpp
@@ -1,0 +1,59 @@
+#include <GUI_Paint.h>
+#include <gfxDrawPath.h>
+
+#include <string>
+
+void draw_scalable(const char *svgPath, int16_t pathX, int16_t pathY,
+                   int16_t pathWidth, uint16_t pathHeight, int16_t centerX,
+                   int16_t centerY, int16_t width,  UWORD fillColor, UWORD strokeColor, float rotation) {
+  const float scale = width / (float)pathWidth;
+  std::vector<gfxDraw::Segment> drawing = gfxDraw::parsePath(svgPath);
+  int16_t pathCenterX = pathX + (pathWidth / 2.0);
+  int16_t pathCenterY = pathY + (pathHeight / 2.0);
+  gfxDraw::moveSegments(drawing, -pathCenterX, -pathCenterY);
+  gfxDraw::scaleSegments(drawing, scale * 100);
+  gfxDraw::rotateSegments(drawing, rotation);
+  gfxDraw::moveSegments(drawing, centerX, centerY);
+  gfxDraw::fillSegments(
+      drawing, [&](int16_t x, int16_t y) { Paint_SetPixel(x, y, strokeColor); },
+      [&](int16_t x, int16_t y) { Paint_SetPixel(x, y, fillColor); });
+}
+
+// from official svg viewbbox 0 0 519 107
+const int16_t total_width = 519;
+const int16_t total_height = 107;
+const int16_t logo_width = 130;
+const char *logo =
+    "M3 45l8 13L37 42L29 30L3 45Z M17 88l14 2l4-30l-14-2l-4 30Z m42 17L70 94 "
+    "L49 73L38 83l21 22Z M98 82L97 67L67 70l1 15l30-3Z m7-45l-13-8L76 54l12 8 "
+    "l17-25Z M74 4L60 9l9 28l14-4L74 4Z M29 8L23 21L52 32l5-14L29 8Z";
+
+const int16_t trmnltext_width = 395;
+const char *trmnltext =
+    "M125 37V26h64V37H163V82H151V37H125Z "
+    "M202 26V82H214V62H247C249 62 251 63 252 64 C 253 65 253 66 253 "
+    "68V82H265V67C265 63 264 60 262 59 C 261 57 259 57 258 56 C 260 55 261 54 "
+    "263 52 C 265 50 266 46 266 43 C 266 37 264 33 260 30 C 257 27 251 26 244 "
+    "26H202Z M242 52H214V36H242C246 36 249 37 251 38 C 252 39 253 41 253 44 C "
+    "253 47 252 49 250 50 C 249 51 246 52 242 52Z "
+    "M281 82V26H298L322 68 347 26H364V82H351V41L328 82H317L293 41V82H281Z "
+    "M397 26H380V82H393V39L432 82H448V26H436V69L397 26Z "
+    "M477 26H465V82H517V71H477V26Z";
+
+void drawLogo(int16_t centerX, int16_t centerY, int16_t width, float rotation) {
+  draw_scalable(logo, 0, 0, logo_width, total_height, centerX, centerY,
+                        width, BLACK, BLACK, rotation);
+}
+
+void drawTRMNL(int16_t centerX, int16_t centerY, int16_t width, 
+               float rotation) {
+  draw_scalable(trmnltext, 125, 0, trmnltext_width, total_height, centerX,
+                centerY, width, BLACK, BLACK, rotation);
+}
+
+void drawFullLogo(int16_t centerX, int16_t centerY, int16_t width,
+                  float rotation) {
+  String trmnlfulllogo = String(logo) + String(trmnltext);
+  draw_scalable(trmnlfulllogo.c_str(), 0, 0, total_width, total_height, centerX,
+                centerY, width, BLACK, BLACK, rotation);
+}

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -3,7 +3,9 @@
 #include <display.h>
 #include <ArduinoLog.h>
 #include "DEV_Config.h"
-#include "EPD.h"
+#include "utility/Debug.h"
+#include "utility/EPD_7in5_V2.h"
+#include <draw_scalable.h>
 #include "GUI_Paint.h"
 #include <config.h>
 #include <ImageData.h>
@@ -288,8 +290,17 @@ void display_show_msg(uint8_t *image_buffer, MSG message_type, String friendly_i
 
     Log.info("%s [%d]: show image for array\r\n", __FILE__, __LINE__);
     Paint_SelectImage(BlackImage);
-    Paint_Clear(WHITE);
-    Paint_DrawBitMap(image_buffer + 62);
+
+#if defined(SVG_LOGO)
+  Paint_Clear(WHITE);
+   const char* heart = "M43 7 a1 1 0 00-36 36l36 36 36-36a1 1 0 00-36-36z";
+   draw_scalable(heart, 0, 0, 108, 82, 400, 150, 100, BLACK, BLACK, 0.0);
+  draw_scalable(heart, 0, 0, 108, 82, 400, 155, 90, WHITE, BLACK, 0.0);
+  drawFullLogo(400, 240, 384);
+#else
+  Paint_DrawBitMap(image_buffer + 62);
+#endif
+
     switch (message_type)
     {
     case FRIENDLY_ID:
@@ -342,5 +353,5 @@ void display_show_msg(uint8_t *image_buffer, MSG message_type, String friendly_i
 void display_sleep(void)
 {
     Log.info("%s [%d]: Goto Sleep...\r\n", __FILE__, __LINE__);
-    EPD_7IN5B_V2_Sleep();
+    EPD_7IN5_V2_Sleep();
 }


### PR DESCRIPTION
This contribution does not change in any way the current implementation.

It shows how we can leverage external librairies to add features in a simple way.

This one uses a subset of gfxDraw (https://github.com/mathertel/gfxDraw) to display SVG  syntax vectorial objects).

It uses Waveshare's GUI_Paint a a backend.

The code is triggered with
#include <draw_scalable.h>

this brings a generic function
```
void draw_scalable(const char *svgPath, int16_t pathX, int16_t pathY,
                   int16_t pathWidth, uint16_t pathHeight, int16_t centerX,
                   int16_t centerY, int16_t width, UWORD fillColor = BLACK, UWORD strokeColor = WHITE, float rotation = 0.0);
```
and 3 TRMNL logo ones.

Sample usage in display.cpp for message screen (for example when asking for Wifi credentials):

```
...
    Paint_SelectImage(BlackImage);

#if #defined(SVG_LOGO)
  Paint_Clear(WHITE);
   const char* heart = "M43 7 a1 1 0 00-36 36l36 36 36-36a1 1 0 00-36-36z";
   draw_scalable(heart, 0, 0, 108, 82, 400, 150, 100, BLACK, BLACK, 0.0);
  draw_scalable(heart, 0, 0, 108, 82, 400, 155, 90, WHITE, BLACK, 0.0);
  drawFullLogo(400, 240, 384);
#else
  Paint_DrawBitMap(image_buffer + 62);
#endif
```

![image](https://github.com/user-attachments/assets/17283a4c-f863-4303-9e8d-1d5d3731b9c4)
