### PR TITLE
Update PNGdec to 1.1.2 release.

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -24,7 +24,7 @@ lib_deps =
 	ESP32Async/ESPAsyncWebServer@3.7.1
 	bblanchon/ArduinoJson@7.2.1
 	https://github.com/thijse/Arduino-Log.git#3f4fcf5a345c1d542e56b88c0ffcb2bd2a5b0bd0
-	https://github.com/bitbank2/PNGdec.git#53eea10f6a04bceadec3f57b1c3a9cd5c3cb40d7
+	bitbank2/PNGdec@1.1.2
 debug_init_break = break setupy
 build_type = debug
 check_tool = clangtidy


### PR DESCRIPTION
The 1.1.2 contains proper fix for png structure decoding & protection against header corruptions.