### PR TITLE
Device Independant Bitmaps

### DIFF
--- a/lib/trmnl/include/trmnl_image.h
+++ b/lib/trmnl/include/trmnl_image.h
@@ -1,0 +1,48 @@
+#include <cstdint>
+#if !defined(TRMNL_IMAGE_H)
+#define TRMN_IMAGE_H
+
+#include <ctype.h>
+
+// TODO: refcount ?
+// TODO: palette
+// TODO: adapt for bitdepth > 1
+
+typedef struct TrmnlImage {
+  uint16_t width;
+  uint16_t height;
+  uint8_t bpp;
+  uint16_t stride; // size of one row in bytes
+  bool owndata;
+  uint8_t *data;
+} TrmnlImage;
+
+// creates a fully owned image
+TrmnlImage *TrmnlNewImage(uint16_t width, uint16_t height, uint8_t bpp,
+                          uint16_t stride);
+
+// Create a copy of an image, owns the image, padding is one byte
+// can flip image vertically
+TrmnlImage *TrmnlFromImage(TrmnlImage *image, bool flip = false);
+
+// creates a proxy image using an already existing image
+// all parameters are copied, but does not own the data
+TrmnlImage *TrmnlUseImage(TrmnlImage *image);
+
+// Deletes an image
+void TrmnlDeleteImage(TrmnlImage *image);
+
+// utilities
+// PNG, Screen buffer
+uint16_t StrideOneByte(uint16_t width, uint8_t bpp);
+
+// PNG, Screen buffer
+uint16_t StrideFourByte(uint16_t width, uint8_t bpp);
+
+uint8_t *TrmnlGetRowData(TrmnlImage *image, uint16_t row);
+
+// takes care of different strides
+void TrmnlCopyRowData(TrmnlImage *dstimage, TrmnlImage *srcimage,
+                      uint16_t dstrow, uint16_t srcrow);
+
+#endif

--- a/lib/trmnl/src/trmnl_image.cpp
+++ b/lib/trmnl/src/trmnl_image.cpp
@@ -1,0 +1,70 @@
+#include <trmnl_image.h>
+#include <cstring>
+#include <cstdlib>
+
+TrmnlImage *TrmnlNewImage(uint16_t width, uint16_t height, uint8_t bpp,
+                          uint16_t stride) {
+  uint8_t *data = (uint8_t*)malloc(stride * height);
+  TrmnlImage *image = (TrmnlImage*)malloc(sizeof(TrmnlImage));
+  image->width = width;
+  image->height = height;
+  image->bpp = bpp;
+  image->stride = stride;
+  image->data = data;
+  image->owndata = true;
+  return image;
+  }
+
+  TrmnlImage *TrmnlFromImage(TrmnlImage *srcimage, bool flip) {
+    uint16_t stride = StrideOneByte(srcimage->width, srcimage->bpp);
+    TrmnlImage *image = TrmnlNewImage(srcimage->width, srcimage->height,
+                                      srcimage->bpp, stride);
+    for (uint16_t h = 0; h < image->height; ++h) {
+      TrmnlCopyRowData(image, srcimage, h, flip ? (image->height - h - 1) : h);
+    }
+    return image;               
+}
+
+TrmnlImage *TrmnlUseImage(TrmnlImage *srcimage) {
+   TrmnlImage *image = (TrmnlImage *)malloc(sizeof(TrmnlImage));
+  image->width = srcimage->width;
+  image->height = srcimage->height;
+  image->bpp = srcimage->bpp;
+  image->stride = srcimage->stride;
+  image->data = srcimage->data;
+  image->owndata = false;
+  return image;
+}
+
+void TrmnlDeleteImage(TrmnlImage *image) {
+  if (image->owndata)
+    free(image->data);
+  free(image);
+}
+
+uint16_t StrideOneByte(uint16_t width, uint8_t bpp) {
+  return ((bpp * width) + 7) / 8;
+}
+
+uint16_t StrideFourByte(uint16_t width, uint8_t bpp) {
+  return (((bpp * width) + 31) / 32) * 4;
+}
+
+uint8_t *TrmnlGetRowData(TrmnlImage *image, uint16_t row) {
+  return image->data + row * image->stride;
+}
+
+// images must have same parameters except stride
+void TrmnlCopyRowData(TrmnlImage *dstimage, TrmnlImage *srcimage, uint16_t dstrow, uint16_t srcrow) {
+  if ((dstimage->width != srcimage->width) ||
+      (dstimage->height != srcimage->height) ||
+      (dstimage->bpp != srcimage->bpp))
+    
+    return;
+  uint16_t smallerstride = dstimage->stride;
+  if (srcimage->stride < smallerstride) {
+    smallerstride = srcimage->stride;
+  }
+  memcpy((char *)TrmnlGetRowData(dstimage, dstrow),
+         (const char *)TrmnlGetRowData(srcimage, srcrow), smallerstride);
+}

