### PR TITLE
Standardize stream downloading behavior

### DIFF
--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -708,20 +708,20 @@ static https_request_err_e downloadAndShow()
             {
               Log.info("%s [%d]: Downloading... Available bytes: %d\r\n", __FILE__, __LINE__, stream->available());
               counter += stream->readBytes(buffer + counter, counter2 -= counter);
-              if (counter >= 2)
-              {
-                if (buffer[0] == 'B' && buffer[1] == 'M')
-                {
-                  isPNG = false;
-                  Log.info("BMP file detected");
-                }
-              }
               iteration_counter++;
             }
 
             delay(10);
           }
+
           Log.info("%s [%d]: Ending a download at: %d, in %d iterations\r\n", __FILE__, __LINE__, getTime(), iteration_counter);
+
+          if (counter >= 2 && buffer[0] == 'B' && buffer[1] == 'M')
+          {
+            isPNG = false;
+            Log.info("BMP file detected");
+          }
+
           if (counter != content_size)
           {
 

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -1587,7 +1587,7 @@ static void getDeviceCredentials()
               buffer = (uint8_t *)malloc(https.getSize());
               if (stream->available() && https.getSize() == DISPLAY_BMP_IMAGE_SIZE)
               {
-                counter = stream->readBytes(buffer, DISPLAY_BMP_IMAGE_SIZE);
+                counter = downloadStream(stream, DISPLAY_BMP_IMAGE_SIZE, buffer);
               }
               https.end();
               if (counter == DISPLAY_BMP_IMAGE_SIZE)


### PR DESCRIPTION
Extract a new `downloadStream()` helper and use it for both the `/api/display` image and the `/api/setup` one.

In particular, this allows the logo image download to loop and call `readBytes()` multiple times, where before it only got one chance.

I tested it on the device, and I can see both downloads working:

```
I: src/bl.cpp [1565]: filename - https://usetrmnl.com/images/setup/setup-logo.bmp
I: src/bl.cpp [1567]: [HTTPS] Request to https://usetrmnl.com/images/setup/setup-logo.bmp
I: src/bl.cpp [1570]: [HTTPS] GET..
E: src/bl.cpp [1578]: [HTTPS] GET... code: 200
I: src/bl.cpp [1582]: Content size: 48062
I: src/bl.cpp [893]: Downloading... Available bytes: 684
I: src/bl.cpp [900]: Download end: 48062/48062 bytes in 386 ms (1 iterations)
I: src/bl.cpp [1596]: Received successfully
```

```
I: src/bl.cpp [696]: Stream available: 5177
I: src/bl.cpp [700]: Starting a download at: 1748924003
I: src/bl.cpp [893]: Downloading... Available bytes: 5177
I: src/bl.cpp [900]: Download end: 5177/5177 bytes in 34 ms (1 iterations)
I: src/bl.cpp [723]: Received successfully
```