### PR TITLE
support for variant V3 of BMP files / No Alpha value checking for palette 

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -26,7 +26,7 @@
 #define WIFI_CONNECTION_RSSI (-100)
 
 #define DISPLAY_BMP_IMAGE_SIZE 48062 // in bytes - 62 bytes - header; 48000 bytes - bitmap (480*800 1bpp) / 8
-#define MAX_BMP_PAYLOAD_SIZE 48130 // V3 header add 68 bytes , only offset changes but it is a valid file
+#define MAX_BMP_PAYLOAD_SIZE 48146 // V3 header add 68 bytes , and v4 84 but only offset changes but it is a valid file
 #define DEFAULT_IMAGE_SIZE 48000
 
 #define SLEEP_uS_TO_S_FACTOR 1000000           /* Conversion factor for micro seconds to seconds */

--- a/include/config.h
+++ b/include/config.h
@@ -26,6 +26,7 @@
 #define WIFI_CONNECTION_RSSI (-100)
 
 #define DISPLAY_BMP_IMAGE_SIZE 48062 // in bytes - 62 bytes - header; 48000 bytes - bitmap (480*800 1bpp) / 8
+#define MAX_BMP_PAYLOAD_SIZE 48130 // V3 header add 68 bytes , only offset changes but it is a valid file
 #define DEFAULT_IMAGE_SIZE 48000
 
 #define SLEEP_uS_TO_S_FACTOR 1000000           /* Conversion factor for micro seconds to seconds */

--- a/lib/trmnl/include/bmp.h
+++ b/lib/trmnl/include/bmp.h
@@ -7,6 +7,7 @@ enum bmp_err_e
   BMP_BAD_SIZE,
   BMP_COLOR_SCHEME_FAILED,
   BMP_INVALID_OFFSET,
+  BMP_INVALID_TYPE,
 };
 
 bmp_err_e parseBMPHeader(uint8_t *data, bool &reserved);

--- a/lib/trmnl/src/bmp.cpp
+++ b/lib/trmnl/src/bmp.cpp
@@ -23,9 +23,13 @@ bmp_err_e parseBMPHeader(uint8_t *data, bool &reversed)
   uint32_t compressionMethod = *(uint32_t *)&data[30];
   uint32_t imageDataSize = *(uint32_t *)&data[34];
   uint32_t colorTableEntries = *(uint32_t *)&data[46];
+  uint32_t biSize = *(uint32_t *)&data[14];
 
   if (width != 800 || height != 480 || bitsPerPixel != 1 || imageDataSize != 48000 || colorTableEntries != 2)
     return BMP_BAD_SIZE;
+
+    if (biSize != 40 || biSize != 108 || biSize != 124)
+    return BMP_INVALID_TYPE;
   // Get the offset of the pixel data
   uint32_t dataOffset = *(uint32_t *)&data[10];
 
@@ -33,11 +37,11 @@ bmp_err_e parseBMPHeader(uint8_t *data, bool &reversed)
   Log.info("%s [%d]: BMP Header Information:\r\nWidth: %d\r\nHeight: %d\r\nBits per Pixel: %d\r\nCompression Method: %d\r\nImage Data Size: %d\r\nColor Table Entries: %d\r\nData offset: %d\r\n", __FILE__, __LINE__, width, height, bitsPerPixel, compressionMethod, imageDataSize, colorTableEntries, dataOffset);
 
   // Check if there's a color table
