### PR TITLE
fix for https://github.com/usetrmnl/trmnl-firmware/issues/252

### DIFF
--- a/lib/trmnl/src/bmp.cpp
+++ b/lib/trmnl/src/bmp.cpp
@@ -23,6 +23,8 @@ bmp_err_e parseBMPHeader(uint8_t *data, bool &reversed)
   uint32_t compressionMethod = *(uint32_t *)&data[30];
   uint32_t imageDataSize = *(uint32_t *)&data[34];
   uint32_t colorTableEntries = *(uint32_t *)&data[46];
+ 
+  if (colorTableEntries == 0) colorTableEntries = (1 << bitsPerPixel);
 
   if (width != 800 || height != 480 || bitsPerPixel != 1 || imageDataSize != 48000 || colorTableEntries != 2)
     return BMP_BAD_SIZE;


### PR DESCRIPTION
BMP spec allows num_colors  = 0 (means 1 << bitsperpixel)

see  https://en.wikipedia.org/wiki/BMP_file_format

<img width="814" height="113" alt="image" src="https://github.com/user-attachments/assets/ebb473ef-d859-4d17-bf36-b4252d2124a1" />
