### PR TITLE
Fix autoConnect to Use Last Used WiFi Index Correctly

### DIFF
--- a/lib/wificaptive/src/WifiCaptive.cpp
+++ b/lib/wificaptive/src/WifiCaptive.cpp
@@ -628,7 +628,7 @@ bool WifiCaptive::autoConnect()
                 // success! save the index of the last used network
                 for (int i = 0; i < WIFI_MAX_SAVED_CREDS; i++)
                 {
-                    if (_savedWifis[i].ssid == network.ssid  && _savedWifis[i].pswd == network.pswd)
+                    if (_savedWifis[i].ssid == network.ssid)
                     {
                         saveLastUsedWifiIndex(i);
                         break;

--- a/lib/wificaptive/src/WifiCaptive.cpp
+++ b/lib/wificaptive/src/WifiCaptive.cpp
@@ -628,8 +628,7 @@ bool WifiCaptive::autoConnect()
                 // success! save the index of the last used network
                 for (int i = 0; i < WIFI_MAX_SAVED_CREDS; i++)
                 {
-                    // Should this also check if the pswd is the same? What if 2 WiFi's have duplicate SSIDs?
-                    if (_savedWifis[i].ssid == network.ssid  && _savedWifis[i].ssid == network.pswd)
+                    if (_savedWifis[i].ssid == network.ssid  && _savedWifis[i].pswd == network.pswd)
                     {
                         saveLastUsedWifiIndex(i);
                         break;

--- a/lib/wificaptive/src/WifiCaptive.cpp
+++ b/lib/wificaptive/src/WifiCaptive.cpp
@@ -73,7 +73,7 @@ void WifiCaptive::setUpWebserver(AsyncWebServer &server, const IPAddress &localI
 			return request->send(202);
 		} else {
 			// Data structure to store the highest RSSI for each SSID
-            // Warning: DO NOT USE true on this function in an async context! 
+            // Warning: DO NOT USE true on this function in an async context!
 			std::vector<Network> uniqueNetworks = getScannedUniqueNetworks(false);
             std::vector<Network> combinedNetworks = combineNetworks(uniqueNetworks, _savedWifis);
 
@@ -609,7 +609,7 @@ bool WifiCaptive::autoConnect()
     WiFi.mode(WIFI_STA);
     for (auto &network : sortedNetworks)
     {
-        if (network.ssid == "" || (network.ssid == _savedWifis[0].ssid && network.pswd == _savedWifis[0].pswd))
+        if (network.ssid == "" || (network.ssid == _savedWifis[last_used_index].ssid && network.pswd == _savedWifis[last_used_index].pswd))
         {
             continue;
         }
@@ -628,7 +628,8 @@ bool WifiCaptive::autoConnect()
                 // success! save the index of the last used network
                 for (int i = 0; i < WIFI_MAX_SAVED_CREDS; i++)
                 {
-                    if (_savedWifis[i].ssid == network.ssid)
+                    // Should this also check if the pswd is the same? What if 2 WiFi's have duplicate SSIDs?
+                    if (_savedWifis[i].ssid == network.ssid  && _savedWifis[i].ssid == network.pswd)
                     {
                         saveLastUsedWifiIndex(i);
                         break;


### PR DESCRIPTION
When the last used WiFi network failed to connect, the loop over saved networks incorrectly skipped the most recently added network (index 0) instead of the last used network (stored in last_used_index)