### PR TITLE
add exponential backoff to WiFi retries

### DIFF
--- a/lib/wificaptive/src/WifiCaptive.cpp
+++ b/lib/wificaptive/src/WifiCaptive.cpp
@@ -593,7 +593,13 @@ bool WifiCaptive::autoConnect()
                 return true;
             }
             WiFi.disconnect();
-            delay(500);
+            
+            // Exponential backoff: 2s, 4s, 8s delays between attempts
+            if (attempt < WIFI_CONNECTION_ATTEMPTS - 1) {
+                uint32_t backoff_delay = 2000 * (1 << attempt); // 2^attempt * 2000ms
+                Log_info("Connection failed, waiting %d ms before retry...", backoff_delay);
+                delay(backoff_delay);
+            }
         }
     }
 
@@ -638,7 +644,13 @@ bool WifiCaptive::autoConnect()
                 return true;
             }
             WiFi.disconnect();
-            delay(2000);
+            
+            // Exponential backoff: 2s, 4s, 8s delays between attempts
+            if (attempt < WIFI_CONNECTION_ATTEMPTS - 1) {
+                uint32_t backoff_delay = 2000 * (1 << attempt); // 2^attempt * 2000ms
+                Log_info("Connection failed, waiting %d ms before retry...", backoff_delay);
+                delay(backoff_delay);
+            }
         }
     }
 


### PR DESCRIPTION
Hi there,

i frequently got issues with both of my TRMNL, not being able to reconnect to my Wi-Fi. Getting `Can't establish WiFi connection.` error messages frequently.

I read somewhere online that the ESP32-C3 being a single core processor and frequently reconnecting to Wi-Fi is challenging. I added this exponential back-off to the Wi-Fi auto-connection and haven't seen any problems in the last 48 hrs. I usually got them after 5-6 hrs of operation.