### PR TITLE
feat: add Xteink X3 board support (BOARD_XTEINK_X3)

### DIFF
--- a/.github/workflows/publish-firmware.yml
+++ b/.github/workflows/publish-firmware.yml
@@ -59,7 +59,7 @@ jobs:
         run: cp .pio/build/trmnl/firmware.bin ${{ env.APP_FIRMWARE_FILE }}
 
       - name: Upload firmware artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: firmware images
           path: "*.bin"

--- a/include/config.h
+++ b/include/config.h
@@ -2,8 +2,8 @@
 #define CONFIG_H
 
 #define FW_MAJOR_VERSION 1
-#define FW_MINOR_VERSION 7
-#define FW_PATCH_VERSION 8
+#define FW_MINOR_VERSION 8
+#define FW_PATCH_VERSION 0
 
 // Helper macros for stringification
 #define STRINGIFY(x) #x

--- a/include/config.h
+++ b/include/config.h
@@ -37,8 +37,13 @@
 
 #define WIFI_CONNECTION_RSSI (-100)
 
+#ifdef BOARD_XTEINK_X3
+#define DISPLAY_BMP_IMAGE_SIZE 52334 // 62-byte header + 52272 bytes bitmap (792*528 1bpp / 8)
+#define DEFAULT_IMAGE_SIZE 52272
+#else
 #define DISPLAY_BMP_IMAGE_SIZE 48062 // in bytes - 62 bytes - header; 48000 bytes - bitmap (480*800 1bpp) / 8
 #define DEFAULT_IMAGE_SIZE 48000
+#endif
 #ifdef BOARD_TRMNL_X
 #define MAX_IMAGE_SIZE 750000 // Use PSRAM on the ESP32-S3
 #else
@@ -76,6 +81,9 @@ enum WIFI_CONNECT_RETRY_TIME // Time to sleep before trying to connect to the Wi
 #define DEVICE_MODEL "og"
 #elif defined(BOARD_XTEINK_X4)
 #define DEVICE_MODEL "XTEINK_X4"
+#define PIN_INTERRUPT 3
+#elif defined(BOARD_XTEINK_X3)
+#define DEVICE_MODEL "XTEINK_X3"
 #define PIN_INTERRUPT 3
 #elif defined(BOARD_TRMNL_X)
 #define PIN_INTERRUPT 0
@@ -119,7 +127,7 @@ enum WIFI_CONNECT_RETRY_TIME // Time to sleep before trying to connect to the Wi
 
 #if defined(BOARD_XIAO_EPAPER_DISPLAY) || defined(BOARD_SEEED_RETERMINAL_E1001) || defined(BOARD_SEEED_RETERMINAL_E1002)
 #define PIN_BATTERY 1
-#elif defined(BOARD_XTEINK_X4)
+#elif defined(BOARD_XTEINK_X4) || defined(BOARD_XTEINK_X3)
 #define PIN_BATTERY 0
 #else
 #define PIN_BATTERY 3

--- a/platformio.ini
+++ b/platformio.ini
@@ -11,7 +11,7 @@ lib_deps =
 	bblanchon/ArduinoJson@7.4.2
 	bitbank2/PNGdec@^1.1.6
 	bitbank2/JPEGDEC@^1.8.4
-	https://github.com/bitbank2/bb_epaper.git#5aaf81fddec42c7775b0599e80808498aee3168b
+	https://github.com/bitbank2/bb_epaper.git#3d3df73aa25b5788acc7a62d8236f5129c812ede
 
 ; Dependencies for all device builds
 [deps_app]

--- a/platformio.ini
+++ b/platformio.ini
@@ -146,6 +146,16 @@ build_flags =
 	-D PNG_MAX_BUFFERED_PIXELS=6432
 	-D ARDUINOJSON_ENABLE_ARDUINO_STRING=1
 
+[env:xteink_x3]
+extends = env:esp32-c3-devkitc-02
+custom_include_git_hash = true
+extra_scripts = scripts/git_version.py
+build_flags =
+	${env:esp32_base.build_flags}
+	-D BOARD_XTEINK_X3
+	-D PNG_MAX_BUFFERED_PIXELS=6336
+	-D ARDUINOJSON_ENABLE_ARDUINO_STRING=1
+
 [env:local]
 extends = env:trmnl
 custom_include_git_hash = true

--- a/src/DEV_Config.h
+++ b/src/DEV_Config.h
@@ -76,6 +76,14 @@
   #define EPD_DC_PIN   4
   #define EPD_BUSY_PIN 6
 
