### PR TITLE
Fix handling downloadAndShow HTTPS_NO_ERR result

### DIFF
--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -328,7 +328,7 @@ void bl_init(void)
     preferences.putInt(PREFERENCES_CONNECT_API_RETRY_COUNT, 1);
   }
 
-  if (request_result != HTTPS_SUCCESS && request_result != HTTPS_NO_REGISTER && request_result != HTTPS_RESET && request_result != HTTPS_PLUGIN_NOT_ATTACHED)
+  if (request_result != HTTPS_SUCCESS && request_result != HTTPS_NO_ERR && request_result != HTTPS_NO_REGISTER && request_result != HTTPS_RESET && request_result != HTTPS_PLUGIN_NOT_ATTACHED)
   {
     uint8_t retries = preferences.getInt(PREFERENCES_CONNECT_API_RETRY_COUNT);
 


### PR DESCRIPTION
If the image is not changed, it is not a problem so we shouldn't enter retry mode.

Otherwise, that's how it works, which doesn't make sense:
```
16:08:36:062 -> I: src/bl.cpp [1124]: Old image. No needed to show it.
16:08:36:064 -> I: src/bl.cpp [1130]: update_firmware: 0
16:08:36:065 -> I: src/bl.cpp [1133]: firmware_url: https://trmnl-fw.s3.us-east-2.amazonaws.com/FW1.5.2.bin
16:08:36:065 -> I: src/bl.cpp [1136]: refresh_rate: 299
16:08:36:066 -> I: src/bl.cpp [1139]: write new refresh rate: 299
16:08:36:070 -> I: src/bl.cpp [1141]: written new refresh rate: 4
16:08:36:071 -> I: src/bl.cpp [1155]: result - 3
16:08:36:074 -> I: src/bl.cpp [991]: Returned result - 0
16:08:36:075 -> I: src/bl.cpp [373]: request result - 0
16:08:36:077 -> I: src/bl.cpp [403]: retry:3 - time to sleep: 30
16:08:36:081 -> I: src/display.cpp [415]: Goto Sleep...
```