### PR TITLE
HTTP Helper

### DIFF
--- a/include/api-client/display.h
+++ b/include/api-client/display.h
@@ -1,0 +1,14 @@
+#include <types.h>
+#include <api_types.h>
+#include <HTTPClient.h>
+
+struct ApiDisplayResult
+{
+  https_request_err_e error;
+  ApiDisplayResponse response;
+  String error_detail;
+};
+
+void addHeaders(HTTPClient &https, ApiDisplayInputs &apiDisplayInputs);
+
+ApiDisplayResult fetchApiDisplay(ApiDisplayInputs &apiDisplayInputs);

--- a/lib/trmnl/include/api_types.h
+++ b/lib/trmnl/include/api_types.h
@@ -30,6 +30,7 @@ enum class ApiDisplayOutcome
 struct ApiDisplayResponse
 {
   ApiDisplayOutcome outcome;
+  String error_detail;
   uint64_t status;
   String image_url;
   uint32_t image_url_timeout;

--- a/lib/trmnl/include/http_client.h
+++ b/lib/trmnl/include/http_client.h
@@ -1,0 +1,69 @@
+#ifndef HTTP_UTILS_H
+#define HTTP_UTILS_H
+
+#include <Arduino.h>
+#include <WiFiClientSecure.h>
+#include <HTTPClient.h>
+
+// Error codes for the HTTP utilities - using distinct values to avoid overlap
+enum HttpError
+{
+  HTTPCLIENT_SUCCESS = 100,
+  HTTPCLIENT_WIFICLIENT_ERROR = 101, // Failed to create client
+  HTTPCLIENT_HTTPCLIENT_ERROR = 102  // Failed to connect
+};
+
+/**
+ * @brief Higher-order function that sets up WiFiClient and HTTPClient, then runs a callback
+ * @param url The initial URL to connect to
+ * @param callback Function to call with the HTTPClient pointer and error code
+ * @return The value returned by the callback
+ */
+template <typename Callback, typename ReturnType = decltype(std::declval<Callback>()(nullptr, (HttpError)0))>
+ReturnType withHttp(const String &url, Callback callback)
+{
+  Log_info("==== withHttp() %s", url.c_str());
+
+  bool isHttps = (url.indexOf("https://") != -1);
+
+  // Conditionally allocate only the client we need
+  WiFiClient *client = nullptr;
+
+  if (isHttps)
+  {
+    WiFiClientSecure *secureClient = new WiFiClientSecure();
+    secureClient->setInsecure();
+    client = secureClient;
+  }
+  else
+  {
+    client = new WiFiClient();
+  }
+
+  // Check if client creation succeeded
+  if (!client)
+  {
+    ReturnType result = callback(nullptr, HTTPCLIENT_WIFICLIENT_ERROR);
+    return result;
+  }
+
+  ReturnType result;
+  { // Add a scoping block for HTTPClient https to make sure it is destroyed before WiFiClientSecure *client is
+
+    HTTPClient https;
+    if (https.begin(*client, url))
+    {
+      result = callback(&https, HTTPCLIENT_SUCCESS);
+      https.end();
+    }
+    else
+    {
+      ReturnType result = callback(nullptr, HTTPCLIENT_HTTPCLIENT_ERROR);
+    }
+  }
+  delete client;
+
+  return result;
+}
+
+#endif // HTTP_UTILS_H

--- a/lib/trmnl/src/parse_response_api_display.cpp
+++ b/lib/trmnl/src/parse_response_api_display.cpp
@@ -12,11 +12,15 @@ ApiDisplayResponse parseResponse_apiDisplay(String &payload)
   if (error)
   {
     Log_error("JSON deserialization error.");
-    return {.outcome = ApiDisplayOutcome::DeserializationError};
+    return ApiDisplayResponse{
+        .outcome = ApiDisplayOutcome::DeserializationError,
+        .error_detail = error.c_str()};
   }
   String special_function_str = doc["special_function"];
 
   return ApiDisplayResponse{
+      .outcome = ApiDisplayOutcome::Ok,
+      .error_detail = "",
       .status = doc["status"],
       .image_url = doc["image_url"] | "",
       .image_url_timeout = doc["image_url_timeout"],
@@ -27,5 +31,5 @@ ApiDisplayResponse parseResponse_apiDisplay(String &payload)
       .reset_firmware = doc["reset_firmware"],
       .special_function = parseSpecialFunction(special_function_str),
       .action = doc["action"] | "",
-      };
+  };
 }