--- a/test/test_image/image.test.cpp
+++ b/test/test_image/image.test.cpp
@@ -1,0 +1,84 @@
+#include <unity.h>
+#include <cstdint>
+#include <cstring>
+#include <trmnl_image.h>
+
+void test_ImageBasic(void) {
+  uint16_t width = 800;
+  uint16_t height = 480;
+  uint8_t bpp = 1;
+  uint16_t bmpstride = StrideFourByte(width, bpp);
+  uint16_t pngstride = StrideOneByte(width, bpp);
+  TEST_ASSERT_EQUAL(bmpstride, pngstride);
+  TEST_ASSERT_EQUAL(bmpstride, 100);
+  TrmnlImage *image1 = TrmnlNewImage(800, 480, bpp, pngstride);
+  TEST_ASSERT_EQUAL(image1->width, width);
+  TEST_ASSERT_EQUAL(image1->height, height);
+  TEST_ASSERT_EQUAL(image1->bpp, bpp);
+  TEST_ASSERT_EQUAL(image1->stride, pngstride);
+  TEST_ASSERT_EQUAL(image1->owndata, true);
+  TrmnlImage *image2 = TrmnlUseImage(image1);
+  TEST_ASSERT_EQUAL(image2->width, image1->width);
+  TEST_ASSERT_EQUAL(image2->height, image1->height);
+  TEST_ASSERT_EQUAL(image2->bpp, image1->bpp);
+  TEST_ASSERT_EQUAL(image2->stride, image1->stride);
+  TEST_ASSERT_EQUAL(image2->owndata, false);
+  TrmnlDeleteImage(image2);
+  // access image 1
+  *TrmnlGetRowData(image1, 0) = 42;
+  TrmnlDeleteImage(image1);
+}
+
+void test_ImageDifferentStrides(void) {
+  uint16_t width = 804;
+  uint16_t height = 640;
+  uint8_t bpp = 1;
+  uint16_t bmpstride = StrideFourByte(width, bpp);
+  uint16_t pngstride = StrideOneByte(width, bpp);
+  TEST_ASSERT_EQUAL(bmpstride, 104);
+  TEST_ASSERT_EQUAL(pngstride, 101);
+  TrmnlImage *image1 = TrmnlNewImage(width, height, bpp, bmpstride);
+  // fill with pattern
+  for (uint16_t h = 0; h < image1->height; ++h) {
+    memset(TrmnlGetRowData(image1, h), h % 256, image1->stride);
+  }
+  // copy with different stride, not flipped
+  TrmnlImage *image2 = TrmnlFromImage(image1);
+  TEST_ASSERT_EQUAL(image2->stride, pngstride);
+  // check that first byte for top and bottom row is the  same
+  TEST_ASSERT_EQUAL(*TrmnlGetRowData(image1, 0), *TrmnlGetRowData(image2, 0));
+  TEST_ASSERT_EQUAL(*TrmnlGetRowData(image1, height - 1),
+                    *TrmnlGetRowData(image2, height - 1));
+  TrmnlDeleteImage(image2);
+
+// copy with different stride, flipped (what happens for normal BMPs)
+  TrmnlImage *image3 = TrmnlFromImage(image1, true);
+  // check that first byte for top and bottom row are flipped
+  TEST_ASSERT_EQUAL(*TrmnlGetRowData(image1, 0), *TrmnlGetRowData(image3, height - 1));
+  TEST_ASSERT_EQUAL(*TrmnlGetRowData(image1, height - 1),
+                    *TrmnlGetRowData(image3, 0));
+  TrmnlDeleteImage(image3);
+  TrmnlDeleteImage(image1);
+}
+
+void setUp(void) {
+  // set stuff up here
+}
+
+void tearDown(void) {
+  // clean stuff up here
+}
+
+void process()
+{
+  UNITY_BEGIN();
+  RUN_TEST(test_ImageBasic);
+  RUN_TEST(test_ImageDifferentStrides);
+  UNITY_END();
+}
+
+int main(int argc, char **argv)
+{
+  process();
+  return 0;
+}


### PR DESCRIPTION
This is a first simple step to replace all "anonymous" memory block that hold a bitmap by some structured object.

With the TrmnImage structure, all image objects have  attached attributes and can be manipulated independently.

Future usages will be  image read from BMP or PNG sources, framebuffer for display, possible conversion between formats.
This will all;ow separation of payload buffer and image data.
It will also be used to read BMP as described in the format, with correct handling of both top-down and bottom-up variants, as well as decoding payload BMP not in 800x480x1 rigid required format (support for more BMP and PNG variants, for example some  palette PNG can be read and converted to grayscale on loading).

Unit test for basic checks.
Code is not used anywhere else than in the tests for now.