+#elif defined(BOARD_XTEINK_X3)
+  #define EPD_SCK_PIN  8
+  #define EPD_MOSI_PIN 10
+  #define EPD_CS_PIN   21
+  #define EPD_RST_PIN  5
+  #define EPD_DC_PIN   4
+  #define EPD_BUSY_PIN 6
+
 #elif defined(BOARD_WAVESHARE_ESP32_DRIVER)
    // Pin definition for Waveshare ESP32 Driver Board
    #define EPD_SCK_PIN  13

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -1993,7 +1993,7 @@ static void goToSleep(void)
 #else
 #error "Unsupported ESP32 target for GPIO wakeup configuration"
 #endif
-#ifdef BOARD_XTEINK_X4
+#if defined(BOARD_XTEINK_X4) || defined(BOARD_XTEINK_X3)
   gpio_hold_en(GPIO_NUM_13); // MOSFET enabling the battery power
   gpio_deep_sleep_hold_en(); // Needed to keep the battery power enabled during RTC sleep
 #endif

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -70,7 +70,7 @@ esp_sleep_wakeup_cause_t wakeup_reason = ESP_SLEEP_WAKEUP_UNDEFINED; // wake-up 
 MSG current_msg = NONE;
 SPECIAL_FUNCTION special_function = SF_NONE;
 RTC_DATA_ATTR uint8_t need_to_refresh_display = 1;
-
+extern int iTempProfile;
 Preferences preferences;
 PreferencesPersistence preferencesPersistence(preferences);
 StoredLogs storedLogs(LOG_MAX_NOTES_NUMBER / 2, LOG_MAX_NOTES_NUMBER / 2, PREFERENCES_LOG_KEY, PREFERENCES_LOG_BUFFER_HEAD_KEY, preferencesPersistence);
@@ -1075,6 +1075,7 @@ https_request_err_e handleApiDisplayResponse(ApiDisplayResponse &apiResponse)
       String firmware_url = apiResponse.firmware_url;
       uint64_t rate = apiResponse.refresh_rate;
       reset_firmware = apiResponse.reset_firmware;
+      iTempProfile = apiResponse.temp_profile;
 
       bool sleep_5_seconds = false;
 
@@ -1168,6 +1169,11 @@ https_request_err_e handleApiDisplayResponse(ApiDisplayResponse &apiResponse)
         Log.info("%s [%d]: write new refresh rate: %d\r\n", __FILE__, __LINE__, rate);
         preferences.putUInt(PREFERENCES_SLEEP_TIME_KEY, rate);
         Log.info("%s [%d]: written new refresh rate: %d\r\n", __FILE__, __LINE__, result);
