### PR TITLE
Fixed regression - don't refresh the display upon wakeup if the playlist has 1 entry

### DIFF
--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -70,6 +70,7 @@ esp_sleep_wakeup_cause_t wakeup_reason = ESP_SLEEP_WAKEUP_UNDEFINED; // wake-up 
 MSG current_msg = NONE;
 SPECIAL_FUNCTION special_function = SF_NONE;
 RTC_DATA_ATTR uint8_t need_to_refresh_display = 1;
+RTC_DATA_ATTR char szPrevName[36] = {0};
 extern int iTempProfile;
 Preferences preferences;
 PreferencesPersistence preferencesPersistence(preferences);
@@ -316,7 +317,9 @@ void bl_init(void)
 
   
     display_show_image(storedLogoOrDefault(1), DEFAULT_IMAGE_SIZE, false);
-
+    // Force the display to show the current playlist image after the loading screen
+    // (even if it hasn't changed)
+    szPrevName[0] = 0;
 
     need_to_refresh_display = 1;
     preferences.putBool(PREFERENCES_DEVICE_REGISTERED_KEY, false);
@@ -708,6 +711,13 @@ static https_request_err_e downloadAndShow()
   if (!status && result == HTTPS_SUCCESS) { // this means we already have this image stored in SPIFFS
       char szTemp[36];
       fixFileName(apiDisplayResult.response.filename.c_str(), szTemp);
+      if (strcmp(szTemp, szPrevName) == 0) {
+        // We just displayed the same image, don't refresh the display
+        Log.info("%s [%d]: The image hasn't changed since the last wakeup, don't refresh the display.\r\n", __FILE__, __LINE__);
+        buffer = nullptr;
+        return result;
+      }
+      strcpy(szPrevName, szTemp); // save the filename to compare on the next wakeup
       Log.info("%s [%d]: Reading %s from SPIFFS\r\n", __FILE__, __LINE__, szTemp);
       size_t content_size = filesystem_read_and_allocate(szTemp, &buffer);
       Log.info("%s [%d]: Decoding image...\r\n", __FILE__, __LINE__);


### PR DESCRIPTION
A customer with 1 entry in the playlist has asked that the display doesn't refresh every time the device wakes up. This change checks if the previous image is the same as the current and skip the display refresh if they're the same.