### PR TITLE
scoped getString

### DIFF
--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -731,6 +731,7 @@ static https_request_err_e downloadAndShow()
           heap_caps_check_integrity_all(true);
 
           // getString() handles chunked transfer encoding automatically
+          {
           String payload = https.getString();
           counter = payload.length();
 
@@ -756,6 +757,7 @@ static https_request_err_e downloadAndShow()
 
           memcpy(buffer, payload.c_str(), counter);
           content_size = counter;
+          }
 
           if (counter >= 2 && buffer[0] == 'B' && buffer[1] == 'M')
           {


### PR DESCRIPTION
fix for https://github.com/usetrmnl/trmnl-firmware/issues/266
using getString consumes much more memory than previous code so while double allocation of payload size is "fixed", max payod sze  is reduxcesd from 90000 to maybe 65000.

Hopefully max png size for 800x480x2bit should stay under this limit, my current largest is 61274 