### PR TITLE
Add support for Waveshare E-Paper ESP32 Driver Board

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -49,8 +49,8 @@ enum WIFI_CONNECT_RETRY_TIME // Time to sleep before trying to connect to the Wi
     WIFI_THIRD_RETRY = 300
 };
 
-#define PIN_RESET 9
-#define PIN_INTERRUPT 2
+#define PIN_RESET 25
+#define PIN_INTERRUPT 16
 #define PIN_BATTERY 3
 
 #define BUTTON_HOLD_TIME 5000

--- a/include/config.h
+++ b/include/config.h
@@ -49,8 +49,15 @@ enum WIFI_CONNECT_RETRY_TIME // Time to sleep before trying to connect to the Wi
     WIFI_THIRD_RETRY = 300
 };
 
+#if defined(BOARD_TRMNL)
+#define PIN_RESET 9
+#define PIN_INTERRUPT 2
+#elif defined(BOARD_WAVESHARE_ESP32_DRIVER)
 #define PIN_RESET 25
 #define PIN_INTERRUPT 16
+#define FAKE_BATTERY_VOLTAGE
+#endif
+
 #define PIN_BATTERY 3
 
 // #define FAKE_BATTERY_VOLTAGE // Uncomment to report 4.2V instead of reading ADC

--- a/include/config.h
+++ b/include/config.h
@@ -53,6 +53,8 @@ enum WIFI_CONNECT_RETRY_TIME // Time to sleep before trying to connect to the Wi
 #define PIN_INTERRUPT 16
 #define PIN_BATTERY 3
 
+// #define FAKE_BATTERY_VOLTAGE // Uncomment to report 4.2V instead of reading ADC
+
 #define BUTTON_HOLD_TIME 5000
 
 #define SERVER_MAX_RETRIES 3

--- a/lib/esp32-waveshare-epd/src/DEV_Config.cpp
+++ b/lib/esp32-waveshare-epd/src/DEV_Config.cpp
@@ -30,7 +30,7 @@
 #include "DEV_Config.h"
 #include "SPI.h"
 
