### PR TITLE
Fixed download issue that Terminus made happen more frequently

### DIFF
--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -848,11 +848,9 @@ static https_request_err_e downloadAndShow()
 
               buffer = (uint8_t *)malloc(counter);
               if (buffer) {
-                while (iCount < counter && millis() < (lStartTime + API_FIRST_RETRY*1000) && stream->connected()) {
-                  iLen = stream->available();
-                  if (iLen) {
-                    stream->readBytes(&buffer[iCount], iLen);
-                    iCount += iLen;
+                while (iCount < counter && millis() < (lStartTime + API_FIRST_RETRY*1000)) {
+                  if (stream->available()) {
+                    buffer[iCount++] = stream->read();
                   } else {
                     vTaskDelay(1); // yield to allow time for the data to arrive
                   }


### PR DESCRIPTION
This problem is due to the ESP32 HTTP library not returning the number of bytes requested and the HTTP connection closing (probably by the server) BEFORE the data has fully been read out. The two changes to the download logic: reading 1 byte at a time and ignoring the connection status, fix the issue 