### PR TITLE
fix: reboot loop on API 202 response

### DIFF
--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -1030,8 +1030,8 @@ https_request_err_e handleApiDisplayResponse(ApiDisplayResponse &apiResponse)
     case 202:
     {
       result = HTTPS_NO_REGISTER;
-      Log.info("%s [%d]: write new refresh rate: %d\r\n", __FILE__, __LINE__, SLEEP_TIME_WHILE_NOT_CONNECTED);
-      size_t result = preferences.putUInt(PREFERENCES_SLEEP_TIME_KEY, SLEEP_TIME_WHILE_NOT_CONNECTED);
+      Log.info("%s [%d]: write new refresh rate: %d\r\n", __FILE__, __LINE__, apiResponse.refresh_rate);
+      size_t result = preferences.putUInt(PREFERENCES_SLEEP_TIME_KEY, apiResponse.refresh_rate);
       Log.info("%s [%d]: written new refresh rate: %d\r\n", __FILE__, __LINE__, result);
       status = false;
     }
@@ -1385,8 +1385,8 @@ https_request_err_e handleApiDisplayResponse(ApiDisplayResponse &apiResponse)
     case 202:
     {
       result = HTTPS_NO_REGISTER;
-      Log.info("%s [%d]: write new refresh rate: %d\r\n", __FILE__, __LINE__, SLEEP_TIME_WHILE_NOT_CONNECTED);
-      size_t result = preferences.putUInt(PREFERENCES_SLEEP_TIME_KEY, SLEEP_TIME_WHILE_NOT_CONNECTED);
+      Log.info("%s [%d]: write new refresh rate: %d\r\n", __FILE__, __LINE__, apiResponse.refresh_rate);
+      size_t result = preferences.putUInt(PREFERENCES_SLEEP_TIME_KEY, apiResponse.refresh_rate);
       Log.info("%s [%d]: written new refresh rate: %d\r\n", __FILE__, __LINE__, result);
       status = false;
     }


### PR DESCRIPTION
Hey there,

i'm not sure how my device ended up in this state. I remember during the first setup i got a `WiFi connected, TRMNL content malformed.` error message on the screen. After waiting for a while (at least 10min) i restarted my device and it entered a reboot loop. I was able to capture the following logs:

```
Reconnecting to /dev/cu.usbmodem101 ....         Connected!
I: src/bl.cpp [148]: Non-GPIO wakeup (4) -> didn't read buttons
I: src/bl.cpp [151]: preferences start
I: src/bl.cpp [155]: preferences init success (429 free entries)
I: src/bl.cpp [170]: preferences end
I: src/bl.cpp [224]: Display init
I: src/display.cpp [19]: dev module start
I: src/display.cpp [21]: dev module end
I: src/display.cpp [23]: screen hw start
e-Paper busy
e-Paper busy release
I: src/display.cpp [25]: screen hw end
I: src/filesystem.cpp [21]: SPIFFS mounted
I: src/bl.cpp [245]: Firmware version 1.5.5
I: src/bl.cpp [246]: Arduino version 2.0.17
I: src/bl.cpp [247]: ESP-IDF version 4.4.7
I: src/filesystem.cpp [206]: Filesystem Usage: 0/113201
I: src/bl.cpp [2158]: NVS Usage: 201/630 entries (31.90%)
I: src/bl.cpp [255]: WiFi saved
I: lib/wificaptive/src/WifiCaptive.cpp [571]: Trying to autoconnect to wifi...
I: lib/wificaptive/src/WifiCaptive.cpp [579]: Trying to connect to last used <redacted>...
I: lib/wificaptive/src/WifiCaptive.cpp [586]: Attempt 1 to connect to <redacted>
I: lib/wificaptive/src/WifiCaptive.cpp [592]: Connected to <redacted>
I: src/bl.cpp [258]: Connection result: 1, WiFI Status: 3
I: src/bl.cpp [264]:wifi_connection [DEBUG]: Connected: 2248146954
I: src/bl.cpp [1804]: Time synchronization...
I: src/bl.cpp [1810]: Time synchronization succeed!
I: src/bl.cpp [1817]: Current time - Sat Jun 14 12:19:59 2025

I: src/bl.cpp [328]: Time since last sleep: 9
I: src/bl.cpp [338]: API key and friendly ID saved
I: src/bl.cpp [577]: Hostname resolved to 157.230.59.36 on attempt 1
I: src/bl.cpp [516]: api_key key exists. Value - <redacted>
I: src/bl.cpp [526]: friendly_id key exists. Value - <redacted>
I: src/bl.cpp [538]: refresh_rate key exists. Value - 5
I: src/bl.cpp [1833]: Battery voltage reading...
I: lib/trmnl/include/http_client.h [25]: ==== withHttp() https://trmnl.app/api/display
I: src/api-client/display.cpp [25]: Added headers:
ID: <redacted>
Special function: 0
Access-Token: <redacted>
Refresh_Rate: 5
Battery-Voltage: 4.77
FW-Version: 1.5.5
RSSI: -76

I: src/api-client/display.cpp [88]: GET... code: 200
I: src/api-client/display.cpp [92]: Content size: 272
I: src/api-client/display.cpp [93]: Free heap size: 151540
I: src/api-client/display.cpp [94]: Payload - {"status":202,"image_url":"https://usetrmnl.com/images/setup/empty_state.png","filename":"empty_state","refresh_rate":903,"reset_firmware":false,"update_firmware":false,"firmware_url":"https://trmnl-fw.s3.us-east-2.amazonaws.com/FW1.5.5.bin","special_function":"identify"}
I: lib/trmnl/src/special_function.cpp [26]: New special function - identify
I: src/bl.cpp [911]: status: 202
I: src/bl.cpp [1033]: write new refresh rate: 5
I: src/bl.cpp [1035]: written new refresh rate: 4
I: lib/trmnl/include/http_client.h [25]: ==== withHttp() 
I: src/bl.cpp [878]: Returned result - 0
I: src/bl.cpp [345]: request result - 0
I: src/bl.cpp [392]: Connection done successfully. Retries counter reset.
I: src/display.cpp [495]: Goto Sleep...
e-Paper busy
e-Paper busy release
I: src/bl.cpp [1774]: time to sleep - 5
Disconnected (read failed: [Errno 6] Device not configured)
```

This loop would repeat every 5 seconds. I basically copied the refresh rate from the HTTP 200 response case because a 202 seemed something my device should accept.
With this fix my device entered normal functionality.

I'm not sure if this is the correct fix or if there is a better fix to address the root cause.