--- a/src/api-client/display.cpp
+++ b/src/api-client/display.cpp
@@ -1,0 +1,53 @@
+#include <api-client/display.h>
+#include <ArduinoLog.h>
+#include <HTTPClient.h>
+#include <trmnl_log.h>
+#include <WiFiClientSecure.h>
+#include <config.h>
+#include <api_response_parsing.h>
+#include <http_client.h>
+
+void addHeaders(HTTPClient &https, ApiDisplayInputs &inputs)
+{
+  Log_info("Added headers:\n\r"
+           "ID: %s\n\r"
+           "Special function: %d\n\r"
+           "Access-Token: %s\n\r"
+           "Refresh_Rate: %s\n\r"
+           "Battery-Voltage: %s\n\r"
+           "FW-Version: %s\r\n"
+           "RSSI: %s\r\n",
+           __FILE__, __LINE__,
+           inputs.macAddress.c_str(),
+           inputs.specialFunction,
+           inputs.apiKey.c_str(),
+           String(inputs.refreshRate).c_str(),
+           String(inputs.batteryVoltage).c_str(),
+           inputs.firmwareVersion.c_str(),
+           String(inputs.rssi));
+
+  https.addHeader("ID", inputs.macAddress);
+  https.addHeader("Access-Token", inputs.apiKey);
+  https.addHeader("Refresh-Rate", String(inputs.refreshRate));
+  https.addHeader("Battery-Voltage", String(inputs.batteryVoltage));
+  https.addHeader("FW-Version", inputs.firmwareVersion);
+  https.addHeader("RSSI", String(inputs.rssi));
+  https.addHeader("Width", String(inputs.displayWidth));
+  https.addHeader("Height", String(inputs.displayHeight));
+
+  if (inputs.specialFunction != SF_NONE)
+  {
+    Log.info("%s [%d]: Add special function: true (%d)\r\n", __FILE__, __LINE__, inputs.specialFunction);
+    https.addHeader("special_function", "true");
+  }
+}
+
+ApiDisplayResult fetchApiDisplay(ApiDisplayInputs &apiDisplayInputs)
+{
+  ApiDisplayResponse response = {};
+  return ApiDisplayResult{
+      .error = https_request_err_e::HTTPS_NO_ERR,
+      .response = response,
+      .error_detail = "",
+  };
+};

--- a/src/api-client/submit_log.cpp
+++ b/src/api-client/submit_log.cpp
@@ -1,67 +1,52 @@
 #include "api-client/submit_log.h"
 #include <stdio.h>
 #include "trmnl_log.h"
-#include <WiFiClientSecure.h>
-#include <HTTPClient.h>
 #include <memory>
+#include "http_client.h"
 
 bool submitLogToApi(LogApiInput &input, const char *api_url)
 {
   String payload = "{\"log\":{\"logs_array\":[" + String(input.log_buffer) + "]}}";
-
-  bool isHttps = String(api_url).indexOf("https://") == 0;
-
-  // because of the lack of virtual destructor in the derived class WiFiClientSecure we have to do some trickery...
-  std::unique_ptr<WiFiClientSecure> secureClient(new WiFiClientSecure());
-  std::unique_ptr<WiFiClient> baseClient(new WiFiClient());
-
-  secureClient->setInsecure();
-  WiFiClient *client;
-  
-  if (isHttps)
-    client = dynamic_cast<WiFiClient *>(secureClient.get());
-  else
-    client = dynamic_cast<WiFiClient *>(baseClient.get());;
-  
-  HTTPClient https;
   Log_info("[HTTPS] begin /api/log ...");
 
   char new_url[200];
   strcpy(new_url, api_url);
   strcat(new_url, "/api/log");
 
-  if (!https.begin(*client, new_url))
-  {
-    Log_error("[HTTPS] Unable to connect");
-    return false;
-  }
+  return withHttp(new_url, [&](HTTPClient *httpsPointer, HttpError errorCode) -> bool
+                  {
+                    if (errorCode != HttpError::HTTPCLIENT_SUCCESS || !httpsPointer)
+                    {
+                      Log_error("[HTTPS] Unable to connect");
+                      return false;
+                    }
 
-  Log_info("[HTTPS] POST...");
+                    Log_info("[HTTPS] POST...");
 
-        https.addHeader("ID", WiFi.macAddress());
-        https.addHeader("Accept", "application/json");
-        https.addHeader("Access-Token", input.api_key);
-        https.addHeader("Content-Type", "application/json");
-        Log_info("Send log - %s", payload.c_str());
-        // start connection and send HTTP header
-        int httpCode = https.POST(payload);
+                    HTTPClient &https = *httpsPointer;
 
-  // httpCode will be negative on error
-  if (httpCode < 0)
-  {
-    Log_error("[HTTPS] POST... failed, error: %d %s", httpCode, https.errorToString(httpCode).c_str());
-    return false;
-  }
-  else if (httpCode != HTTP_CODE_OK && httpCode != HTTP_CODE_MOVED_PERMANENTLY && httpCode != HTTP_CODE_NO_CONTENT)
-  {
-    Log_error("[HTTPS] POST... failed, returned HTTP code unknown: %d %s", httpCode, https.errorToString(httpCode).c_str());
-    return false;
-  }
-  
-  // HTTP header has been send and Server response header has been handled
-  Log_info("[HTTPS] POST OK, code: %d", httpCode);
+                    https.addHeader("ID", WiFi.macAddress());
+                    https.addHeader("Accept", "application/json");
+                    https.addHeader("Access-Token", input.api_key);
+                    https.addHeader("Content-Type", "application/json");
+                    Log_info("Send log - %s", payload.c_str());
+                    // start connection and send HTTP header
+                    int httpCode = https.POST(payload);
 
-  https.end();
+                    // httpCode will be negative on error
+                    if (httpCode < 0)
+                    {
+                      Log_error("[HTTPS] POST... failed, error: %d %s", httpCode, https.errorToString(httpCode).c_str());
+                      return false;
+                    }
+                    else if (httpCode != HTTP_CODE_OK && httpCode != HTTP_CODE_MOVED_PERMANENTLY && httpCode != HTTP_CODE_NO_CONTENT)
+                    {
+                      Log_error("[HTTPS] POST... failed, returned HTTP code unknown: %d %s", httpCode, https.errorToString(httpCode).c_str());
+                      return false;
+                    }
 
-  return true;
+                    // HTTP header has been send and Server response header has been handled
+                    Log_info("[HTTPS] POST OK, code: %d", httpCode);
+
+                    return true; });
 }

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -27,6 +27,8 @@
 #include <api_response_parsing.h>
 #include "logging_parcers.h"
 #include <SPIFFS.h>
