### PR TITLE
Breakpoint typo

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -80,7 +80,7 @@ board_build.filesystem = spiffs
 build_flags =
 	-D CORE_DEBUG_LEVEL=0
 lib_ldf_mode = deep
-debug_init_break = break setupy
+debug_init_break = break setup
 
 [env:esp32-c3-devkitc-02]
 extends = env:esp32_base


### PR DESCRIPTION
Looks like this is a typo, since there is no symbol `setupy` and `setup` is a typical configuration.