-static SPIClass * display_spi = new SPIClass(FSPI);
+static SPIClass * display_spi = new SPIClass(HSPI); // Use HSPI peripheral
 
 void GPIO_Config(void)
 {    

--- a/lib/esp32-waveshare-epd/src/DEV_Config.cpp
+++ b/lib/esp32-waveshare-epd/src/DEV_Config.cpp
@@ -30,7 +30,14 @@
 #include "DEV_Config.h"
 #include "SPI.h"
 
-static SPIClass * display_spi = new SPIClass(HSPI); // Use HSPI peripheral
+#if CONFIG_IDF_TARGET_ESP32
+  static SPIClass * display_spi = new SPIClass(HSPI);
+#elif CONFIG_IDF_TARGET_ESP32C3
+  static SPIClass * display_spi = new SPIClass(FSPI);
+#else
+  #error "Unsupported ESP32 target"
+#endif
+
 
 void GPIO_Config(void)
 {    

--- a/lib/esp32-waveshare-epd/src/DEV_Config.h
+++ b/lib/esp32-waveshare-epd/src/DEV_Config.h
@@ -44,12 +44,27 @@
 /**
  * GPIO config
 **/
-#define EPD_SCK_PIN  13 // SCLK -> P13
-#define EPD_MOSI_PIN 14 // DIN -> P14
-#define EPD_CS_PIN   15 // CS -> P15
-#define EPD_RST_PIN  26 // RST -> P26
-#define EPD_DC_PIN   27 // DC -> P27
-#define EPD_BUSY_PIN 25 // BUSY -> P25
+#if defined(BOARD_TRMNL)
+   // Pin definition for TRMNL Board
+   #define EPD_SCK_PIN  7
+   #define EPD_MOSI_PIN 8
+   #define EPD_CS_PIN   6
+   #define EPD_RST_PIN  10
+   #define EPD_DC_PIN   5
+   #define EPD_BUSY_PIN 4
+
+#elif defined(BOARD_WAVESHARE_ESP32_DRIVER)
+   // Pin definition for Waveshare ESP32 Driver Board
+   #define EPD_SCK_PIN  13
+   #define EPD_MOSI_PIN 14
+   #define EPD_CS_PIN   15
+   #define EPD_RST_PIN  26
+   #define EPD_DC_PIN   27
+   #define EPD_BUSY_PIN 25
+
+#else
+   #error "Board type not defined. Please define BOARD_WAVESHARE_ESP32_DRIVER or BOARD_TRMNL in platformio.ini build_flags."
+#endif
 
 #define GPIO_PIN_SET   1
 #define GPIO_PIN_RESET 0

--- a/lib/esp32-waveshare-epd/src/DEV_Config.h
+++ b/lib/esp32-waveshare-epd/src/DEV_Config.h
@@ -44,12 +44,12 @@
 /**
  * GPIO config
 **/
-#define EPD_SCK_PIN  7
-#define EPD_MOSI_PIN 8
-#define EPD_CS_PIN   6
-#define EPD_RST_PIN  10
-#define EPD_DC_PIN   5
-#define EPD_BUSY_PIN 4
+#define EPD_SCK_PIN  13 // SCLK -> P13
+#define EPD_MOSI_PIN 14 // DIN -> P14
+#define EPD_CS_PIN   15 // CS -> P15
+#define EPD_RST_PIN  26 // RST -> P26
+#define EPD_DC_PIN   27 // DC -> P27
+#define EPD_BUSY_PIN 25 // BUSY -> P25
 
 #define GPIO_PIN_SET   1
 #define GPIO_PIN_RESET 0

--- a/platformio.ini
+++ b/platformio.ini
@@ -13,6 +13,7 @@ default_envs = esp32dev
 
 [env:esp32_base]
 framework = arduino
+platform = espressif32@6.10.0
 board_build.partitions = min_spiffs.csv
 board_build.filesystem = spiffs
 upload_speed = 460800
@@ -34,7 +35,6 @@ monitor_speed = 115200
 
 [env:esp32-c3-devkitc-02]
 extends = env:esp32_base
-platform = espressif32@6.10.0
 board = esp32-c3-devkitc-02
 board_build.f_cpu = 80000000L
 board_build.f_flash = 40000000L
@@ -47,17 +47,28 @@ debug_tool = esp-builtin
 
 [env:esp32dev]
 extends = env:esp32_base
-platform = espressif32@6.10.0
 board = esp32dev
 board_build.f_cpu = 240000000L
 board_build.f_flash = 80000000L ; Assuming 80MHz flash freq for generic ESP32, adjust if needed
 board_build.flash_mode = dio    ; Common flash mode for ESP32dev
 
+[env:waveshare-esp32-driver]
+extends = env:esp32dev
+build_flags =
+	${env:esp32_base.build_flags}
+	-D BOARD_WAVESHARE_ESP32_DRIVER
+
+[env:trmnl]
+extends = env:esp32-c3-devkitc-02
+build_flags =
+	${env:esp32_base.build_flags}
+	-D BOARD_TRMNL
+
 [env:local]
 extends = env:esp32_base
 platform = espressif32@6.10.0 # Specify platform for local env
 board = esp32-c3-devkitc-02 # Specify board for local env (assuming C3 for local debugging)
-build_flags = 
+build_flags =
 	-D ARDUINO_USB_MODE=1
 	-D ARDUINO_USB_CDC_ON_BOOT=1
 	-D CORE_DEBUG_LEVEL=0
@@ -69,10 +80,10 @@ build_flags =
 [env:native]
 platform = native
 test_framework = unity
-lib_deps = 
+lib_deps =
 	bblanchon/ArduinoJson@7.2.1
 	fabiobatsilva/ArduinoFake@^0.4.0
-build_flags = 
+build_flags =
 	-D ARDUINOJSON_ENABLE_ARDUINO_STRING=1
 	-std=gnu++11
 	# avoids errors about WProgram.h from ArduinoLog:

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,44 +9,10 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [platformio]
-default_envs = esp32-c3-devkitc-02
+default_envs = esp32dev
 
-[env:esp32-c3-devkitc-02]
-platform = espressif32@6.10.0
-board = esp32-c3-devkitc-02
+[env:esp32_base]
 framework = arduino
-board_build.f_cpu = 80000000L
-board_build.f_flash = 40000000L
-board_build.flash_mode = qio
-board_build.partitions = min_spiffs.csv
-board_build.filesystem = spiffs
-upload_speed = 460800
-build_flags = 
-	-D ARDUINO_USB_MODE=0
-	-D ARDUINO_USB_CDC_ON_BOOT=0
-	-D CORE_DEBUG_LEVEL=0
-lib_ldf_mode = deep
-lib_deps = 
-	ESP32Async/ESPAsyncWebServer@3.7.1
-	bblanchon/ArduinoJson@7.2.1
-	https://github.com/thijse/Arduino-Log.git#3f4fcf5a345c1d542e56b88c0ffcb2bd2a5b0bd0
-	https://github.com/bitbank2/PNGdec.git#53eea10f6a04bceadec3f57b1c3a9cd5c3cb40d7
-debug_tool = esp-builtin
-debug_init_break = break setupy
-build_type = debug
-check_tool = clangtidy
-check_flags = 
-	clangtidy: --checks=bugprone-*,portability-*,clang-analyzer-*,google-*,-google-readability-*
-monitor_filters = esp32_exception_decoder
-monitor_speed = 115200
-
-[env:esp32dev]
-platform = espressif32@6.9.0
-board = esp32dev
-framework = arduino
-board_build.f_cpu = 240000000L
-board_build.f_flash = 40000000L
-board_build.flash_mode = qio
 board_build.partitions = min_spiffs.csv
 board_build.filesystem = spiffs
 upload_speed = 460800
@@ -57,7 +23,7 @@ lib_deps =
 	ESP32Async/ESPAsyncWebServer@3.7.1
 	bblanchon/ArduinoJson@7.2.1
 	https://github.com/thijse/Arduino-Log.git#3f4fcf5a345c1d542e56b88c0ffcb2bd2a5b0bd0
-	bitbank2/PNGdec@^1.1.0
+	https://github.com/bitbank2/PNGdec.git#53eea10f6a04bceadec3f57b1c3a9cd5c3cb40d7
 debug_init_break = break setupy
 build_type = debug
 check_tool = clangtidy
@@ -66,20 +32,39 @@ check_flags =
 monitor_filters = esp32_exception_decoder
 monitor_speed = 115200
 
+[env:esp32-c3-devkitc-02]
+extends = env:esp32_base
+platform = espressif32@6.10.0
+board = esp32-c3-devkitc-02
+board_build.f_cpu = 80000000L
+board_build.f_flash = 40000000L
+board_build.flash_mode = qio
+build_flags =
+	${env:esp32_base.build_flags} ; Inherit base flags
+	-D ARDUINO_USB_MODE=0
+	-D ARDUINO_USB_CDC_ON_BOOT=0
+debug_tool = esp-builtin
+
+[env:esp32dev]
+extends = env:esp32_base
+platform = espressif32@6.10.0
+board = esp32dev
+board_build.f_cpu = 240000000L
+board_build.f_flash = 80000000L ; Assuming 80MHz flash freq for generic ESP32, adjust if needed
+board_build.flash_mode = dio    ; Common flash mode for ESP32dev
+
 [env:local]
-extends = env:esp32-c3-devkitc-02
+extends = env:esp32_base
+platform = espressif32@6.10.0 # Specify platform for local env
+board = esp32-c3-devkitc-02 # Specify board for local env (assuming C3 for local debugging)
 build_flags = 
 	-D ARDUINO_USB_MODE=1
 	-D ARDUINO_USB_CDC_ON_BOOT=1
 	-D CORE_DEBUG_LEVEL=0
 	-D WAIT_FOR_SERIAL=1
 	-D ARDUINOJSON_ENABLE_ARDUINO_STRING=1
-lib_deps = 
-	ESP32Async/ESPAsyncWebServer@3.7.1
-	bblanchon/ArduinoJson@7.2.1
-	https://github.com/thijse/Arduino-Log.git#3f4fcf5a345c1d542e56b88c0ffcb2bd2a5b0bd0
-	https://github.com/bitbank2/PNGdec.git#53eea10f6a04bceadec3f57b1c3a9cd5c3cb40d7
-monitor_filters = esp32_exception_decoder
+# lib_deps are inherited from esp32_base
+# monitor_filters are inherited from esp32_base
 
 [env:native]
 platform = native

--- a/platformio.ini
+++ b/platformio.ini
@@ -40,6 +40,32 @@ check_flags =
 monitor_filters = esp32_exception_decoder
 monitor_speed = 115200
 
+[env:esp32dev]
+platform = espressif32@6.9.0
+board = esp32dev
+framework = arduino
+board_build.f_cpu = 240000000L
+board_build.f_flash = 40000000L
+board_build.flash_mode = qio
+board_build.partitions = min_spiffs.csv
+board_build.filesystem = spiffs
+upload_speed = 460800
+build_flags =
+	-D CORE_DEBUG_LEVEL=0
+lib_ldf_mode = deep
+lib_deps =
+	ESP32Async/ESPAsyncWebServer@3.7.1
+	bblanchon/ArduinoJson@7.2.1
+	https://github.com/thijse/Arduino-Log.git#3f4fcf5a345c1d542e56b88c0ffcb2bd2a5b0bd0
+	bitbank2/PNGdec@^1.1.0
+debug_init_break = break setupy
+build_type = debug
+check_tool = clangtidy
+check_flags =
+	clangtidy: --checks=bugprone-*,portability-*,clang-analyzer-*,google-*,-google-readability-*
+monitor_filters = esp32_exception_decoder
+monitor_speed = 115200
+
 [env:local]
 extends = env:esp32-c3-devkitc-02
 build_flags = 

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [platformio]
-default_envs = esp32dev
+default_envs = trmnl
 
 [env:esp32_base]
 framework = arduino

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -1726,8 +1726,14 @@ static void goToSleep(void)
   preferences.end();
   esp_sleep_enable_timer_wakeup((uint64_t)time_to_sleep * SLEEP_uS_TO_S_FACTOR);
   // Configure GPIO pin for wakeup
+#if CONFIG_IDF_TARGET_ESP32
   gpio_wakeup_enable((gpio_num_t)PIN_INTERRUPT, GPIO_INTR_LOW_LEVEL);
   esp_sleep_enable_gpio_wakeup();
+#elif CONFIG_IDF_TARGET_ESP32C3
+  esp_deep_sleep_enable_gpio_wakeup(1 << PIN_INTERRUPT, ESP_GPIO_WAKEUP_GPIO_LOW);
+#else
+  #error "Unsupported ESP32 target for GPIO wakeup configuration"
+#endif
   esp_deep_sleep_start();
 }
 
@@ -1769,6 +1775,10 @@ static bool setClock()
  */
 static float readBatteryVoltage(void)
 {
+#ifdef FAKE_BATTERY_VOLTAGE
+  Log.warning("%s [%d]: FAKE_BATTERY_VOLTAGE is defined. Returning 4.2V.\r\n", __FILE__, __LINE__);
+  return 4.2f;
+#else
   Log.info("%s [%d]: Battery voltage reading...\r\n", __FILE__, __LINE__);
   int32_t adc = 0;
   for (uint8_t i = 0; i < 128; i++)
@@ -1780,6 +1790,7 @@ static float readBatteryVoltage(void)
 
   float voltage = sensorValue / 1000.0;
   return voltage;
+#endif // FAKE_BATTERY_VOLTAGE
 }
 
 /**

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -29,6 +29,7 @@
 #include <SPIFFS.h>
 #include "http_client.h"
 #include <api-client/display.h>
+#include "driver/gpio.h"
 
 bool pref_clear = false;
 String new_filename = "";
@@ -1724,8 +1725,9 @@ static void goToSleep(void)
   preferences.putUInt(PREFERENCES_LAST_SLEEP_TIME, getTime());
   preferences.end();
   esp_sleep_enable_timer_wakeup((uint64_t)time_to_sleep * SLEEP_uS_TO_S_FACTOR);
-  esp_deep_sleep_enable_gpio_wakeup(1 << PIN_INTERRUPT,
-                                    ESP_GPIO_WAKEUP_GPIO_LOW);
+  // Configure GPIO pin for wakeup
+  gpio_wakeup_enable((gpio_num_t)PIN_INTERRUPT, GPIO_INTR_LOW_LEVEL);
+  esp_sleep_enable_gpio_wakeup();
   esp_deep_sleep_start();
 }
 


### PR DESCRIPTION
I've added support to the official driver for the [Waveshare ESP32 driver board](https://www.waveshare.com/wiki/E-Paper_ESP32_Driver_Board), which makes it really easy to create a TRMNL with just hooking up an e-ink display to this driver board.

The changes required are minimal, as you can see, and I can add some #ifdefs for them. There should be one based on the environment (some of the changes are ESP32-specific), but there are things like faking the battery voltage for builds that don't use a battery.

Are there any specific defines you guys would like to see, or any opinions you have on this?