### PR TITLE
Add button support for Waveshare E-Paper ESP32 Driver Board

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -54,7 +54,7 @@ enum WIFI_CONNECT_RETRY_TIME // Time to sleep before trying to connect to the Wi
 #define PIN_INTERRUPT 2
 #elif defined(BOARD_WAVESHARE_ESP32_DRIVER)
 #define PIN_RESET 25
-#define PIN_INTERRUPT 16
+#define PIN_INTERRUPT 33
 #define FAKE_BATTERY_VOLTAGE
 #elif defined(BOARD_SEEED_XIAO_ESP32C3)
 #define PIN_INTERRUPT 9

--- a/src/button.cpp
+++ b/src/button.cpp
@@ -11,6 +11,9 @@ ButtonPressResult read_button_presses()
   {
     auto elapsed = millis() - time_start;
     auto pin = digitalRead(PIN_INTERRUPT);
+  #if defined(BOARD_WAVESHARE_ESP32_DRIVER)
+    pin = !pin;
+  #endif
     if(pin == LOW && elapsed > BUTTON_SOFT_RESET_TIME){
       return SoftReset;
     }


### PR DESCRIPTION
This PR extends the functionality introduced in #122 by implementing hardware button support for DIY units based on the Waveshare E-Paper ESP32 Driver Board using the RTC pin 33 as an interrupt source.

### What I found out

So turns out ESP32 doesn't like `gpio_wakeup_enable` for waking from deep sleep. Spent some time debugging this until I tried `esp_sleep_enable_ext1_wakeup` - works like a charm now.

The catch is that RTC wakeup needs the button pulled to GND, so I had to flip the logic in `read_button_presses()`. Not a big deal, just something to keep in mind.

### What works

Tested both long press and double click - everything's working smoothly. The unit wakes up from deep sleep reliably which was my main concern.

Let me know if you need me to test anything else or if you have questions about the implementation.