### PR TITLE
First simple implementation of Device Independent Bitmaps

### DIFF
--- a/lib/trmnl/include/png.h
+++ b/lib/trmnl/include/png.h
@@ -13,6 +13,5 @@ enum image_err_e
   PNG_FILE_NOT_FOUND
 };
 
-image_err_e processPNG(PNG *png, uint8_t *&decoded_buffer);
-
-image_err_e decodePNG(uint8_t *buffer, uint8_t *&decoded_buffer);
+image_err_e processPNG(PNG *png, uint8_t * png_buffer, uint8_t *decoded_buffer);
+image_err_e decodePNG(uint8_t* pngbuffer, uint8_t *&decoded_buffer);

--- a/lib/trmnl/include/trmnl_image.h
+++ b/lib/trmnl/include/trmnl_image.h
@@ -1,0 +1,48 @@
+#include <cstdint>
+#if !defined(TRMNL_IMAGE_H)
+#define TRMN_IMAGE_H
+
+#include <ctype.h>
+
+// TODO: refcount ?
+// TODO: palette
+// TODO: adapt for bitdepth > 1
+
+typedef struct TrmnlImage {
+  uint16_t width;
+  uint16_t height;
+  uint8_t bpp;
+  uint16_t stride; // size of one row in bytes
+  bool owndata;
+  uint8_t *data;
+} TrmnlImage;
+
+// creates a fully owned image
+TrmnlImage *TrmnlNewImage(uint16_t width, uint16_t height, uint8_t bpp,
+                          uint16_t stride);
+
+// Create a copy of an image, owns the image, padding is one byte
+// can flip image vertically
+TrmnlImage *TrmnlFromImage(TrmnlImage *image, bool flip = false);
+
+// creates a proxy image using an already existing image
+// all parameters are copied, but does not own the data
+TrmnlImage *TrmnlUseImage(TrmnlImage *image);
+
+// Deletes an image
+void TrmnlDeleteImage(TrmnlImage *image);
+
+// utilities
+// PNG, Screen buffer
+uint16_t StrideOneByte(uint16_t width, uint8_t bpp);
+
+// PNG, Screen buffer
+uint16_t StrideFourByte(uint16_t width, uint8_t bpp);
+
+uint8_t *TrmnlGetRowData(TrmnlImage *image, uint16_t row);
+
+// takes care of different strides
+void TrmnlCopyRowData(TrmnlImage *dstimage, TrmnlImage *srcimage,
+                      uint16_t dstrow, uint16_t srcrow);
+
+#endif

--- a/lib/trmnl/src/png.cpp
+++ b/lib/trmnl/src/png.cpp
@@ -1,30 +1,78 @@
-#include <PNGdec.h>
 #include "png.h"
+#include <PNGdec.h>
 #include <trmnl_log.h>
 
