### PR TITLE
Skip loading screen on button wake-up

### DIFF
--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -246,15 +246,9 @@ void bl_init(void)
 
   if (wakeup_reason != ESP_SLEEP_WAKEUP_TIMER)
   {
-    Log.info("%s [%d]: Display TRMNL logo start\r\n", __FILE__, __LINE__);
-
-  
-    display_show_image(storedLogoOrDefault(1), DEFAULT_IMAGE_SIZE, false);
-
-
+    Log.info("%s [%d]: Button wake-up, skip loading screen\r\n", __FILE__, __LINE__);
     need_to_refresh_display = 1;
     preferences.putBool(PREFERENCES_DEVICE_REGISTERED_KEY, false);
-    Log.info("%s [%d]: Display TRMNL logo end\r\n", __FILE__, __LINE__);
     preferences.putString(PREFERENCES_FILENAME_KEY, "");
   }
 


### PR DESCRIPTION
## Summary

- Remove the `display_show_image()` call on button wake-up in `bl.cpp`, eliminating one full e-ink refresh
- On color panels (Spectra 6), `bWait=1` is forced for all refreshes, making the loading logo display very slow — pressing the wake button previously caused two slow full refreshes back-to-back
- Now the device goes directly to downloading and displaying the new image (1 refresh instead of 2)

## Details

The preference resets (`PREFERENCES_DEVICE_REGISTERED_KEY`, `PREFERENCES_FILENAME_KEY`) and `need_to_refresh_display` flag are preserved, so the download logic works unchanged. If the download fails, existing error handling already shows the appropriate message (`MSG_TOO_BIG`, `WIFI_FAILED`, `FRIENDLY_ID`, etc.).

## Test plan

- [ ] Flash firmware to reTerminal E1002 (Spectra 6 panel)
- [ ] Press the wake/reset button — display should go directly to downloading new content without first showing loading logo
- [ ] Disconnect WiFi and press wake button — verify appropriate error message is displayed
- [ ] Verify timer-based wake-up is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)