### PR TITLE
Add grouping for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,12 @@
 
 version: 2
 updates:
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
-
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adding grouping so that dependabot will group all the updates into a single PR