-  if (dataOffset > 54)
+  if (dataOffset > (biSize + 14))
   {
     // Read color table entries
     uint32_t colorTableSize = colorTableEntries * 4; // Each color entry is 4 bytes
-    uint8_t* colorTable = data + dataOffset - colorTableSize;
+    uint8_t* colorTable = data + dataOffset - colorTableSize; // = data + biSize + 14
 
     // Display color table
     Log.info("%s [%d]: Color table\r\n", __FILE__, __LINE__);

--- a/lib/trmnl/src/bmp.cpp
+++ b/lib/trmnl/src/bmp.cpp
@@ -28,7 +28,7 @@ bmp_err_e parseBMPHeader(uint8_t *data, bool &reversed)
   if (width != 800 || height != 480 || bitsPerPixel != 1 || imageDataSize != 48000 || colorTableEntries != 2)
     return BMP_BAD_SIZE;
 
-    if (biSize != 40 || biSize != 108 || biSize != 124)
+    if (biSize != 40 && biSize != 108 && biSize != 124)
     return BMP_INVALID_TYPE;
   // Get the offset of the pixel data
   uint32_t dataOffset = *(uint32_t *)&data[10];

--- a/lib/trmnl/src/bmp.cpp
+++ b/lib/trmnl/src/bmp.cpp
@@ -37,7 +37,7 @@ bmp_err_e parseBMPHeader(uint8_t *data, bool &reversed)
   Log.info("%s [%d]: BMP Header Information:\r\nbiSize:%d\r\nWidth: %d\r\nHeight: %d\r\nBits per Pixel: %d\r\nCompression Method: %d\r\nImage Data Size: %d\r\nColor Table Entries: %d\r\nData offset: %d\r\n", __FILE__, __LINE__, biSize, width, height, bitsPerPixel, compressionMethod, imageDataSize, colorTableEntries, dataOffset);
 
   // Check if there's a color table
-  if (dataOffset > (biSize + 14))
+  if (dataOffset >= (biSize + 14))
   {
     // Read color table entries
     uint32_t colorTableSize = colorTableEntries * 4; // Each color entry is 4 bytes

--- a/lib/trmnl/src/bmp.cpp
+++ b/lib/trmnl/src/bmp.cpp
@@ -37,27 +37,28 @@ bmp_err_e parseBMPHeader(uint8_t *data, bool &reversed)
   {
     // Read color table entries
     uint32_t colorTableSize = colorTableEntries * 4; // Each color entry is 4 bytes
+    uint8_t* colorTable = data + dataOffset - colorTableSize;
 
     // Display color table
     Log.info("%s [%d]: Color table\r\n", __FILE__, __LINE__);
     for (uint32_t i = 0; i < colorTableSize; i += 4)
     {
-      Log.info("%s [%d]: Color %d: B-%d, R-%d, G-%d\r\n", __FILE__, __LINE__, i / 4 + 1, data[54 + 4 * i], data[55 + 4 * i], data[56 + 4 * i], data[57 + 4 * i]);
+      Log.info("%s [%d]: Color %d: B-%d, R-%d, G-%d\r\n", __FILE__, __LINE__, i / 4 + 1, colorTable[4 * i + 0], colorTable[4 * i + 1], colorTable[4 * i + 2], colorTable[4 * i + 3]);
     }
 
-    if (data[54] == 0 && data[55] == 0 && data[56] == 0 && data[57] == 0 && data[58] == 255 && data[59] == 255 && data[60] == 255 && data[61] == 0)
+    if (colorTable[0] == 0 && colorTable[1] == 0 && colorTable[2] == 0 && colorTable[4] == 255 && colorTable[5] == 255 && colorTable[6] == 255)
     {
       Log.info("%s [%d]: Color scheme standart\r\n", __FILE__, __LINE__);
       reversed = false;
     }
-    else if (data[54] == 255 && data[55] == 255 && data[56] == 255 && data[57] == 0 && data[58] == 0 && data[59] == 0 && data[60] == 0 && data[61] == 0)
+    else if (colorTable[0] == 255 && colorTable[1] == 255 && colorTable[2] == 255 && colorTable[4] == 0 && colorTable[5] == 0 && colorTable[6] == 0)
     {
       Log.info("%s [%d]: Color scheme reversed\r\n", __FILE__, __LINE__);
       reversed = true;
     }
     else
     {
-      Log.info("%s [%d]: Color scheme demaged\r\n", __FILE__, __LINE__);
+      Log.info("%s [%d]: Color scheme damaged\r\n", __FILE__, __LINE__);
       return BMP_COLOR_SCHEME_FAILED;
     }
     return BMP_NO_ERR;

--- a/lib/trmnl/src/bmp.cpp
+++ b/lib/trmnl/src/bmp.cpp
@@ -34,14 +34,14 @@ bmp_err_e parseBMPHeader(uint8_t *data, bool &reversed)
   uint32_t dataOffset = *(uint32_t *)&data[10];
 
   // Display BMP information
-  Log.info("%s [%d]: BMP Header Information:\r\nWidth: %d\r\nHeight: %d\r\nBits per Pixel: %d\r\nCompression Method: %d\r\nImage Data Size: %d\r\nColor Table Entries: %d\r\nData offset: %d\r\n", __FILE__, __LINE__, width, height, bitsPerPixel, compressionMethod, imageDataSize, colorTableEntries, dataOffset);
+  Log.info("%s [%d]: BMP Header Information:\r\nbiSize:%d\r\nWidth: %d\r\nHeight: %d\r\nBits per Pixel: %d\r\nCompression Method: %d\r\nImage Data Size: %d\r\nColor Table Entries: %d\r\nData offset: %d\r\n", __FILE__, __LINE__, biSize, width, height, bitsPerPixel, compressionMethod, imageDataSize, colorTableEntries, dataOffset);
 
   // Check if there's a color table
   if (dataOffset > (biSize + 14))
   {
     // Read color table entries
     uint32_t colorTableSize = colorTableEntries * 4; // Each color entry is 4 bytes
-    uint8_t* colorTable = data + dataOffset - colorTableSize; // = data + biSize + 14
+    uint8_t* colorTable = data + dataOffset - colorTableSize; // = data + biSize + 14 (40 + 14 == 62 - 8)
 
     // Display color table
     Log.info("%s [%d]: Color table\r\n", __FILE__, __LINE__);

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -644,7 +644,7 @@ static https_request_err_e downloadAndShow()
       Log.info("%s [%d]: Content size: %d\r\n", __FILE__, __LINE__, https.getSize());
 
       uint32_t counter = 0;
-      if (content_size > DISPLAY_BMP_IMAGE_SIZE)
+      if (content_size > MAX_BMP_PAYLOAD_SIZE)
       {
         Log.error("%s [%d]: Receiving failed. Bad file size\r\n", __FILE__, __LINE__);
 
@@ -1199,8 +1199,8 @@ https_request_err_e handleApiDisplayResponse(ApiDisplayResponse &apiResponse)
           if (last_dot_file == "/last.bmp")
           {
             Log.info("Rewind BMP\n\r");
-            buffer = (uint8_t *)malloc(DISPLAY_BMP_IMAGE_SIZE);
-            file_check_bmp = filesystem_read_from_file(last_dot_file.c_str(), buffer, DISPLAY_BMP_IMAGE_SIZE);
+            buffer = (uint8_t *)malloc(MAX_BMP_PAYLOAD_SIZE);
+            file_check_bmp = filesystem_read_from_file(last_dot_file.c_str(), buffer, MAX_BMP_PAYLOAD_SIZE);
             bmp_proccess_response = parseBMPHeader(buffer, image_reverse);
           }
           else if (last_dot_file == "/last.png")
@@ -1279,9 +1279,9 @@ https_request_err_e handleApiDisplayResponse(ApiDisplayResponse &apiResponse)
           if (filesystem_file_exists("/current.bmp"))
           {
             Log.info("%s [%d]: send_to_me BMP\r\n", __FILE__, __LINE__);
-            buffer = (uint8_t *)malloc(DISPLAY_BMP_IMAGE_SIZE);
+            buffer = (uint8_t *)malloc(MAX_BMP_PAYLOAD_SIZE);
 
-            if (!filesystem_read_from_file("/current.bmp", buffer, DISPLAY_BMP_IMAGE_SIZE))
+            if (!filesystem_read_from_file("/current.bmp", buffer, MAX_BMP_PAYLOAD_SIZE))
             {
               Log.info("%s [%d]: Error reading image!\r\n", __FILE__, __LINE__);
               free(buffer);
@@ -1535,16 +1535,16 @@ static void getDeviceCredentials()
               uint32_t counter = 0;
               // Read and save BMP data to buffer
               buffer = (uint8_t *) malloc(https.getSize());
-              if (stream->available() && https.getSize() == DISPLAY_BMP_IMAGE_SIZE)
+              if (stream->available() && https.getSize() <= MAX_BMP_PAYLOAD_SIZE)
               {
-                counter = stream->readBytes(buffer, DISPLAY_BMP_IMAGE_SIZE);
+                counter = stream->readBytes(buffer, MAX_BMP_PAYLOAD_SIZE);
               }
               https.end();
-              if (counter == DISPLAY_BMP_IMAGE_SIZE)
+              if ((counter == DISPLAY_BMP_IMAGE_SIZE) || (counter == MAX_BMP_PAYLOAD_SIZE))
               {
                 Log.info("%s [%d]: Received successfully\r\n", __FILE__, __LINE__);
 
-                writeImageToFile("/logo.bmp", buffer, DEFAULT_IMAGE_SIZE);
+                writeImageToFile("/logo.bmp", buffer, counter);
 
                 // show the image
                 String friendly_id = preferences.getString(PREFERENCES_FRIENDLY_ID, PREFERENCES_FRIENDLY_ID_DEFAULT);

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -100,7 +100,10 @@ void display_show_image(uint8_t *image_buffer, bool reverse, bool isPNG)
         Paint_DrawBitMap(image_buffer);
     }
     else{
-        Paint_DrawBitMap(image_buffer + 62);
+        // Get the offset of the pixel data
+    uint32_t dataOffset = *(uint32_t *)&image_buffer[10];
+
+        Paint_DrawBitMap(image_buffer + dataOffset);
     }
     EPD_7IN5_V2_Display(BlackImage);
     Log.info("%s [%d]: display\r\n", __FILE__, __LINE__);

--- a/test/test_bmp/bmp.test.cpp
+++ b/test/test_bmp/bmp.test.cpp
@@ -111,7 +111,7 @@ void test_parseBMPHeader_BMP_INVALID_OFFSET(void)
 
   bmp_data[10] = 5;
 
-  TEST_ASSERT_EQUAL(BMP_INVALID_TYPE, parseBMPHeader(bmp_data.data(), image_reverse));
+  TEST_ASSERT_EQUAL(BMP_INVALID_OFFSET, parseBMPHeader(bmp_data.data(), image_reverse));
 }
 
 void setUp(void) {

--- a/test/test_bmp/bmp.test.cpp
+++ b/test/test_bmp/bmp.test.cpp
@@ -114,6 +114,16 @@ void test_parseBMPHeader_BMP_INVALID_OFFSET(void)
   TEST_ASSERT_EQUAL(BMP_INVALID_OFFSET, parseBMPHeader(bmp_data.data(), image_reverse));
 }
 
+void test_parseBMPHeader_BMP_INVALID_TYPE(void)
+{
+  auto bmp_data = readBMPFile("./test.bmp");
+  bool image_reverse = false;
+
+  bmp_data[14] = 112;
+
+  TEST_ASSERT_EQUAL(BMP_INVALID_TYPE, parseBMPHeader(bmp_data.data(), image_reverse));
+}
+
 void setUp(void) {
   // set stuff up here
 }
@@ -133,6 +143,7 @@ void process()
   RUN_TEST(test_parseBMPHeader_BMP_INVALID_OFFSET);
 
   RUN_TEST(test_parseBMPHeader_BMPV3_NO_ERR);
+  RUN_TEST(test_parseBMPHeader_BMP_INVALID_TYPE);
   UNITY_END();
 }
 

--- a/test/test_bmp/bmp.test.cpp
+++ b/test/test_bmp/bmp.test.cpp
@@ -45,6 +45,17 @@ void test_parseBMPHeader_BMP_NO_ERR(void)
   TEST_ASSERT_EQUAL(false, image_reverse);
 }
 
+void test_parseBMPHeader_BMPV3_NO_ERR(void)
+{
+  auto bmp_data = readBMPFile("./logo.bmp");
+  bool image_reverse = false;
+
+  bmp_err_e result = parseBMPHeader(bmp_data.data(), image_reverse);
+
+  TEST_ASSERT_EQUAL(BMP_NO_ERR, result);
+  TEST_ASSERT_EQUAL(false, image_reverse);
+}
+
 void test_parseBMPHeader_BMP_NO_ERR_reversed(void)
 {
   auto bmp_data = readBMPFile("./test.bmp");
@@ -120,6 +131,8 @@ void process()
   RUN_TEST(test_parseBMPHeader_BMP_BAD_SIZE);
   RUN_TEST(test_parseBMPHeader_BMP_COLOR_SCHEME_FAILED);
   RUN_TEST(test_parseBMPHeader_BMP_INVALID_OFFSET);
+
+  RUN_TEST(test_parseBMPHeader_BMPV3_NO_ERR);
   UNITY_END();
 }
 

--- a/test/test_bmp/bmp.test.cpp
+++ b/test/test_bmp/bmp.test.cpp
@@ -111,7 +111,7 @@ void test_parseBMPHeader_BMP_INVALID_OFFSET(void)
 
   bmp_data[10] = 5;
 
-  TEST_ASSERT_EQUAL(BMP_INVALID_OFFSET, parseBMPHeader(bmp_data.data(), image_reverse));
+  TEST_ASSERT_EQUAL(BMP_INVALID_TYPE, parseBMPHeader(bmp_data.data(), image_reverse));
 }
 
 void setUp(void) {


### PR DESCRIPTION
rationale:
- do not reject files whose palette is not exactly what is expected for the unused Alpha value
- accept V3 BMP variant files as payload (they are 48130 instead of 48062 and are currently rejected)

68 bytes larger but same structure (also v4 with a few more bytes)

I had to change a bit the way payload size is checked to allow for slightly larger files
BMP parser now locates the colormap instead of harcoded  offset to 54
checking for reversed black and white does not look at Alpha value.

This should allow ./logo.bmp o be used as payload and previously rejected files to work

I added checked that new parsing works as before and new tests have been added for new method, based on logo.bmp
  