### PR TITLE
Fix HTTP client leaving open connections on server

### DIFF
--- a/lib/trmnl/include/http_client.h
+++ b/lib/trmnl/include/http_client.h
@@ -52,6 +52,7 @@ ReturnType withHttp(const String &url, Callback callback)
     HTTPClient https;
     if (https.begin(*client, url))
     {
+      https.setReuse(false);  // Disable keep-alive to ensure connection closes properly
       result = callback(&https, HTTPCLIENT_SUCCESS);
       https.end();
     }
@@ -60,6 +61,7 @@ ReturnType withHttp(const String &url, Callback callback)
       result = callback(nullptr, HTTPCLIENT_HTTPCLIENT_ERROR);
     }
   }
+  client->stop();  // Explicitly close TCP socket before deleting
   delete client;
 
   return result;


### PR DESCRIPTION
## Background

The ESP `HTTPClient` class defaults to requesting HTTP keep-alive connections (`Connection: keep-alive` header). This tells the server to hold the TCP connection open for potential reuse.

However, `withHttp()` creates a fresh `WiFiClientSecure` for each request - it never reuses the previous connection. The result: each request opens a new TCP socket while the server dutifully keeps all the previous connections alive, waiting for reuse that will never come.

Over time these orphaned connections accumulate. Once the server hits its connection limit, it starts refusing new connections - causing intermittent request failures that can be tricky to diagnose.

## The Fix

Setting `setReuse(false)` sends `Connection: close` instead, signaling the server to close the connection after responding. This ensures clean connection teardown and prevents the accumulation.

(The `client->stop()` call is included for completeness, though the underlying implementation treats it as a no-op since the HTTP layer handles the socket lifecycle.)

## Test plan
- [x] Verify HTTP requests complete successfully
- [x] Monitor server to confirm connections are properly closed after requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)