+#include "http_client.h"
+#include <api-client/display.h>
 
 bool pref_clear = false;
 String new_filename = "";
@@ -533,41 +535,6 @@ ApiDisplayInputs loadApiDisplayInputs(Preferences &preferences)
   inputs.specialFunction = special_function;
 
   return inputs;
-}
-
-void addHeaders(HTTPClient &https, ApiDisplayInputs &inputs)
-{
-  Log.info("%s [%d]: Added headers:\n\r"
-           "ID: %s\n\r"
-           "Special function: %d\n\r"
-           "Access-Token: %s\n\r"
-           "Refresh_Rate: %s\n\r"
-           "Battery-Voltage: %s\n\r"
-           "FW-Version: %s\r\n"
-           "RSSI: %s\r\n",
-           __FILE__, __LINE__,
-           inputs.macAddress.c_str(),
-           inputs.specialFunction,
-           inputs.apiKey.c_str(),
-           String(inputs.refreshRate).c_str(),
-           String(inputs.batteryVoltage).c_str(),
-           inputs.firmwareVersion.c_str(),
-           String(inputs.rssi));
-
-  https.addHeader("ID", WiFi.macAddress());
-  https.addHeader("Access-Token", inputs.apiKey);
-  https.addHeader("Refresh-Rate", String(inputs.refreshRate));
-  https.addHeader("Battery-Voltage", String(inputs.batteryVoltage));
-  https.addHeader("FW-Version", inputs.firmwareVersion);
-  https.addHeader("RSSI", String(inputs.rssi));
-  https.addHeader("Width", String(inputs.displayWidth));
-  https.addHeader("Height", String(inputs.displayHeight));
-
-  if (special_function != SF_NONE)
-  {
-    Log.info("%s [%d]: Add special function: true (%d)\r\n", __FILE__, __LINE__, special_function);
-    https.addHeader("special_function", "true");
-  }
 }
 
 /**


### PR DESCRIPTION
This PR adds a new helper to wrangle some of the common logic around the connection lifecycle. It works like this:
```cpp
return withHttp(binUrl, [&](HTTPClient *https, HttpError errorCode) -> bool {

  if(errorCode == HttpError::HTTPCLIENT_WIFICLIENT_ERROR){
    // ...
    return false;
  }

  auto httpCode = https->GET();

  // ...

  return true;
});
```

For now I used it in three places:
 - submitLogToApi() (`/api/log`)
 - checkAndPerformFirmwareUpdate()
 - downloadAndShow (just `/api/display` for now, not the image download)

I've tested this on-device, and seen all three of those operations working.

I thought I'd stop there for now. If we like this approach, I'll follow up later with the other HTTP operations (`/api/setup/` in getDeviceCredentials(), streaming image downloads, etc.)

