### PR TITLE
Revised log payload

### DIFF
--- a/lib/trmnl/src/serialize_log.cpp
+++ b/lib/trmnl/src/serialize_log.cpp
@@ -6,30 +6,25 @@ String serialize_log(const LogWithDetails &input)
 {
   JsonDocument json_log;
 
-  json_log["creation_timestamp"] = input.timestamp;
+  json_log["created_at"] = input.timestamp;
+  json_log["id"] = input.logId;
+  json_log["message"] = input.logMessage;
+  json_log["source_line"] = input.codeline;
+  json_log["source_path"] = input.sourceFile;
 
-  json_log["device_status_stamp"]["wifi_rssi_level"] = input.deviceStatusStamp.wifi_rssi_level;
-  json_log["device_status_stamp"]["wifi_status"] = input.deviceStatusStamp.wifi_status;
-  json_log["device_status_stamp"]["refresh_rate"] = input.deviceStatusStamp.refresh_rate;
-  json_log["device_status_stamp"]["time_since_last_sleep_start"] = input.deviceStatusStamp.time_since_last_sleep;
-  json_log["device_status_stamp"]["current_fw_version"] = input.deviceStatusStamp.current_fw_version;
-  json_log["device_status_stamp"]["special_function"] = input.deviceStatusStamp.special_function;
-  json_log["device_status_stamp"]["battery_voltage"] = input.deviceStatusStamp.battery_voltage;
-  json_log["device_status_stamp"]["wakeup_reason"] = input.deviceStatusStamp.wakeup_reason;
-  json_log["device_status_stamp"]["free_heap_size"] = input.deviceStatusStamp.free_heap_size;
-  json_log["device_status_stamp"]["max_alloc_size"] = input.deviceStatusStamp.max_alloc_size;
-
-  json_log["log_id"] = input.logId;
-  json_log["log_message"] = input.logMessage;
-  json_log["log_codeline"] = input.codeline;
-  json_log["log_sourcefile"] = input.sourceFile;
-
-  json_log["additional_info"]["filename_current"] = input.filenameCurrent;
-  json_log["additional_info"]["filename_new"] = input.filenameNew;
+  json_log["wifi_signal"] = input.deviceStatusStamp.wifi_rssi_level;
+  json_log["wifi_status"] = input.deviceStatusStamp.wifi_status;
+  json_log["refresh_rate"] = input.deviceStatusStamp.refresh_rate;
+  json_log["sleep_duration"] = input.deviceStatusStamp.time_since_last_sleep;
+  json_log["firmware_version"] = input.deviceStatusStamp.current_fw_version;
+  json_log["special_function"] = input.deviceStatusStamp.special_function;
+  json_log["battery_voltage"] = input.deviceStatusStamp.battery_voltage;
+  json_log["wake_reason"] = input.deviceStatusStamp.wakeup_reason;
+  json_log["free_heap_size"] = input.deviceStatusStamp.free_heap_size;
 
   if (input.logRetry)
   {
-    json_log["additional_info"]["retry_attempt"] = input.retryAttempt;
+    json_log["retry"] = input.retryAttempt;
   }
 
   String json_string;

--- a/lib/trmnl/src/serialize_request_api_log.cpp
+++ b/lib/trmnl/src/serialize_request_api_log.cpp
@@ -2,5 +2,5 @@
 
 String serializeApiLogRequest(String log_buffer)
 {
-  return "{\"log\":{\"logs_array\":[" + log_buffer + "]}}";
+  return "{\"logs\":[" + log_buffer + "]}";
 }

--- a/test/test_serialize_api_log/serialize_api_log.test.cpp
+++ b/test/test_serialize_api_log/serialize_api_log.test.cpp
@@ -16,7 +16,7 @@ String compact(String input)
 
 void test_serialize_one_log(void)
 {
-  auto expected = String("{\"log\":{\"logs_array\":[{\"foo\":\"bar\"}]}}");
+  auto expected = String("{\"logs\":[{\"foo\":\"bar\"}]}");
   auto result = serializeApiLogRequest("{\"foo\":\"bar\"}");
 
   TEST_ASSERT_EQUAL_STRING(expected.c_str(), result.c_str());
@@ -24,7 +24,7 @@ void test_serialize_one_log(void)
 
 void test_serialize_multiple_logs(void)
 {
-  auto expected = String("{\"log\":{\"logs_array\":[{\"foo\":\"bar\"},{\"foo\":\"baz\"}]}}");
+  auto expected = String("{\"logs\":[{\"foo\":\"bar\"},{\"foo\":\"baz\"}]}");
   auto result = serializeApiLogRequest("{\"foo\":\"bar\"},{\"foo\":\"baz\"}");
 
   TEST_ASSERT_EQUAL_STRING(expected.c_str(), result.c_str());

--- a/test/test_serialize_log/serialize_log.test.cpp
+++ b/test/test_serialize_log/serialize_log.test.cpp
@@ -41,27 +41,20 @@ String compact(String input)
 void test_serialize_log(void)
 {
   auto expected = compact(R"({
-    "creation_timestamp": 1609459200,
-    "device_status_stamp": {
-      "wifi_rssi_level": -50,
-      "wifi_status": "Connected",
-      "refresh_rate": 30000,
-      "time_since_last_sleep_start": 120,
-      "current_fw_version": "1.2.3",
-      "special_function": "None",
-      "battery_voltage": 4.2,
-      "wakeup_reason": "Timer",
-      "free_heap_size": 50000,
-      "max_alloc_size": 40000
-    },
-    "log_id": 456,
-    "log_message": "Test log message",
-    "log_codeline": 123,
-    "log_sourcefile": "test.cpp",
-    "additional_info": {
-      "filename_current": "current.png",
-      "filename_new": "new.png"
-    }
+    "created_at": 1609459200,
+    "id": 456,
+    "message": "Test log message",
+    "source_line": 123,
+    "source_path": "test.cpp",
+    "wifi_signal": -50,
+    "wifi_status": "Connected",
+    "refresh_rate": 30000,
+    "sleep_duration": 120,
+    "firmware_version": "1.2.3",
+    "special_function": "None",
+    "battery_voltage": 4.2,
+    "wake_reason": "Timer",
+    "free_heap_size": 50000
   })");
 
   auto result = serialize_log(input);
@@ -76,28 +69,21 @@ void test_serialize_log_with_retry(void)
   inputWithRetry.retryAttempt = 2;
 
   auto expected = compact(R"({
-    "creation_timestamp": 1609459200,
-    "device_status_stamp": {
-      "wifi_rssi_level": -50,
-      "wifi_status": "Connected",
-      "refresh_rate": 30000,
-      "time_since_last_sleep_start": 120,
-      "current_fw_version": "1.2.3",
-      "special_function": "None",
-      "battery_voltage": 4.2,
-      "wakeup_reason": "Timer",
-      "free_heap_size": 50000,
-      "max_alloc_size": 40000
-    },
-    "log_id": 456,
-    "log_message": "Test log message",
-    "log_codeline": 123,
-    "log_sourcefile": "test.cpp",
-    "additional_info": {
-      "filename_current": "current.png",
-      "filename_new": "new.png",
-      "retry_attempt": 2
-    }
+    "created_at": 1609459200,
+    "id": 456,
+    "message": "Test log message",
+    "source_line": 123,
+    "source_path": "test.cpp",
+    "wifi_signal": -50,
+    "wifi_status": "Connected",
+    "refresh_rate": 30000,
+    "sleep_duration": 120,
+    "firmware_version": "1.2.3",
+    "special_function": "None",
+    "battery_voltage": 4.2,
+    "wake_reason": "Timer",
+    "free_heap_size": 50000,
+    "retry": 2
   })");
 
   String result = serialize_log(inputWithRetry);


### PR DESCRIPTION
Closes #99.

Here's a log of it working:
```
I: lib/trmnl/include/http_client.h [25]: ==== withHttp() https://trmnl.app/api/log
I: src/api-client/submit_log.cpp [25]: [HTTPS] POST...
I: src/api-client/submit_log.cpp [37]: Send log - {"logs":[{"created_at":1751432214,"id":5,"message":"Hello, world! This is a test of the new log format.","source_line":336,"source_path":"src/bl.cpp","wifi_signal":-50,"wifi_status":"connected","refresh_rate":906,"sleep_duration":151,"firmware_version":"1.5.9","special_function":"none","battery_voltage":4.778,"wake_reason":"powercycle","free_heap_size":217112}]}
I: src/api-client/submit_log.cpp [54]: [HTTPS] POST OK, code: 204
```

Server implementations will need to change to support this, including core:

<img width="465" alt="image" src="https://github.com/user-attachments/assets/a8b0fdf1-2948-4092-83fa-03435c250991" />