+      }
+      Log.info("%s [%d]: temp_profile: %d\r\n", __FILE__, __LINE__, iTempProfile);
+      if (iTempProfile != preferences.getUInt(PREFERENCES_TEMP_PROFILE, TEMP_PROFILE_DEFAULT)) {
+        Log_info("Saving new temperature profile (%d) to FLASH", iTempProfile);
+        preferences.putUInt(PREFERENCES_TEMP_PROFILE, iTempProfile);
       }
 
       if (reset_firmware)

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -844,10 +844,14 @@ int png_draw(PNGDRAW *pDraw)
                 }
             } // for x
         } else { // normal 0/1 split plane
-            ucMask = (iPlane == PNG_2_BIT_0) ? 0x40 : 0x80; // lower or upper source bit
+            const uint8_t ucTranslate[4] = {0, 2, 1, 3}; // translate grays to odd order of native 4-gray mode on 7.5" panel
+            const uint8_t ucNoTranslate[4] = {0, 1, 2, 3}; // for other 2-bit panels
+            uint8_t ucPT = bbep.getPanelType();
+            const uint8_t *pTranslate = (ucPT == EP75_800x480_4GRAY || ucPT == EP75_800x480_4GRAY_GEN2) ? ucTranslate : ucNoTranslate;
+            ucMask = (iPlane == PNG_2_BIT_0) ? 0x1 : 0x2; // lower or upper source bit
             for (x=0; x<iWidth; x++) {
                 uc <<= 1;
-                if (src & ucMask) {
+                if (pTranslate[src>>6] & ucMask) {
                     uc |= 1; // high bit of source pair
                 }
                 src <<= 2;
@@ -1262,6 +1266,7 @@ PNG *png = new PNG();
                     png->decode(&iPlane, 0);
                 } // temp profile needs the second plane written
             } else { // 2-bpp (or greater, but reduced to 2-bpp)
+                Log_info("%s [%d]: Using temp profile %d\r\n", __FILE__, __LINE__, iTempProfile);
                 bbep.setPanelType(dpList[iTempProfile].TwoBit);
                 rc = REFRESH_FULL; // 4gray mode must be full refresh
                 iUpdateCount = 0; // grayscale mode resets the partial update counter
@@ -1383,11 +1388,6 @@ void display_show_image(uint8_t *image_buffer, int data_size, bool bWait)
     }
     Log_info("Display refresh start");
 #ifdef BB_EPAPER
-    if (iTempProfile != apiDisplayResult.response.temp_profile) {
-        iTempProfile = apiDisplayResult.response.temp_profile;
-        Log_info("Saving new temperature profile (%d) to FLASH", iTempProfile);
-        preferences.putUInt(PREFERENCES_TEMP_PROFILE, iTempProfile);
-    }
     if ((iUpdateCount & 7) == 0 || apiDisplayResult.response.maximum_compatibility == true) {
         Log_info("%s [%d]: Forcing full refresh; desired refresh mode was: %d\r\n", __FILE__, __LINE__, iRefreshMode);
         iRefreshMode = REFRESH_FULL; // force full refresh every 8 partials
@@ -1399,7 +1399,7 @@ void display_show_image(uint8_t *image_buffer, int data_size, bool bWait)
         iRefreshMode = REFRESH_FAST;
     }
     if (bbep.capabilities() & (BBEP_4COLOR | BBEP_3COLOR | BBEP_7COLOR)) bWait = 1;
-    if (!bWait) iRefreshMode = REFRESH_PARTIAL; // fast update when showing loading screen
+    if (!bWait) iRefreshMode = REFRESH_FAST; // fast update when showing loading screen
     Log_info("%s [%d]: EPD refresh mode: %d\r\n", __FILE__, __LINE__, iRefreshMode);
     bbep.setLightSleep(true);
     bbep.refresh(iRefreshMode, bWait);

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -17,6 +17,12 @@ const DISPLAY_PROFILE dpList[4] = { // 1-bit and 2-bit display types for each pr
     {EP426_800x480, EP426_800x480_4GRAY}, // b = darker grays
 };
 BBEPAPER bbep(EP426_800x480);
+#elif defined(BOARD_XTEINK_X3)
+    {EP368_792x528, EP368_792x528_4GRAY}, // default
+    {EP368_792x528, EP368_792x528_4GRAY}, // a
+    {EP368_792x528, EP368_792x528_4GRAY}, // b
+};
+BBEPAPER bbep(EP368_792x528);
 #elif defined(BOARD_WAVESHARE_397)
     {EP397_800x480, EP397_800x480_4GRAY}, // default (for original EPD)
     {EP397_800x480, EP397_800x480_4GRAY}, // a = uses built-in fast + 4-gray


### PR DESCRIPTION
Hi! Following up on the suggestion to mirror the X4 pattern — here's X3 support in the same style.

## What changed

| File | Change |
|---|---|
| `platformio.ini` | New `[env:xteink_x3]` env |
| `src/DEV_Config.h` | X3 SPI pin block |
| `include/config.h` | `DEVICE_MODEL`, `PIN_INTERRUPT`, `PIN_BATTERY`, correct BMP size for 792×528 |
| `src/display.cpp` | `EP368_792x528` / `EP368_792x528_4GRAY` panel selection |
| `src/bl.cpp` | Extend GPIO13 battery-latch hold to cover X3 |

## Hardware

The Xteink X3 is an ESP32-C3 e-reader with a 792×528 SSD1677-family panel. The SPI pin layout is identical to the X4 so `DEV_Config.h` is a straight copy. The non-obvious bit is the battery latch: the X3 (like the X4) uses a MOSFET-off topology where GPIO13 must be held HIGH through deep sleep or the device cuts its own power and can never timer-wake. The `bl.cpp` change just adds `BOARD_XTEINK_X3` to the existing `#if defined(BOARD_XTEINK_X4)` block.

`EP368_792x528` / `EP368_792x528_4GRAY` are already present in bb_epaper — no library changes needed.

## Not included yet

Battery readout via the BQ27220 I²C fuel gauge (the X3 has a proper fuel gauge instead of a bare ADC divider). `PIN_BATTERY 0` gives a raw ADC read that works but isn't accurate. Happy to add BQ27220 support in a follow-up if that's in scope.

## Test plan

- [x] Builds cleanly with `pio run -e xteink_x3`
- [x] Flashed on real X3 hardware; device provisions, fetches display, and timer-wakes correctly
- [ ] 4-gray / partial refresh not yet exercised — would appreciate testing if you have time