### PR TITLE
Display log output during unit tests

### DIFF
--- a/lib/trmnl/include/mock_log.h
+++ b/lib/trmnl/include/mock_log.h
@@ -1,20 +1,41 @@
 
 #pragma once
 
-/** Empty reimplementation of ArduinoLog for use by tests */
+#include <cstdio>
+#include <cstdarg>
+
+/** Reimplementation of ArduinoLog for use by tests */
 class Logging
 {
+private:
+  void logImpl(const char* level, const char* msg, va_list args) {
+    printf("[%s] ", level);
+    vprintf(msg, args);
+  }
+
 public:
   Logging() {}
 
-  template <class T>
-  void fatal(T msg, ...) {}
+  void fatal(const char* msg, ...) {
+    va_list args;
+    va_start(args, msg);
+    logImpl("FATAL", msg, args);
+    va_end(args);
+  }
 
-  template <class T>
-  void error(T msg, ...) {}
+  void error(const char* msg, ...) {
+    va_list args;
+    va_start(args, msg);
+    logImpl("ERROR", msg, args);
+    va_end(args);
+  }
 
-  template <class T>
-  void info(T msg, ...) {}
+  void info(const char* msg, ...) {
+    va_list args;
+    va_start(args, msg);
+    logImpl("INFO", msg, args);
+    va_end(args);
+  }
 };
 
 extern Logging Log;


### PR DESCRIPTION
Today the unit tests use a mock ArduinoLog, but the implementation is empty. This PR implements the mock logger, so that stdout messages appear when you run unit tests with `-v`, e.g.:

```
> pio test -e native --filter test_bmp -v
Collected 4 tests (test_bmp, test_parse_api_display, test_parse_api_setup, test_png_flip)

Processing test_bmp in native environment
----------------------------------------------------------------------------------------------------------------------------
Building...

Testing...
[INFO] lib/trmnl/src/bmp.cpp [33]: BMP Header Information:
Width: 800
Height: 480
Bits per Pixel: 1
Compression Method: 0
Image Data Size: 48000
Color Table Entries: 2
Data offset: 62
[INFO] lib/trmnl/src/bmp.cpp [42]: Color table
[INFO] lib/trmnl/src/bmp.cpp [45]: Color 1: B-0, R-0, G-0
[INFO] lib/trmnl/src/bmp.cpp [45]: Color 2: B-0, R-0, G-0
[INFO] lib/trmnl/src/bmp.cpp [50]: Color scheme standart
test/test_bmp/bmp.test.cpp:117:test_parseBMPHeader_BMP_NO_ERR:PASS
[INFO] lib/trmnl/src/bmp.cpp [33]: BMP Header Information:
( ... )
```