### PR TITLE
Fix broken redirect URL handling for custom API servers

### DIFF
--- a/src/api-client/display.cpp
+++ b/src/api-client/display.cpp
@@ -82,9 +82,13 @@ ApiDisplayResult fetchApiDisplay(ApiDisplayInputs &apiDisplayInputs)
         Log_info("Start location: %s", https->getLocation().c_str());
         int httpCode = https->GET();
         if(httpCode == HTTP_CODE_PERMANENT_REDIRECT ||httpCode == HTTP_CODE_TEMPORARY_REDIRECT){
+              String location = https->getLocation();
               https->end();
-              https->begin(API_BASE_URL + https->getLocation());
-              Log_info("Redirected to: %s", https->getLocation().c_str());
+              String redirectUrl = (location.startsWith("http://") || location.startsWith("https://"))
+                  ? location
+                  : (apiDisplayInputs.baseUrl + location);
+              https->begin(redirectUrl);
+              Log_info("Redirected to: %s", redirectUrl.c_str());
               https->setTimeout(15000);
               https->setConnectTimeout(15000);
               addHeaders(*https, apiDisplayInputs);

--- a/src/api-client/submit_log.cpp
+++ b/src/api-client/submit_log.cpp
@@ -39,8 +39,12 @@ bool submitLogToApi(LogApiInput &input, const char *api_url)
                     // start connection and send HTTP header
                     int httpCode = https.POST(payload);
                     if(httpCode == HTTP_CODE_PERMANENT_REDIRECT || httpCode == HTTP_CODE_TEMPORARY_REDIRECT){
+                      String location = https.getLocation();
                       https.end();
-                      https.begin(String(api_url) + https.getLocation());
+                      String redirectUrl = (location.startsWith("http://") || location.startsWith("https://"))
+                          ? location
+                          : (String(api_url) + location);
+                      https.begin(redirectUrl);
                       https.addHeader("ID", WiFi.macAddress());
                       https.addHeader("Accept", "application/json, */*");
                       https.addHeader("Access-Token", input.api_key);

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -687,9 +687,23 @@ static https_request_err_e downloadAndShow()
           int content_size = https.getSize();
           if(httpCode == HTTP_CODE_PERMANENT_REDIRECT ||
             httpCode == HTTP_CODE_TEMPORARY_REDIRECT){
+              String location = https.getLocation();
               https.end();
-              https.begin(API_BASE_URL +https.getLocation());
-              Log_info("Redirected to: %s", https.getLocation().c_str());
+              String redirectUrl;
+              if (location.startsWith("http://") || location.startsWith("https://")) {
+                redirectUrl = location;
+              } else {
+                // Extract origin from the original image URL for relative redirects
+                String origin = String(filename);
+                int schemeEnd = origin.indexOf("://");
+                if (schemeEnd != -1) {
+                  int pathStart = origin.indexOf('/', schemeEnd + 3);
+                  if (pathStart != -1) origin = origin.substring(0, pathStart);
+                }
+                redirectUrl = origin + location;
+              }
+              https.begin(redirectUrl);
+              Log_info("Redirected to: %s", redirectUrl.c_str());
               https.setTimeout(15000);
               https.setConnectTimeout(15000);
               httpCode = https.GET();


### PR DESCRIPTION
## Summary

- Redirect handlers in three locations (`src/api-client/display.cpp`, `src/api-client/submit_log.cpp`, `src/bl.cpp`) were unconditionally prepending a base URL to the `Location` header value on 301/307 redirects.
- When the server returns an **absolute** redirect URL (the common case), this produced a malformed URL like `https://trmnl.apphttps://other.com/path`.
- When a **custom API server** was configured via the captive portal, relative redirects were incorrectly resolved against the hardcoded `API_BASE_URL` (`https://trmnl.app`) instead of the configured server.
- Each redirect handler now checks whether the `Location` header is absolute (starts with `http://` or `https://`). If so, it is used directly. If relative, the correct context-specific base URL is prepended.

## Files changed

- `src/api-client/display.cpp` — `/api/display` fetch: use `apiDisplayInputs.baseUrl` instead of `API_BASE_URL`
- `src/api-client/submit_log.cpp` — `/api/log` POST: use the passed `api_url` parameter (was already correct for relative, now also correct for absolute)
- `src/bl.cpp` — Image download: extract origin from the original image URL for relative redirects, use absolute `Location` directly

## Test plan

- [ ] Configure a custom API server via the captive portal and verify `/api/display` redirects resolve correctly
- [ ] Verify image download redirects (both absolute and relative `Location` headers) produce valid URLs
- [ ] Verify log submission redirects work with both default and custom API servers
- [ ] Confirm no regression when using the default `https://trmnl.app` server with no redirects


Made with [Cursor](https://cursor.com)