### PR TITLE
Dependency updates

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -22,7 +22,7 @@ build_flags =
 lib_ldf_mode = deep
 lib_deps =
 	ESP32Async/ESPAsyncWebServer@3.7.7
-	bblanchon/ArduinoJson@7.2.1
+	bblanchon/ArduinoJson@7.4.1
 	https://github.com/thijse/Arduino-Log.git#3f4fcf5a345c1d542e56b88c0ffcb2bd2a5b0bd0
 	bitbank2/PNGdec@1.1.3
 debug_init_break = break setupy
@@ -81,7 +81,7 @@ build_flags =
 platform = native
 test_framework = unity
 lib_deps =
-	bblanchon/ArduinoJson@7.2.1
+	bblanchon/ArduinoJson@7.4.1
 	fabiobatsilva/ArduinoFake@^0.4.0
 	bitbank2/PNGdec@1.1.3
 build_flags =

--- a/platformio.ini
+++ b/platformio.ini
@@ -24,7 +24,7 @@ lib_deps =
 	ESP32Async/ESPAsyncWebServer@3.7.7
 	bblanchon/ArduinoJson@7.2.1
 	https://github.com/thijse/Arduino-Log.git#3f4fcf5a345c1d542e56b88c0ffcb2bd2a5b0bd0
-	bitbank2/PNGdec@1.1.2
+	bitbank2/PNGdec@1.1.3
 debug_init_break = break setupy
 build_type = debug
 check_tool = clangtidy
@@ -83,7 +83,7 @@ test_framework = unity
 lib_deps =
 	bblanchon/ArduinoJson@7.2.1
 	fabiobatsilva/ArduinoFake@^0.4.0
-	bitbank2/PNGdec@1.1.2
+	bitbank2/PNGdec@1.1.3
 build_flags =
 	-D ARDUINOJSON_ENABLE_ARDUINO_STRING=1
 	-std=gnu++11

--- a/platformio.ini
+++ b/platformio.ini
@@ -13,7 +13,7 @@ default_envs = trmnl
 
 [env:esp32_base]
 framework = arduino
-platform = espressif32@6.10.0
+platform = espressif32@6.11.0
 board_build.partitions = min_spiffs.csv
 board_build.filesystem = spiffs
 upload_speed = 460800
@@ -66,7 +66,6 @@ build_flags =
 
 [env:local]
 extends = env:esp32_base
-platform = espressif32@6.10.0 # Specify platform for local env
 board = esp32-c3-devkitc-02 # Specify board for local env (assuming C3 for local debugging)
 build_flags =
 	-D BOARD_TRMNL

--- a/platformio.ini
+++ b/platformio.ini
@@ -21,7 +21,7 @@ build_flags =
 	-D CORE_DEBUG_LEVEL=0
 lib_ldf_mode = deep
 lib_deps =
-	ESP32Async/ESPAsyncWebServer@3.7.1
+	ESP32Async/ESPAsyncWebServer@3.7.7
 	bblanchon/ArduinoJson@7.2.1
 	https://github.com/thijse/Arduino-Log.git#3f4fcf5a345c1d542e56b88c0ffcb2bd2a5b0bd0
 	bitbank2/PNGdec@1.1.2


### PR DESCRIPTION
Update a handful of third-party components:
 - espressif32
 - ESPAsyncWebServer
 - ArduinoJson
 - PNGdec

I haven't tested this on the device yet, but wanted to get it on the radar. I'll follow up when I've had a chance to try it.

Note that a previous ArduinoJson update [was reverted](https://github.com/usetrmnl/firmware/commit/6ab3989db2189418bbf41218850a3f1dc0fc6f9e) when it was suspected of causing problems. When or if this change goes in to a release, we may want to have a slower rollout to watch for issues.