### PR TITLE
Add fine-grained Update-Source header for /api/display requests

### DIFF
--- a/lib/trmnl/include/api_types.h
+++ b/lib/trmnl/include/api_types.h
@@ -50,6 +50,7 @@ struct ApiDisplayInputs
   String baseUrl;
   String apiKey;
   String friendlyId;
+  String updateSource;
   uint32_t refreshRate;
   String macAddress;
   float batteryVoltage;

--- a/lib/trmnl/src/logging_parsers.cpp
+++ b/lib/trmnl/src/logging_parsers.cpp
@@ -40,13 +40,21 @@ static const WakeupReasonNode wakeupReasonMap[] = {
 
 bool parseWakeupReasonToStr(char *buffer, size_t buffer_size, esp_sleep_source_t wakeup_reason)
 {
+  if (buffer == nullptr || buffer_size == 0)
+  {
+    return false;
+  }
+
   for (const WakeupReasonNode &entry : wakeupReasonMap)
   {
     if (wakeup_reason == entry.value)
     {
       strncpy(buffer, entry.name, buffer_size);
+      buffer[buffer_size - 1] = '\0';
       return true;
     }
   }
+
+  buffer[0] = '\0';
   return false;
 }

--- a/src/api-client/display.cpp
+++ b/src/api-client/display.cpp
@@ -11,6 +11,7 @@ void addHeaders(HTTPClient &https, ApiDisplayInputs &inputs)
   Log_info("Added headers:\n\r"
            "ID: %s\n\r"
            "Special function: %d\n\r"
+           "Update-Source: %s\n\r"
            "Access-Token: %s\n\r"
            "Refresh_Rate: %s\n\r"
            "Battery-Voltage: %s\n\r"
@@ -20,6 +21,7 @@ void addHeaders(HTTPClient &https, ApiDisplayInputs &inputs)
            "temperature-profile:true\r\n",
            inputs.macAddress.c_str(),
            inputs.specialFunction,
+           inputs.updateSource.c_str(),
            inputs.apiKey.c_str(),
            String(inputs.refreshRate).c_str(),
            String(inputs.batteryVoltage).c_str(),
@@ -29,6 +31,7 @@ void addHeaders(HTTPClient &https, ApiDisplayInputs &inputs)
 
   https.addHeader("ID", inputs.macAddress);
   https.addHeader("Content-Type", "application/json");
+  https.addHeader("Update-Source", inputs.updateSource);
   https.addHeader("Access-Token", inputs.apiKey);
   https.addHeader("Refresh-Rate", String(inputs.refreshRate));
   https.addHeader("Battery-Voltage", String(inputs.batteryVoltage));

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -538,6 +538,16 @@ ApiDisplayInputs loadApiDisplayInputs(Preferences &preferences)
 
   inputs.baseUrl = preferences.getString(PREFERENCES_API_URL, API_BASE_URL);
 
+  char wakeupReasonString[32] = {0};
+  if (parseWakeupReasonToStr(wakeupReasonString, sizeof(wakeupReasonString), (esp_sleep_source_t)wakeup_reason))
+  {
+    inputs.updateSource = String(wakeupReasonString);
+  }
+  else
+  {
+    inputs.updateSource = "unknown";
+  }
+
   if (preferences.isKey(PREFERENCES_API_KEY))
   {
     inputs.apiKey = preferences.getString(PREFERENCES_API_KEY, PREFERENCES_API_KEY_DEFAULT);


### PR DESCRIPTION
Problem: server cannot distinguish refresh trigger granularity.
Solution: use parseWakeupReasonToStr to send wake reason as Update-Source header.
Validation: compiles clean, uploaded to TRMNL_7inch5_OG_DIY_Kit and verified header is sent.