-image_err_e processPNG(PNG *png, uint8_t *&decoded_buffer)
-{
-  if (!(decoded_buffer = (uint8_t *)malloc(48000)))
-  {
-    Log_error("PNG MALLOC FAILED");
-    return PNG_MALLOC_FAILED;
-  }
-  png->setBuffer(decoded_buffer);
+// raw chunk (type size data chcksum)
+typedef uint8_t(callback)(uint32_t chunk, uint32_t size, uint8_t *data);
+
+uint8_t chunk_IEND[4] = {'I', 'E', 'N', 'D'};
+uint8_t chunk_bKGD[4] = {'b', 'K', 'G', 'D'};
+uint8_t chunk_oFFs[4] = {'o', 'F', 'F', 's'};
+
+uint32_t PNGStride(uint32_t width) { return ((width + 7) / 8); }
+
+void handleKnownChunks(uint8_t *data_chunk, int32_t *xoffset,
+                       int32_t *yoffset) {
+  bool finished = false;
+  do {
+
+    uint32_t chunk_name = *(uint32_t *)&data_chunk[0];
+    uint32_t chunk_length = *(uint32_t *)&data_chunk[4];
+    if (chunk_name == *((uint32_t *)chunk_bKGD)) {
+      uint16_t background = *((uint16_t *)data_chunk);
+      int8_t background_fill = background & 1 ? 0xff : 0;
+    } else if (chunk_name == *((uint32_t *)chunk_oFFs)) {
+      *xoffset = *((uint16_t *)data_chunk);
+      *yoffset = *((uint16_t *)(data_chunk + 4));
+    }
+    data_chunk += chunk_length + 12;
+    finished = chunk_name == *((uint32_t *)chunk_IEND);
+  } while (!finished);
+}
+
+image_err_e processPNG(PNG *png, uint8_t *png_buffer, uint8_t *decoded_buffer) {
 
   uint32_t width = png->getWidth();
   uint32_t height = png->getHeight();
   uint32_t bpp = png->getBpp();
 
-  if (width != 800 || height != 480 || bpp != 1)
-  {
+  if (width > 800 || height > 480 || bpp != 1) {
     Log_error("PNG_BAD_SIZE");
     return PNG_BAD_SIZE;
   }
 
-  if (!(png->decode(nullptr, 0)))
-  {
-    Log_error("PNG_SUCCESS");
+  if (width != 800 || height != 480) {
+    int32_t xoffset = 0;
+    int32_t yoffset = 0;
+    handleKnownChunks(png_buffer, &xoffset, &yoffset);
+    // decode to local buffer
+    uint8_t *tmpbuf = (uint8_t *)malloc(PNGStride(width) * height);
+    png->setBuffer(tmpbuf);
+    png->decode(nullptr, 0);
+    // copy to image
+    int32_t x_in_bytes = xoffset / 8;
+    for (int32_t yy = 0; yy < height; ++yy) {
+      if (((yoffset + yy) > 0 && (yoffset + yy) < 480)) {
+        uint8_t *startrow =
+            decoded_buffer + ((yoffset + yy) * PNGStride(width));
+        uint8_t *startsrc = tmpbuf + yy * x_in_bytes;
+        for (int32_t xx = 0; xx < PNGStride(width); ++xx) {
+          // last incomplete byte depends on width % 8
+          // TODO replace by memcpy
+          if (((x_in_bytes + xx) > 0 && (x_in_bytes + xx) < 800)) {
+            startrow[xx + x_in_bytes] = startsrc[xx];
+          }
+        }
+      }
+    }
+    free(tmpbuf);
     return PNG_NO_ERR;
+  } else {
+
+    if (!(png->decode(nullptr, 0))) {
+      Log_error("PNG_SUCCESS");
+      return PNG_NO_ERR;
+    }
   }
   Log_error("PNG_DECODE_ERR");
   return PNG_DECODE_ERR;
@@ -36,8 +84,7 @@ image_err_e processPNG(PNG *png, uint8_t *&decoded_buffer)
  * @param decodded_buffer Buffer where decoded PNG bitmap save
  * @return image_err_e error code
  */
-image_err_e decodePNG(uint8_t *buffer, uint8_t *&decoded_buffer)
-{
+image_err_e decodePNG(uint8_t *buffer, uint8_t *&decoded_buffer) {
   PNG *png = new PNG();
 
   if (!png)
@@ -45,13 +92,12 @@ image_err_e decodePNG(uint8_t *buffer, uint8_t *&decoded_buffer)
 
   int rc = png->openRAM(buffer, 48000, nullptr);
 
-  if (rc == PNG_INVALID_FILE)
-  {
+  if (rc == PNG_INVALID_FILE) {
     delete png;
     return PNG_WRONG_FORMAT;
   }
 
-  image_err_e result = processPNG(png, decoded_buffer);
+  image_err_e result = processPNG(png, buffer, decoded_buffer);
   delete png;
   return result;
 }

--- a/lib/trmnl/src/trmnl_image.cpp
+++ b/lib/trmnl/src/trmnl_image.cpp
@@ -1,0 +1,67 @@
+#include <trmnl_image.h>
+#include <cstdlib>
+
+TrmnlImage *TrmnlNewImage(uint16_t width, uint16_t height, uint8_t bpp,
+                          uint16_t stride) {
+  uint8_t *data = (uint8_t*)malloc(stride * height);
+  TrmnlImage *image = (TrmnlImage*)malloc(sizeof(TrmnlImage));
+  image->width = width;
+  image->height = height;
+  image->bpp == bpp;
+  image->stride = stride;
+  image->data = data;
+  image->owndata = true;
+  return image;
+  }
+
+  TrmnlImage *TrmnlFromImage(TrmnlImage *srcimage, bool flip) {
+    uint16_t stride = StrideOneByte(srcimage->width, srcimage->bpp);
+    TrmnlImage *image = TrmnlNewImage(srcimage->width, srcimage->height,
+                                      srcimage->bpp, stride);
+    for (uint16_t h = 0; h < image->height; ++h) {
+      TrmnlCopyRowData(image, srcimage, h, flip ? (image->height - h + 1) : h);
+    }
+    return image;               
+}
+
+TrmnlImage *TrmnlUseImage(TrmnlImage *srcimage) {
+   TrmnlImage *image = (TrmnlImage *)malloc(sizeof(TrmnlImage));
+  image->width = srcimage->width;
+  image->height = srcimage->height;
+  image->bpp == srcimage->bpp;
+  image->stride = srcimage->stride;
+  image->data = srcimage->data;
+  image->owndata = false;
+  return image;
+}
+
+void TrmnlDeleteImage(TrmnlImage *image) {
+  if (image->owndata)
+    free(image->data);
+  free(image);
+}
+
+uint16_t StrideOneByte(uint16_t width, uint8_t bpp) {
+  return ((bpp * width) + 7) / 8;
+}
+
+uint16_t StrideFourByte(uint16_t width, uint8_t bpp) {
+  return (((bpp * width) + 31) / 32) * 4;
+}
+
+uint8_t *TrmnlGetRowData(TrmnlImage *image, uint16_t row) {
+  return image->data + row * image->stride;
+}
+
+// images must have same parameters except stride
+void TrmnlCopyRowData(TrmnlImage *dstimage, TrmnlImage *srcimage, uint16_t dstrow, uint16_t srcrow) {
+  if ((dstimage->width != srcimage->width) || (dstimage->height != srcimage->height) ||
+      (dstimage->bpp !=srcimage->bpp))
+    return;
+  uint16_t smallerstride = dstimage->stride;
+  if (srcimage->stride < smallerstride) {
+    smallerstride = srcimage->stride;
+  }
+  memcpy((char *)TrmnlGetRowData(dstimage, dstrow),
+         (const char *)TrmnlGetRowData(srcimage, srcrow), smallerstride);
+}

--- a/src/png_file.cpp
+++ b/src/png_file.cpp
@@ -1,75 +1,30 @@
+#include "png.h"
+#include <PNGdec.h>
+#include <SPIFFS.h>
+#include <esp_mac.h>
 #include <png_file.h>
 #include <trmnl_log.h>
-#include <PNGdec.h>
-#include <esp_mac.h>
-#include <SPIFFS.h>
-#include "png.h"
-
-File pngfile; // Global file handle
-
-void *pngOpen(const char *filename, int32_t *size)
-{
-  Serial.printf("Attempting to open %s from SPIFFS\n", filename);
-  pngfile = SPIFFS.open(filename, "r");
-
-  if (!pngfile)
-  {
-    Serial.println("Failed to open file!");
-    *size = 0;
-    return nullptr;
-  }
-
-  *size = pngfile.size();
-  return &pngfile;
-}
-
-void pngClose(void *handle)
-{
-  if (pngfile)
-  {
-    pngfile.close();
-  }
-}
-
-int32_t pngRead(PNGFILE *page, uint8_t *buffer, int32_t length)
-{
-  if (!pngfile)
-    return 0;
-  (void)page; // suppress unused warning
-  return pngfile.read(buffer, length);
-}
-
-int32_t pngSeek(PNGFILE *page, int32_t position)
-{
-  if (!pngfile)
-    return 0;
-  (void)page;
-  return pngfile.seek(position);
-}
+#include <stdio.h>
 
 /**
  * @brief Function to decode png file
  * @param szFilename PNG file location
- * @param decodded_buffer Buffer where decoded PNG bitmap save
+ * @param decoded_buffer Buffer where decoded PNG bitmap save
  * @return image_err_e error code
  */
-image_err_e decodePNG(const char *szFilename, uint8_t *&decoded_buffer)
-{
+image_err_e decodePNG(const char *szFilename, uint8_t *&decoded_buffer) {
   PNG *png = new PNG();
 
   if (!png)
     return PNG_MALLOC_FAILED;
 
-  int rc = png->open(szFilename, pngOpen, pngClose, pngRead, pngSeek, nullptr);
-
-  if (rc == PNG_INVALID_FILE)
-  {
-    Log_error("WRONG_FILE");
-    delete png;
-    return PNG_WRONG_FORMAT;
-  }
-
-  image_err_e result = processPNG(png, decoded_buffer);
+  File f = SPIFFS.open(szFilename);
+  int32_t size = f.size();
+  uint8_t *buffer_png = (uint8_t *)malloc(size);
+  f.readBytes((char*)buffer_png, size);
+  f.close();
+  image_err_e result = processPNG(png, buffer_png, decoded_buffer);
   delete png;
+  free(buffer_png);
   return result;
 }

--- a/test/test_image/image_test.cpp
+++ b/test/test_image/image_test.cpp
@@ -1,0 +1,64 @@
+#include <unity.h>
+#include <cstdint>
+#include <string.h>
+#include <trmnl_image.h>
+
+void test_ImageBasic() {
+  uint16_t width = 800;
+  uint16_t height = 640;
+  uint8_t bpp = 1;
+  uint16_t bmpstride = StrideFourByte(width, bpp);
+  uint16_t pngstride = StrideOneByte(width, bpp);
+  TEST_ASSERT_EQUAL(bmpstride, pngstride);
+  TEST_ASSERT_EQUAL(bmpstride, 100);
+  TrmnlImage *image1 = TrmnlNewImage(800, 480, bpp, pngstride);
+  TEST_ASSERT_EQUAL(image1->width, width);
+  TEST_ASSERT_EQUAL(image1->height, height);
+  TEST_ASSERT_EQUAL(image1->bpp, bpp);
+  TEST_ASSERT_EQUAL(image1->stride, pngstride);
+  TEST_ASSERT_EQUAL(image1->owndata, true);
+  TrmnlImage *image2 = TrmnlUseImage(image1);
+  TEST_ASSERT_EQUAL(image2->width, image1->width);
+  TEST_ASSERT_EQUAL(image2->height, image1->height);
+  TEST_ASSERT_EQUAL(image2->bpp, image1->bpp);
+  TEST_ASSERT_EQUAL(image2->stride, image1->stride);
+  TEST_ASSERT_EQUAL(image2->owndata, false);
+  TrmnlDeleteImage(image2);
+  // access image 1
+  *TrmnlGetRowData(image1, 0) = 42;
+  TrmnlDeleteImage(image1);
+}
+
+void test_ImageBDifferentStrides() {
+  uint16_t width = 804;
+  uint16_t height = 640;
+  uint8_t bpp = 1;
+  uint16_t bmpstride = StrideFourByte(width, bpp);
+  uint16_t pngstride = StrideOneByte(width, bpp);
+  TEST_ASSERT_EQUAL(bmpstride, 104);
+  TEST_ASSERT_EQUAL(bmpstride, 101);
+  TrmnlImage *image1 = TrmnlNewImage(width, height, bpp, bmpstride);
+  // fill with pattern
+  for (uint16_t h = 0; h < image1->height; ++h) {
+    memset(TrmnlGetRowData(image1, h), h % 256, image1->stride);
+  }
+  // copy with different stride, not flipped
+  TrmnlImage *image2 = TrmnlFromImage(image1);
+  TEST_ASSERT_EQUAL(image2->stride, pngstride);
+  // check that first byte for top and bottom row is the  same
+  TEST_ASSERT_EQUAL(*TrmnlGetRowData(image1, 0), *TrmnlGetRowData(image2, 0));
+  TEST_ASSERT_EQUAL(*TrmnlGetRowData(image1, height - 1),
+                    *TrmnlGetRowData(image2, height - 1));
+  TrmnlDeleteImage(image2);
+
+// copy with different stride, flipped (what happens for normal BMPs)
+  TrmnlImage *image3 = TrmnlFromImage(image1, true);
+  // check that first byte for top and bottom row are flipped
+  TEST_ASSERT_EQUAL(*TrmnlGetRowData(image1, 0), *TrmnlGetRowData(image3, height - 1));
+  TEST_ASSERT_EQUAL(TrmnlGetRowData(image1, height - 1),
+                    TrmnlGetRowData(image3, 0));
+  TrmnlDeleteImage(image3);
+
+  TrmnlDeleteImage(image3);
+  
+}


### PR DESCRIPTION
This set of functions work on a simple Trmnlmage structure, that describes a DIB.

This allows manipulation of images in a consistent way, before all we had was a pointer to the data, and no related attributes such as width height, bitdepth, this makes handling difficult.

This can be the basis of many other features, from a framebuffer to independent images read from bmp, png or memory .

Next step i to implement a real BMP decoder for this structure.

I created some unit tests  but cannot get them to compile, the linker does not want to use  the new trmnl-image.cpp (.o)
The TrmnlImage structure is not used anywere else than n the test for now..