### PR TITLE
Add support for Seeed reTerminal E1003 (10.3" IT8951 ePaper)

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -39,7 +39,7 @@
 
 #define DISPLAY_BMP_IMAGE_SIZE 48062 // in bytes - 62 bytes - header; 48000 bytes - bitmap (480*800 1bpp) / 8
 #define DEFAULT_IMAGE_SIZE 48000
-#ifdef BOARD_TRMNL_X
+#if defined(BOARD_TRMNL_X) || defined(BOARD_SEEED_RETERMINAL_E1003)
 #define MAX_IMAGE_SIZE 750000 // Use PSRAM on the ESP32-S3
 #else
 #define MAX_IMAGE_SIZE 90000 // largest compressed image we can receive
@@ -115,9 +115,12 @@ enum WIFI_CONNECT_RETRY_TIME // Time to sleep before trying to connect to the Wi
 #define PIN_INTERRUPT 3         //the green button
 #define PIN_VBAT_SWITCH 21      //load switch enable pin for battery voltage measurement
 #define VBAT_SWITCH_LEVEL HIGH  //load switch enable pin active level
+#elif defined(BOARD_SEEED_RETERMINAL_E1003)
+#define DEVICE_MODEL "reTerminal E1003"
+#define PIN_INTERRUPT 3         //the green button
 #endif
 
-#if defined(BOARD_XIAO_EPAPER_DISPLAY) || defined(BOARD_SEEED_RETERMINAL_E1001) || defined(BOARD_SEEED_RETERMINAL_E1002)
+#if defined(BOARD_XIAO_EPAPER_DISPLAY) || defined(BOARD_SEEED_RETERMINAL_E1001) || defined(BOARD_SEEED_RETERMINAL_E1002) || defined(BOARD_SEEED_RETERMINAL_E1003)
 #define PIN_BATTERY 1
 #elif defined(BOARD_XTEINK_X4)
 #define PIN_BATTERY 0

--- a/include/config.h
+++ b/include/config.h
@@ -118,6 +118,8 @@ enum WIFI_CONNECT_RETRY_TIME // Time to sleep before trying to connect to the Wi
 #elif defined(BOARD_SEEED_RETERMINAL_E1003)
 #define DEVICE_MODEL "reTerminal E1003"
 #define PIN_INTERRUPT 3         //the green button
+#define PIN_VBAT_SWITCH 40      //load switch enable pin for battery voltage measurement (ESP_IO40/VBAT_EN)
+#define VBAT_SWITCH_LEVEL HIGH  //load switch enable pin active level
 #endif
 
 #if defined(BOARD_XIAO_EPAPER_DISPLAY) || defined(BOARD_SEEED_RETERMINAL_E1001) || defined(BOARD_SEEED_RETERMINAL_E1002) || defined(BOARD_SEEED_RETERMINAL_E1003)

--- a/lib/it8951/include/it8951.h
+++ b/lib/it8951/include/it8951.h
@@ -1,0 +1,177 @@
+#pragma once
+
+#include <Arduino.h>
+#include <SPI.h>
+
+// IT8951 command codes
+#define IT8951_TCON_SYS_RUN      0x0001
+#define IT8951_TCON_STANDBY      0x0002
+#define IT8951_TCON_SLEEP        0x0003
+#define IT8951_TCON_REG_RD       0x0010
+#define IT8951_TCON_REG_WR       0x0011
+#define IT8951_TCON_LD_IMG       0x0020
+#define IT8951_TCON_LD_IMG_AREA  0x0021
+#define IT8951_TCON_LD_IMG_END   0x0022
+
+// User-defined I80 command codes
+#define USDEF_I80_CMD_DPY_AREA       0x0034
+#define USDEF_I80_CMD_GET_DEV_INFO   0x0302
+#define USDEF_I80_CMD_VCOM           0x0039
+#define USDEF_I80_CMD_TEMP           0x0040
+
+// Pixel format constants
+#define IT8951_4BPP 2
+#define IT8951_8BPP 3
+#define IT8951_LDIMG_L_ENDIAN 0
+
+// Register addresses
+#define IT8951_REG_I80CPCR  0x0004
+#define IT8951_REG_LISAR    0x0208
+#define IT8951_REG_LUTAFSR  0x1224
+#define IT8951_REG_UP1SR    0x1138
+#define IT8951_REG_BGVR     0x1250
+
+// SPI frequencies
+#define IT8951_SPI_PROBE_FREQUENCY 1000000
+#define IT8951_SPI_RUN_FREQUENCY   4000000
+
+// IT8951 device info structure
+typedef struct {
+    uint16_t panel_width;
+    uint16_t panel_height;
+    uint16_t img_buf_addr_l;
+    uint16_t img_buf_addr_h;
+    uint16_t fw_version[8];
+    uint16_t lut_version[8];
+} IT8951DevInfo;
+
+// Pin configuration
+typedef struct {
+    int8_t sck;
+    int8_t miso;
+    int8_t mosi;
+    int8_t cs;
+    int8_t busy;
+    int8_t rst;
+    int8_t en;
+    int8_t ite_en;
+} IT8951Pins;
+
+class IT8951 {
+public:
+    /**
+     * Initialize the IT8951 controller.
+     * Performs hardware reset, SPI probe, VCOM configuration, and PSRAM check.
+     * @param pins Pin configuration for the IT8951
+     * @param vcom VCOM voltage value (default 1400 = -1.40V)
+     * @return true if initialization succeeded
+     */
+    bool init(const IT8951Pins &pins, uint16_t vcom = 1400);
+
+    /**
+     * Upload a 4bpp framebuffer to the IT8951.
+     * The buffer format is packed nibbles: 2 pixels per byte, high nibble first.
+     * 0x00 = black, 0x0F = white.
+     * @param buf Framebuffer data (width*height/2 bytes)
+     * @param width Display width in pixels
+     * @param height Display height in pixels
+     */
+    void uploadFramebuffer4bpp(const uint8_t *buf, uint16_t width, uint16_t height);
+
+    /**
+     * Upload a 1bpp framebuffer (derived from 4bpp data) to the IT8951.
+     * Scans the 4bpp buffer and packs pixels into 1bpp for sharper text rendering.
+     * @param buf 4bpp framebuffer data
+     * @param width Display width in pixels
+     * @param height Display height in pixels
+     */
+    void uploadFramebuffer1bpp(const uint8_t *buf, uint16_t width, uint16_t height);
+
+    /**
+     * Trigger a display refresh in the given area.
+     * @param x X coordinate
+     * @param y Y coordinate
+     * @param w Width
+     * @param h Height
+     * @param mode Waveform mode (2 = GC16 for grayscale)
+     */
+    void displayArea(uint16_t x, uint16_t y, uint16_t w, uint16_t h, uint16_t mode = 2);
+
+    /**
+     * Trigger a 1bpp display refresh with foreground/background gray levels.
+     * @param x X coordinate
+     * @param y Y coordinate
+     * @param w Width
+     * @param h Height
+     * @param mode Waveform mode
+     * @param bg_gray Background gray level (0xFF = white)
+     * @param fg_gray Foreground gray level (0x00 = black)
+     */
+    void displayArea1bpp(uint16_t x, uint16_t y, uint16_t w, uint16_t h,
+                         uint16_t mode = 2, uint8_t bg_gray = 0xFF, uint8_t fg_gray = 0x00);
+
+    /**
+     * Put the IT8951 into sleep mode.
+     */
+    void sleep();
+
+    /**
+     * Wait until the display engine finishes the current operation.
+     */
+    void waitForDisplayReady();
+
+    /**
+     * Check if the framebuffer contains only pure black (0x00) and white (0x0F) pixels.
+     * If true, the sharper 1bpp upload path can be used.
+     * @param buf 4bpp framebuffer
+     * @param size Buffer size in bytes
+     * @return true if all pixels are binary
+     */
+    static bool framebufferIsBinary(const uint8_t *buf, uint32_t size);
+
+    uint16_t getWidth() const { return dev_info_.panel_width; }
+    uint16_t getHeight() const { return dev_info_.panel_height; }
+    uint32_t getImgBufAddr() const { return img_buf_addr_; }
+    bool isInitialized() const { return initialized_; }
+
+private:
+    // Low-level SPI helpers
+    void spiSendWord(uint16_t word);
+    uint16_t spiRecvWord();
+    void lcdWaitForReady();
+    void lcdWriteCmdCode(uint16_t cmd);
+    void lcdWriteData(uint16_t data);
+    void lcdWriteNData(const uint16_t *buf, uint32_t word_count);
+    uint16_t lcdReadData();
+    void lcdReadNData(uint16_t *buf, uint32_t word_count);
+    void lcdSendCmdArg(uint16_t cmd, uint16_t *args, uint16_t num_args);
+
+    // Hardware control
+    void hardwareReset();
+    void powerCycle();
+
+    // Register access
+    uint16_t readReg(uint16_t addr);
+    void writeReg(uint16_t addr, uint16_t val);
+
+    // IT8951 commands
+    void getSystemInfo();
+    void setImgBufBaseAddr(uint32_t addr);
+    void loadImgAreaStart(uint16_t endian, uint16_t pix_fmt, uint16_t rotate,
+                          uint16_t x, uint16_t y, uint16_t w, uint16_t h);
+    void writeVcom(uint16_t selector, uint16_t value);
+    bool probeController(const char *label, bool send_sys_run, int vcom_selector);
+    bool hasValidDevInfo() const;
+
+    // Bulk framebuffer upload helpers
+    void writeFramebufferRows4bpp(const uint16_t *buf, uint16_t width_in_words, uint16_t height);
+    void writeFramebufferRows1bpp(const uint8_t *buf_4bpp, uint16_t width, uint16_t height);
+
+    IT8951Pins pins_{};
+    IT8951DevInfo dev_info_{};
+    uint32_t img_buf_addr_{0};
+    uint16_t vcom_{1400};
+    uint32_t spi_frequency_{IT8951_SPI_PROBE_FREQUENCY};
+    uint16_t vcom_write_selector_{0};
+    bool initialized_{false};
+};

--- a/lib/it8951/src/it8951.cpp
+++ b/lib/it8951/src/it8951.cpp
@@ -1,0 +1,473 @@
+#include "it8951.h"
+#include <cstring>
+#include <trmnl_log.h>
+
+static const char *TAG = "IT8951";
+
+// ─── Low-level SPI helpers ──────────────────────────────────────────────────
+
+void IT8951::spiSendWord(uint16_t word) {
+    SPI.transfer16(word);
+}
+
+uint16_t IT8951::spiRecvWord() {
+    return SPI.transfer16(0);
+}
+
+void IT8951::lcdWaitForReady() {
+    const uint32_t start = millis();
+    while (digitalRead(pins_.busy) == LOW) {
+        if (millis() - start > 3000) {
+            // Serial-only — HRDY timeouts are expected during the multi-attempt probe sequence
+            Log_info_serial("%s: HRDY timeout", TAG);
+            break;
+        }
+        vTaskDelay(pdMS_TO_TICKS(1));
+    }
+}
+
+void IT8951::lcdWriteCmdCode(uint16_t cmd) {
+    digitalWrite(pins_.cs, LOW);
+    SPI.beginTransaction(SPISettings(spi_frequency_, MSBFIRST, SPI_MODE0));
+    lcdWaitForReady();
+    spiSendWord(0x6000); // command preamble
+    lcdWaitForReady();
+    spiSendWord(cmd);
+    SPI.endTransaction();
+    digitalWrite(pins_.cs, HIGH);
+}
+
+void IT8951::lcdWriteData(uint16_t data) {
+    digitalWrite(pins_.cs, LOW);
+    SPI.beginTransaction(SPISettings(spi_frequency_, MSBFIRST, SPI_MODE0));
+    lcdWaitForReady();
+    spiSendWord(0x0000); // data preamble
+    lcdWaitForReady();
+    spiSendWord(data);
+    SPI.endTransaction();
+    digitalWrite(pins_.cs, HIGH);
+}
+
+void IT8951::lcdWriteNData(const uint16_t *buf, uint32_t word_count) {
+    digitalWrite(pins_.cs, LOW);
+    SPI.beginTransaction(SPISettings(spi_frequency_, MSBFIRST, SPI_MODE0));
+    lcdWaitForReady();
+    spiSendWord(0x0000); // data preamble
+    lcdWaitForReady();
+    for (uint32_t i = 0; i < word_count; i++) {
+        spiSendWord(buf[i]);
+    }
+    SPI.endTransaction();
+    digitalWrite(pins_.cs, HIGH);
+}
+
+uint16_t IT8951::lcdReadData() {
+    digitalWrite(pins_.cs, LOW);
+    SPI.beginTransaction(SPISettings(spi_frequency_, MSBFIRST, SPI_MODE0));
+    lcdWaitForReady();
+    spiSendWord(0x1000); // read preamble
+    spiRecvWord();       // dummy read
+    lcdWaitForReady();
+    const uint16_t data = spiRecvWord();
+    SPI.endTransaction();
+    digitalWrite(pins_.cs, HIGH);
+    return data;
+}
+
+void IT8951::lcdReadNData(uint16_t *buf, uint32_t word_count) {
+    digitalWrite(pins_.cs, LOW);
+    SPI.beginTransaction(SPISettings(spi_frequency_, MSBFIRST, SPI_MODE0));
+    lcdWaitForReady();
+    spiSendWord(0x1000); // read preamble
+    lcdWaitForReady();
+    spiRecvWord();       // dummy read
+    lcdWaitForReady();
+    for (uint32_t i = 0; i < word_count; i++) {
+        buf[i] = spiRecvWord();
+    }
+    SPI.endTransaction();
+    digitalWrite(pins_.cs, HIGH);
+}
+
+void IT8951::lcdSendCmdArg(uint16_t cmd, uint16_t *args, uint16_t num_args) {
+    lcdWriteCmdCode(cmd);
+    for (uint16_t i = 0; i < num_args; i++) {
+        lcdWriteData(args[i]);
+    }
+}
+
+// ─── Hardware control ───────────────────────────────────────────────────────
+
+void IT8951::hardwareReset() {
+    digitalWrite(pins_.cs, HIGH);
+    digitalWrite(pins_.rst, HIGH);
+    digitalWrite(pins_.en, HIGH);
+    digitalWrite(pins_.ite_en, HIGH);
+    delay(50);
+    digitalWrite(pins_.rst, LOW);
+    delay(10);
+    digitalWrite(pins_.rst, HIGH);
+    delay(10);
+}
+
+void IT8951::powerCycle() {
+    digitalWrite(pins_.cs, HIGH);
+    digitalWrite(pins_.rst, HIGH);
+    digitalWrite(pins_.en, LOW);
+    digitalWrite(pins_.ite_en, LOW);
+    delay(100);
+    digitalWrite(pins_.en, HIGH);
+    digitalWrite(pins_.ite_en, HIGH);
+    delay(500);
+    hardwareReset();
+    delay(1500);
+}
+
+// ─── Register access ────────────────────────────────────────────────────────
+
+uint16_t IT8951::readReg(uint16_t addr) {
+    lcdWriteCmdCode(IT8951_TCON_REG_RD);
+    lcdWriteData(addr);
+    return lcdReadData();
+}
+
+void IT8951::writeReg(uint16_t addr, uint16_t val) {
+    lcdWriteCmdCode(IT8951_TCON_REG_WR);
+    lcdWriteData(addr);
+    lcdWriteData(val);
+}
+
+// ─── IT8951 commands ────────────────────────────────────────────────────────
+
+void IT8951::getSystemInfo() {
+    memset(&dev_info_, 0, sizeof(dev_info_));
+    lcdWriteCmdCode(USDEF_I80_CMD_GET_DEV_INFO);
+    lcdReadNData(reinterpret_cast<uint16_t *>(&dev_info_), sizeof(IT8951DevInfo) / 2);
+}
+
+void IT8951::setImgBufBaseAddr(uint32_t addr) {
+    const uint16_t hi = (addr >> 16) & 0xFFFF;
+    const uint16_t lo = addr & 0xFFFF;
+    writeReg(IT8951_REG_LISAR + 2, hi);
+    writeReg(IT8951_REG_LISAR, lo);
+}
+
+void IT8951::loadImgAreaStart(uint16_t endian, uint16_t pix_fmt, uint16_t rotate,
+                              uint16_t x, uint16_t y, uint16_t w, uint16_t h) {
+    uint16_t args[5];
+    args[0] = (endian << 8) | (pix_fmt << 4) | rotate;
+    args[1] = x;
+    args[2] = y;
+    args[3] = w;
+    args[4] = h;
+    lcdSendCmdArg(IT8951_TCON_LD_IMG_AREA, args, 5);
+}
+
+void IT8951::writeVcom(uint16_t selector, uint16_t value) {
+    lcdWriteCmdCode(USDEF_I80_CMD_VCOM);
+    lcdWriteData(selector);
+    lcdWriteData(value);
+}
+
+bool IT8951::hasValidDevInfo() const {
+    return dev_info_.panel_width > 0 && dev_info_.panel_width < 10000 &&
+           dev_info_.panel_height > 0 && dev_info_.panel_height < 10000;
+}
+
+bool IT8951::probeController(const char *label, bool send_sys_run, int vcom_selector) {
+    memset(&dev_info_, 0, sizeof(dev_info_));
+
+    if (send_sys_run) {
+        Log_info("%s: [%s] Sending SYS_RUN wake command", TAG, label);
+        lcdWriteCmdCode(IT8951_TCON_SYS_RUN);
+        delay(10);
+    }
+
+    if (vcom_selector > 0) {
+        Log_info("%s: [%s] Writing VCOM=%u with selector 0x%04X", TAG, label, vcom_, vcom_selector);
+        writeVcom(vcom_selector, vcom_);
+        lcdWriteCmdCode(USDEF_I80_CMD_VCOM);
+        lcdWriteData(0x0000);
+        uint16_t readback = lcdReadData();
+        Log_info("%s: [%s] VCOM read-back: %u (0x%04X)", TAG, label, readback, readback);
+        if (readback == vcom_) {
+            vcom_write_selector_ = vcom_selector;
+        }
+    }
+
+    getSystemInfo();
+    Log_info("%s: [%s] DevInfo: W=%u H=%u BufL=0x%04X BufH=0x%04X",
+             TAG, label, dev_info_.panel_width, dev_info_.panel_height,
+             dev_info_.img_buf_addr_l, dev_info_.img_buf_addr_h);
+    return hasValidDevInfo();
+}
+
+// ─── Bulk framebuffer upload ────────────────────────────────────────────────
+
+void IT8951::writeFramebufferRows4bpp(const uint16_t *buf, uint16_t width_in_words, uint16_t height) {
+    // Send row-by-row with word-reversal but preserve byte order within each word.
+    // The IT8951 interprets the first received byte as the high byte of each 16-bit word,
+    // so we must send the framebuffer bytes in their natural memory order (low address first)
+    // to keep nibble/pixel alignment correct.
+    uint8_t row_buffer[936];
+    const uint32_t row_size_bytes = uint32_t(width_in_words) * 2;
+    if (row_size_bytes > sizeof(row_buffer)) {
+        Log_error("%s: Row buffer too small for %u-byte row", TAG, (unsigned)row_size_bytes);
+        return;
+    }
+
+    const uint8_t *byte_buf = reinterpret_cast<const uint8_t *>(buf);
+
+    digitalWrite(pins_.cs, LOW);
+    SPI.beginTransaction(SPISettings(spi_frequency_, MSBFIRST, SPI_MODE0));
+    lcdWaitForReady();
+    spiSendWord(0x0000); // data preamble
+    lcdWaitForReady();
+
+    for (uint16_t y = 0; y < height; y++) {
+        const uint32_t row_byte_start = uint32_t(y) * row_size_bytes;
+        for (uint16_t x = 0; x < width_in_words; x++) {
+            const uint32_t src_byte_offset = row_byte_start + (width_in_words - 1 - x) * 2;
+            const uint32_t dst_byte_index = uint32_t(x) * 2;
+            row_buffer[dst_byte_index] = byte_buf[src_byte_offset];
+            row_buffer[dst_byte_index + 1] = byte_buf[src_byte_offset + 1];
+        }
+        SPI.writeBytes(row_buffer, row_size_bytes);
+        if ((y & 0x07) == 0) {
+            yield();
+        }
+    }
+
+    SPI.endTransaction();
+    digitalWrite(pins_.cs, HIGH);
+}
+
+void IT8951::writeFramebufferRows1bpp(const uint8_t *buf_4bpp, uint16_t width, uint16_t height) {
+    uint16_t row_words[117]; // 1872/16 = 117
+    uint8_t row_buffer[234]; // 117 * 2
+    const uint16_t width_in_words = width / 16;
+    const uint32_t row_size_bytes = uint32_t(width_in_words) * 2;
+
+    if (width_in_words > (sizeof(row_words) / sizeof(row_words[0])) ||
+        row_size_bytes > sizeof(row_buffer)) {
+        Log_error("%s: 1bpp row buffer too small for %u-byte row", TAG, (unsigned)row_size_bytes);
+        return;
+    }
+
+    digitalWrite(pins_.cs, LOW);
+    SPI.beginTransaction(SPISettings(spi_frequency_, MSBFIRST, SPI_MODE0));
+    lcdWaitForReady();
+    spiSendWord(0x0000); // data preamble
+    lcdWaitForReady();
+
+    for (uint16_t y = 0; y < height; y++) {
+        memset(row_words, 0x00, row_size_bytes);
+
+        for (uint16_t x = 0; x < width; x++) {
+            // Read 4bpp nibble from the source buffer
+            const uint32_t pos = (x + y * width) / 2;
+            uint8_t nibble;
+            if ((x & 1U) == 0) {
+                nibble = buf_4bpp[pos] >> 4;
+            } else {
+                nibble = buf_4bpp[pos] & 0x0F;
+            }
+            // Threshold: nibble <= 7 → black (set bit)
+            if (nibble <= 0x07) {
+                row_words[x / 16] |= uint16_t(0x8000 >> (x & 0x0F));
+            }
+        }
+
+        // Reverse words for IT8951 upload order
+        for (uint16_t i = 0; i < width_in_words; i++) {
+            const uint16_t word = row_words[width_in_words - 1 - i];
+            const uint32_t byte_index = uint32_t(i) * 2;
+            row_buffer[byte_index] = static_cast<uint8_t>(word >> 8);
+            row_buffer[byte_index + 1] = static_cast<uint8_t>(word & 0xFF);
+        }
+
+        SPI.writeBytes(row_buffer, row_size_bytes);
+        if ((y & 0x07) == 0) {
+            yield();
+        }
+    }
+
+    SPI.endTransaction();
+    digitalWrite(pins_.cs, HIGH);
+}
+
+// ─── Public API ─────────────────────────────────────────────────────────────
+
+bool IT8951::init(const IT8951Pins &pins, uint16_t vcom) {
+    pins_ = pins;
+    vcom_ = vcom;
+    initialized_ = false;
+
+    Log_info("%s: Setting up IT8951 reTerminal E1003...", TAG);
+
+    pinMode(pins_.cs, OUTPUT);
+    pinMode(pins_.en, OUTPUT);
+    pinMode(pins_.ite_en, OUTPUT);
+    pinMode(pins_.rst, OUTPUT);
+    pinMode(pins_.busy, INPUT);
+
+    digitalWrite(pins_.cs, HIGH);
+    digitalWrite(pins_.en, HIGH);
+    digitalWrite(pins_.ite_en, HIGH);
+    digitalWrite(pins_.rst, HIGH);
+
+    spi_frequency_ = IT8951_SPI_PROBE_FREQUENCY;
+    SPI.begin(pins_.sck, pins_.miso, pins_.mosi, -1);
+    Log_info("%s: SPI bus initialized at %u Hz probe speed", TAG, spi_frequency_);
+
+    // Multi-attempt probe sequence
+    struct ProbeAttempt {
+        const char *label;
+        bool send_sys_run;
+        int vcom_selector;
+    };
+    static const ProbeAttempt attempts[] = {
+        {"cold read", false, 0},
+        {"wake then read", true, 0},
+        {"wake + VCOM 0x0001", true, 0x0001},
+        {"wake + VCOM 0x0002", true, 0x0002},
+    };
+
+    bool found_device = false;
+    for (size_t i = 0; i < sizeof(attempts) / sizeof(attempts[0]); i++) {
+        Log_info("%s: Probe attempt %u: %s", TAG, (unsigned)(i + 1), attempts[i].label);
+        powerCycle();
+        Log_info("%s: [%s] Power cycle complete, HRDY=%s",
+                 TAG, attempts[i].label,
+                 digitalRead(pins_.busy) ? "HIGH" : "LOW");
+        lcdWaitForReady();
+        if (probeController(attempts[i].label, attempts[i].send_sys_run, attempts[i].vcom_selector)) {
+            found_device = true;
+            break;
+        }
+    }
+
+    if (!found_device) {
+        Log_error("%s: SPI communication failed - IT8951 never returned valid device info", TAG);
+        return false;
+    }
+
+    // If VCOM wasn't verified during probe, try preferred selectors
+    if (vcom_write_selector_ == 0) {
+        Log_info("%s: Panel answered before VCOM was verified, trying selector 0x0002", TAG);
+        writeVcom(0x0002, vcom_);
+        lcdWriteCmdCode(USDEF_I80_CMD_VCOM);
+        lcdWriteData(0x0000);
+        uint16_t readback = lcdReadData();
+        if (readback == vcom_) {
+            vcom_write_selector_ = 0x0002;
+        } else {
+            Log_info("%s: Selector 0x0002 read-back was %u, trying 0x0001", TAG, readback);
+            writeVcom(0x0001, vcom_);
+            lcdWriteCmdCode(USDEF_I80_CMD_VCOM);
+            lcdWriteData(0x0000);
+            readback = lcdReadData();
+            if (readback == vcom_) {
+                vcom_write_selector_ = 0x0001;
+            }
+        }
+    }
+
+    img_buf_addr_ = (uint32_t(dev_info_.img_buf_addr_h) << 16) | dev_info_.img_buf_addr_l;
+    Log_info("%s: Panel: %dx%d, ImgBuf: 0x%08X", TAG,
+             dev_info_.panel_width, dev_info_.panel_height, img_buf_addr_);
+
+    // Enable packed write mode and set temperature
+    writeReg(IT8951_REG_I80CPCR, 0x0001);
+    lcdWriteCmdCode(USDEF_I80_CMD_TEMP);
+    lcdWriteData(0x0001);
+    lcdWriteData(14);
+
+    // Switch to runtime SPI speed
+    spi_frequency_ = IT8951_SPI_RUN_FREQUENCY;
+    Log_info("%s: Switching SPI speed to %u Hz", TAG, spi_frequency_);
+
+    initialized_ = true;
+    Log_info("%s: IT8951 initialization complete", TAG);
+    return true;
+}
+
+void IT8951::waitForDisplayReady() {
+    const uint32_t start = millis();
+    while (readReg(IT8951_REG_LUTAFSR) != 0) {
+        if (millis() - start > 30000) {
+            Log_error("%s: Display-ready timeout (LUTAFSR)", TAG);
+            break;
+        }
+        yield();
+        vTaskDelay(pdMS_TO_TICKS(10));
+    }
+}
+
+void IT8951::uploadFramebuffer4bpp(const uint8_t *buf, uint16_t width, uint16_t height) {
+    if (!initialized_) return;
+
+    const uint16_t width_in_words = (width + 3) / 4;
+
+    waitForDisplayReady();
+    setImgBufBaseAddr(img_buf_addr_);
+
+    // Disable 1bpp mode if it was previously enabled
+    writeReg(IT8951_REG_UP1SR + 2, readReg(IT8951_REG_UP1SR + 2) & ~(1 << 2));
+
+    loadImgAreaStart(IT8951_LDIMG_L_ENDIAN, IT8951_4BPP, 0, 0, 0, width, height);
+    Log_info("%s: Uploading 4bpp: %u rows x %u words", TAG, height, width_in_words);
+    writeFramebufferRows4bpp(reinterpret_cast<const uint16_t *>(buf), width_in_words, height);
+    lcdWriteCmdCode(IT8951_TCON_LD_IMG_END);
+}
+
+void IT8951::uploadFramebuffer1bpp(const uint8_t *buf, uint16_t width, uint16_t height) {
+    if (!initialized_) return;
+
+    const uint16_t one_bpp_width_bytes = width / 8;
+
+    waitForDisplayReady();
+    setImgBufBaseAddr(img_buf_addr_);
+
+    loadImgAreaStart(IT8951_LDIMG_L_ENDIAN, IT8951_8BPP, 0, 0, 0, one_bpp_width_bytes, height);
+    Log_info("%s: Uploading 1bpp: %u rows x %u packed bytes", TAG, height, one_bpp_width_bytes);
+    writeFramebufferRows1bpp(buf, width, height);
+    lcdWriteCmdCode(IT8951_TCON_LD_IMG_END);
+}
+
+void IT8951::displayArea(uint16_t x, uint16_t y, uint16_t w, uint16_t h, uint16_t mode) {
+    if (!initialized_) return;
+    lcdWriteCmdCode(USDEF_I80_CMD_DPY_AREA);
+    lcdWriteData(x);
+    lcdWriteData(y);
+    lcdWriteData(w);
+    lcdWriteData(h);
+    lcdWriteData(mode);
+}
+
+void IT8951::displayArea1bpp(uint16_t x, uint16_t y, uint16_t w, uint16_t h,
+                             uint16_t mode, uint8_t bg_gray, uint8_t fg_gray) {
+    if (!initialized_) return;
+    // Enable 1bpp mode
+    writeReg(IT8951_REG_UP1SR + 2, readReg(IT8951_REG_UP1SR + 2) | (1 << 2));
+    writeReg(IT8951_REG_BGVR, (uint16_t(bg_gray) << 8) | fg_gray);
+    displayArea(x, y, w, h, mode);
+    waitForDisplayReady();
+}
+
+void IT8951::sleep() {
+    if (!initialized_) return;
+    Log_info("%s: Entering sleep mode", TAG);
+    lcdWriteCmdCode(IT8951_TCON_SLEEP);
+}
+
+bool IT8951::framebufferIsBinary(const uint8_t *buf, uint32_t size) {
+    for (uint32_t i = 0; i < size; i++) {
+        const uint8_t hi = buf[i] >> 4;
+        const uint8_t lo = buf[i] & 0x0F;
+        if ((hi != 0x00 && hi != 0x0F) || (lo != 0x00 && lo != 0x0F)) {
+            return false;
+        }
+    }
+    return true;
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -11,7 +11,7 @@ lib_deps =
 	bblanchon/ArduinoJson@7.4.2
 	bitbank2/PNGdec@^1.1.6
 	bitbank2/JPEGDEC@^1.8.4
-	https://github.com/bitbank2/bb_epaper.git#5aaf81fddec42c7775b0599e80808498aee3168b
+	https://github.com/bitbank2/bb_epaper.git#3d3df73aa25b5788acc7a62d8236f5129c812ede
 
 ; Dependencies for all device builds
 [deps_app]
@@ -270,4 +270,23 @@ build_flags =
 	-D ARDUINO_USB_MODE=0
 	-D ARDUINO_USB_CDC_ON_BOOT=0
 	-D PNG_MAX_BUFFERED_PIXELS=6432
+
+[env:seeed_reTerminal_E1003]
+extends = env:esp32_base
+board = seeed_xiao_esp32s3
+framework = arduino
+board_build.extra_flags =
+	-D ARDUINO_XIAO_ESP32S3
+	-D BOARD_HAS_PSRAM
+	-D DARDUINO_RUNNING_CORE=1
+	-D ARDUINO_EVENT_RUNNING_CORE=1
+build_flags =
+	${env:esp32_base.build_flags}
+	-D BOARD_SEEED_RETERMINAL_E1003
+	-D ARDUINO_USB_MODE=0
+	-D ARDUINO_USB_CDC_ON_BOOT=0
+	-D PNG_MAX_BUFFERED_PIXELS=14984
+lib_deps =
+	${deps_app.lib_deps}
+	bitbank2/FastEPD@1.3.0
 

--- a/src/DEV_Config.h
+++ b/src/DEV_Config.h
@@ -132,6 +132,17 @@
    #define EPD_RST_PIN  12
    #define EPD_DC_PIN   11
    #define EPD_BUSY_PIN 13
+
+#elif defined(BOARD_SEEED_RETERMINAL_E1003)
+   // Pin definition for reTerminal E1003 (IT8951-based 10.3" ePaper)
+   #define EPD_SCK_PIN   7
+   #define EPD_MISO_PIN  8
+   #define EPD_MOSI_PIN  9
+   #define EPD_CS_PIN    10
+   #define EPD_BUSY_PIN  13
+   #define EPD_RST_PIN   12
+   #define EPD_EN_PIN    11
+   #define EPD_ITE_EN_PIN 21
 #else
    #error "Board type not defined. Please define BOARD_WAVESHARE_ESP32_DRIVER or BOARD_TRMNL or BOARD_SEEED_XIAO_ESP32C3 or BOARD_SEEED_XIAO_ESP32S3 in platformio.ini build_flags."
 #endif

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -2076,7 +2076,7 @@ static float readBatteryVoltage(void)
   Log.warning("%s [%d]: FAKE_BATTERY_VOLTAGE is defined. Returning 4.2V.\r\n", __FILE__, __LINE__);
   return 4.2f;
 #else
-  #if defined(BOARD_XIAO_EPAPER_DISPLAY) || defined(BOARD_SEEED_RETERMINAL_E1001) || defined(BOARD_SEEED_RETERMINAL_E1002)
+  #ifdef PIN_VBAT_SWITCH
     pinMode(PIN_VBAT_SWITCH, OUTPUT);
     digitalWrite(PIN_VBAT_SWITCH, VBAT_SWITCH_LEVEL);
     delay(10); // Wait for the switch to stabilize
@@ -2090,7 +2090,7 @@ static float readBatteryVoltage(void)
     for (uint8_t i = 0; i < 8; i++) {
       adc += analogReadMilliVolts(PIN_BATTERY);
     }
-  #if defined(BOARD_XIAO_EPAPER_DISPLAY) || defined(BOARD_SEEED_RETERMINAL_E1001) || defined(BOARD_XIAO_EPAPER_DISPLAY_3CLR)
+  #ifdef PIN_VBAT_SWITCH
     digitalWrite(PIN_VBAT_SWITCH, (VBAT_SWITCH_LEVEL == HIGH ? LOW : HIGH));
   #endif
     sensorValue = (adc / 8) * 2;

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -71,6 +71,7 @@ MSG current_msg = NONE;
 SPECIAL_FUNCTION special_function = SF_NONE;
 RTC_DATA_ATTR uint8_t need_to_refresh_display = 1;
 RTC_DATA_ATTR char szPrevName[36] = {0};
+extern int iTempProfile;
 Preferences preferences;
 PreferencesPersistence preferencesPersistence(preferences);
 StoredLogs storedLogs(LOG_MAX_NOTES_NUMBER / 2, LOG_MAX_NOTES_NUMBER / 2, PREFERENCES_LOG_KEY, PREFERENCES_LOG_BUFFER_HEAD_KEY, preferencesPersistence);
@@ -1092,6 +1093,7 @@ https_request_err_e handleApiDisplayResponse(ApiDisplayResponse &apiResponse)
       String firmware_url = apiResponse.firmware_url;
       uint64_t rate = apiResponse.refresh_rate;
       reset_firmware = apiResponse.reset_firmware;
+      iTempProfile = apiResponse.temp_profile;
 
       bool sleep_5_seconds = false;
 
@@ -1185,6 +1187,11 @@ https_request_err_e handleApiDisplayResponse(ApiDisplayResponse &apiResponse)
         Log.info("%s [%d]: write new refresh rate: %d\r\n", __FILE__, __LINE__, rate);
         preferences.putUInt(PREFERENCES_SLEEP_TIME_KEY, rate);
         Log.info("%s [%d]: written new refresh rate: %d\r\n", __FILE__, __LINE__, result);
+      }
+      Log.info("%s [%d]: temp_profile: %d\r\n", __FILE__, __LINE__, iTempProfile);
+      if (iTempProfile != preferences.getUInt(PREFERENCES_TEMP_PROFILE, TEMP_PROFILE_DEFAULT)) {
+        Log_info("Saving new temperature profile (%d) to FLASH", iTempProfile);
+        preferences.putUInt(PREFERENCES_TEMP_PROFILE, iTempProfile);
       }
 
       if (reset_firmware)

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -7,7 +7,7 @@
 #include <preferences_persistence.h>
 #include "DEV_Config.h"
 #define MAX_BIT_DEPTH 8
-#ifndef BOARD_TRMNL_X
+#if !defined(BOARD_TRMNL_X) && !defined(BOARD_SEEED_RETERMINAL_E1003)
 #define BB_EPAPER
 #include "bb_epaper.h"
 const DISPLAY_PROFILE dpList[4] = { // 1-bit and 2-bit display types for each profile
@@ -51,9 +51,22 @@ BBEPAPER bbep(EP75_800x480);
 #ifdef BOARD_SEEED_RETERMINAL_E1002
 uint8_t u8SpectraPal[512]; // RGB333 mapped to closest Spectra6 color
 #endif // E1002
-#else
+#else // BOARD_TRMNL_X or BOARD_SEEED_RETERMINAL_E1003
 #include "FastEPD.h"
 FASTEPD bbep;
+#ifdef BOARD_SEEED_RETERMINAL_E1003
+#define IT8951_EPAPER
+#include "it8951.h"
+static IT8951 it8951;
+// IT8951 expects actual 4-bit grayscale values (0x00=black, 0x0F=white).
+// FastEPD's BBEP_WHITE/BBEP_BLACK are 1-bit palette indices (0 and 1) that
+// TRMNL_X maps via its custom waveform graytable, but IT8951 uses them as
+// literal gray levels — so remap to the full 4-bit range.
+#undef BBEP_WHITE
+#undef BBEP_BLACK
+#define BBEP_WHITE 0x0F
+#define BBEP_BLACK 0x00
+#else // TRMNL_X only
 const uint8_t u8_graytable[] = {
 /* 0 */  2, 2, 1, 1, 1, 1, 1, 1,
 /* 1 */  2, 2, 2, 2, 1, 1, 2, 1,
@@ -72,7 +85,8 @@ const uint8_t u8_graytable[] = {
 /* 14 */  2, 2, 2, 2, 2, 1, 2, 2,
 /* 15 */  2, 2, 2, 2, 2, 2, 2, 2
 };
-#endif
+#endif // BOARD_SEEED_RETERMINAL_E1003 vs TRMNL_X
+#endif // BB_EPAPER vs FastEPD
 // Counts the number of partial updates to know when to do a full update
 RTC_DATA_ATTR int iUpdateCount = 0;
 #include "Group5.h"
@@ -82,6 +96,14 @@ RTC_DATA_ATTR int iUpdateCount = 0;
 #include <ctype.h> //iscntrl()
 #include <api-client/display.h>
 #include <trmnl_log.h>
+// Color constants that are defined in bb_epaper.h but not in FastEPD.h.
+// These are used in the color-matching functions for 3/4-color panels.
+#ifndef BBEP_RED
+#define BBEP_RED 3
+#endif
+#ifndef BBEP_YELLOW
+#define BBEP_YELLOW 4
+#endif
 #include "png_flip.h"
 #include "nicoclean_8.h"
 #include "Inter_18.h"
@@ -96,6 +118,31 @@ static uint8_t *pDither;
 // Runtime control for light sleep (true = enabled, false = disabled)
 static bool g_light_sleep_enabled = true;
 
+#ifdef IT8951_EPAPER
+/**
+ * @brief Upload the FastEPD virtual framebuffer to IT8951 and trigger a display refresh.
+ *        Automatically selects the sharper 1bpp path when the image is pure black/white.
+ */
+static void it8951_flush_framebuffer(void)
+{
+    uint16_t w = bbep.width();
+    uint16_t h = bbep.height();
+    uint8_t *buf = bbep.currentBuffer();
+    uint32_t buf_size = (uint32_t(w) * h) / 2;
+    bool use_1bpp = IT8951::framebufferIsBinary(buf, buf_size);
+
+    if (use_1bpp) {
+        Log_info("IT8951: Using sharp 1bpp upload path");
+        it8951.uploadFramebuffer1bpp(buf, w, h);
+        it8951.displayArea1bpp(0, 0, w, h, 2, 0xFF, 0x00);
+    } else {
+        Log_info("IT8951: Using 4bpp grayscale upload path");
+        it8951.uploadFramebuffer4bpp(buf, w, h);
+        it8951.displayArea(0, 0, w, h, 2);
+    }
+}
+#endif // IT8951_EPAPER
+
 /**
  * @brief Function to init the display
  * @param none
@@ -109,6 +156,24 @@ void display_init(void)
 #ifdef BB_EPAPER
     bbep.setPanelType(dpList[iTempProfile].OneBit); // must be set BEFORE calling initio
     bbep.initIO(EPD_DC_PIN, EPD_RST_PIN, EPD_BUSY_PIN, EPD_CS_PIN, EPD_MOSI_PIN, EPD_SCK_PIN, 8000000);
+#elif defined(IT8951_EPAPER)
+    // Use FastEPD as a virtual rendering backend (no hardware — just a framebuffer)
+    bbep.initPanel(BB_PANEL_VIRTUAL);
+    bbep.setPanelSize(1872, 1404, 0);
+    bbep.setMode(BB_MODE_4BPP); // IT8951 always uploads 4bpp; must match buffer layout
+    // Initialize the IT8951 controller for actual display hardware
+    IT8951Pins pins;
+    pins.sck = EPD_SCK_PIN;
+    pins.miso = EPD_MISO_PIN;
+    pins.mosi = EPD_MOSI_PIN;
+    pins.cs = EPD_CS_PIN;
+    pins.busy = EPD_BUSY_PIN;
+    pins.rst = EPD_RST_PIN;
+    pins.en = EPD_EN_PIN;
+    pins.ite_en = EPD_ITE_EN_PIN;
+    if (!it8951.init(pins)) {
+        Log_error("IT8951 initialization failed!");
+    }
 #else
     bbep.initPanel(BB_PANEL_EPDIY_V7_16); //, 26000000);
     bbep.setPanelSize(1872, 1404, BB_PANEL_FLAG_MIRROR_X);
@@ -123,7 +188,9 @@ void display_init(void)
  */
 void display_set_light_sleep(uint8_t enabled)
 {
+#ifdef BB_EPAPER
     bbep.setLightSleep(enabled);
+#endif
 }
 
 /**
@@ -154,13 +221,15 @@ void display_reset(void)
 {
     Log_info("e-Paper Clear start");
     bbep.fillScreen(BBEP_WHITE);
-    bbep.setLightSleep(true);
 #ifdef BB_EPAPER
+    bbep.setLightSleep(true);
     if (!apiDisplayResult.response.maximum_compatibility) {
         bbep.refresh(REFRESH_FAST, true);
     } else {
         bbep.refresh(REFRESH_FULL, true); // incompatible panel
     }
+#elif defined(IT8951_EPAPER)
+    it8951_flush_framebuffer();
 #else
     bbep.fullUpdate();
 #endif
@@ -844,10 +913,14 @@ int png_draw(PNGDRAW *pDraw)
                 }
             } // for x
         } else { // normal 0/1 split plane
-            ucMask = (iPlane == PNG_2_BIT_0) ? 0x40 : 0x80; // lower or upper source bit
+            const uint8_t ucTranslate[4] = {0, 2, 1, 3}; // translate grays to odd order of native 4-gray mode on 7.5" panel
+            const uint8_t ucNoTranslate[4] = {0, 1, 2, 3}; // for other 2-bit panels
+            uint8_t ucPT = bbep.getPanelType();
+            const uint8_t *pTranslate = (ucPT == EP75_800x480_4GRAY || ucPT == EP75_800x480_4GRAY_GEN2) ? ucTranslate : ucNoTranslate;
+            ucMask = (iPlane == PNG_2_BIT_0) ? 0x1 : 0x2; // lower or upper source bit
             for (x=0; x<iWidth; x++) {
                 uc <<= 1;
-                if (src & ucMask) {
+                if (pTranslate[src>>6] & ucMask) {
                     uc |= 1; // high bit of source pair
                 }
                 src <<= 2;
@@ -876,6 +949,35 @@ int png_draw(PNGDRAW *pDraw)
     d = bbep.currentBuffer();
     iPitch = bbep.width()/2;
     if (pDraw->iBpp == 1) {
+#ifdef IT8951_EPAPER
+        // IT8951 always uses 4bpp buffer: convert 1bpp source to 4bpp nibbles
+        d += pDraw->y * iPitch; // iPitch = bbep.width()/2 (4bpp pitch)
+        if (bbep.width() == pDraw->iWidth) { // normal orientation
+            for (x = 0; x < pDraw->iWidth; x++) {
+                uint8_t bit = (s[x >> 3] >> (7 - (x & 7))) & 1;
+                uint8_t nibble = bit ? 0x0F : 0x00;
+                if ((x & 1) == 0) {
+                    d[x >> 1] = nibble << 4;
+                } else {
+                    d[x >> 1] |= nibble;
+                }
+            }
+        } else { // rotated (portrait PNG on landscape display)
+            d = bbep.currentBuffer();
+            d += (bbep.height() - 1) * iPitch;
+            d += (pDraw->y / 2);
+            for (x = 0; x < pDraw->iWidth; x++) {
+                uint8_t bit = (s[x >> 3] >> (7 - (x & 7))) & 1;
+                uint8_t nibble = bit ? 0x0F : 0x00;
+                if (pDraw->y & 1) {
+                    d[0] = (d[0] & 0xF0) | nibble;
+                } else {
+                    d[0] = (d[0] & 0x0F) | (nibble << 4);
+                }
+                d -= iPitch;
+            }
+        }
+#else
         if (bbep.width() == pDraw->iWidth) { // normal orientation
             iPitch = (bbep.width() + 7)/8;
             d += pDraw->y * iPitch; // point to the correct line
@@ -894,6 +996,7 @@ int png_draw(PNGDRAW *pDraw)
                 d -= iPitch;
             }
         }
+#endif
     } else if (pDraw->iBpp == 2) { // we need to convert the 2-bit data into 4-bits
         iPitch = bbep.width()/2;
         if (bbep.width() == pDraw->iWidth) { // normal orientation
@@ -1262,6 +1365,7 @@ PNG *png = new PNG();
                     png->decode(&iPlane, 0);
                 } // temp profile needs the second plane written
             } else { // 2-bpp (or greater, but reduced to 2-bpp)
+                Log_info("%s [%d]: Using temp profile %d\r\n", __FILE__, __LINE__, iTempProfile);
                 bbep.setPanelType(dpList[iTempProfile].TwoBit);
                 rc = REFRESH_FULL; // 4gray mode must be full refresh
                 iUpdateCount = 0; // grayscale mode resets the partial update counter
@@ -1277,7 +1381,11 @@ PNG *png = new PNG();
                 bbep.startWrite(PLANE_1); // start writing image data to plane 1
                 png->decode(&iPlane, 0); // decode it again to get plane 1 data
             }
-#else // FastEPD
+#elif defined(IT8951_EPAPER)
+            bbep.setMode(BB_MODE_4BPP); // IT8951 always uses 4bpp; png_draw converts 1bpp->4bpp
+            png->decode(NULL, 0);
+            png->close();
+#else // FastEPD (TRMNL_X)
             bbep.setMode((png->getBpp() == 1) ? BB_MODE_1BPP : BB_MODE_4BPP);
             png->decode(NULL, 0);
             png->close();
@@ -1383,11 +1491,6 @@ void display_show_image(uint8_t *image_buffer, int data_size, bool bWait)
     }
     Log_info("Display refresh start");
 #ifdef BB_EPAPER
-    if (iTempProfile != apiDisplayResult.response.temp_profile) {
-        iTempProfile = apiDisplayResult.response.temp_profile;
-        Log_info("Saving new temperature profile (%d) to FLASH", iTempProfile);
-        preferences.putUInt(PREFERENCES_TEMP_PROFILE, iTempProfile);
-    }
     if ((iUpdateCount & 7) == 0 || apiDisplayResult.response.maximum_compatibility == true) {
         Log_info("%s [%d]: Forcing full refresh; desired refresh mode was: %d\r\n", __FILE__, __LINE__, iRefreshMode);
         iRefreshMode = REFRESH_FULL; // force full refresh every 8 partials
@@ -1399,7 +1502,7 @@ void display_show_image(uint8_t *image_buffer, int data_size, bool bWait)
         iRefreshMode = REFRESH_FAST;
     }
     if (bbep.capabilities() & (BBEP_4COLOR | BBEP_3COLOR | BBEP_7COLOR)) bWait = 1;
-    if (!bWait) iRefreshMode = REFRESH_PARTIAL; // fast update when showing loading screen
+    if (!bWait) iRefreshMode = REFRESH_FAST; // fast update when showing loading screen
     Log_info("%s [%d]: EPD refresh mode: %d\r\n", __FILE__, __LINE__, iRefreshMode);
     bbep.setLightSleep(true);
     bbep.refresh(iRefreshMode, bWait);
@@ -1410,6 +1513,8 @@ void display_show_image(uint8_t *image_buffer, int data_size, bool bWait)
         bbep.freeBuffer();
     }
     iUpdateCount++;
+#elif defined(IT8951_EPAPER)
+    it8951_flush_framebuffer();
 #else
     bbep.setCustomMatrix(u8_graytable, sizeof(u8_graytable));
     bbep.fullUpdate();
@@ -1481,7 +1586,7 @@ void display_show_msg(uint8_t *image_buffer, MSG message_type)
 #endif
     }
 
-#ifdef BOARD_TRMNL_X
+#if defined(BOARD_TRMNL_X) || defined(BOARD_SEEED_RETERMINAL_E1003)
     bbep.setFont(Inter_18);
 #else
     bbep.setFont(nicoclean_8);
@@ -1774,6 +1879,8 @@ void display_show_msg(uint8_t *image_buffer, MSG message_type)
     bbep.writePlane(PLANE_0);
     bbep.refresh(REFRESH_FULL, true);
     bbep.freeBuffer();
+#elif defined(IT8951_EPAPER)
+    it8951_flush_framebuffer();
 #else
     bbep.fullUpdate();
 #endif
@@ -1862,6 +1969,8 @@ void display_show_msg_qa(uint8_t *image_buffer, const float *voltage, const floa
         bbep.writePlane(PLANE_0);
         bbep.refresh(REFRESH_FULL, true);
         bbep.freeBuffer();
+    #elif defined(IT8951_EPAPER)
+        it8951_flush_framebuffer();
     #else
         bbep.fullUpdate();
     #endif
@@ -1908,6 +2017,8 @@ void display_show_msg(uint8_t *image_buffer, MSG message_type, String friendly_i
         } else {
             bbep.refresh(REFRESH_FULL, true); // incompatible panel (for now)
         }
+#elif defined(IT8951_EPAPER)
+        it8951_flush_framebuffer();
 #else
         bbep.fullUpdate();
 #endif
@@ -1941,7 +2052,7 @@ void display_show_msg(uint8_t *image_buffer, MSG message_type, String friendly_i
 #endif
     }
 
-#ifdef BOARD_TRMNL_X
+#if defined(BOARD_TRMNL_X) || defined(BOARD_SEEED_RETERMINAL_E1003)
     bbep.setFont(Inter_18);
 #else
     bbep.setFont(nicoclean_8);
@@ -2004,7 +2115,7 @@ void display_show_msg(uint8_t *image_buffer, MSG message_type, String friendly_i
         UWORD y_start = 340;
         UWORD font_width = 18; // DEBUG
         Paint_DrawMultilineText(0, y_start, message.c_str(), width, font_width, BBEP_BLACK, BBEP_WHITE,
-#ifdef BOARD_TRMNL_X
+#if defined(BOARD_TRMNL_X) || defined(BOARD_SEEED_RETERMINAL_E1003)
         Inter_18, true);
 #else
         nicoclean_8, true);
@@ -2019,6 +2130,8 @@ void display_show_msg(uint8_t *image_buffer, MSG message_type, String friendly_i
     bbep.writePlane(PLANE_0);
     bbep.refresh(REFRESH_FULL, true);
     bbep.freeBuffer();
+#elif defined(IT8951_EPAPER)
+    it8951_flush_framebuffer();
 #else
     bbep.fullUpdate();
 #endif
@@ -2035,6 +2148,8 @@ void display_sleep(void)
     Log_info("Goto Sleep...");
 #ifdef BB_EPAPER
     bbep.sleep(DEEP_SLEEP);
+#elif defined(IT8951_EPAPER)
+    it8951.sleep();
 #else
     bbep.einkPower(0);
     bbep.deInit();


### PR DESCRIPTION
Add a new board target for the Seeed reTerminal E1003, which uses an IT8951 controller driving a 10.3-inch 1872×1404 ePaper display over SPI. 

This PR would not have been possible without @koosoli's work on https://github.com/koosoli/Seeed-10.3-inch-IT8951-ESPHome-Drivers.

## New IT8951 driver library (`lib/it8951/`)

A self-contained IT8951 controller driver that handles:
- Multi-attempt SPI probe sequence with automatic VCOM calibration
- Hardware reset and power cycling
- 4bpp grayscale framebuffer upload with row-reversed word order
- 1bpp sharp-text upload path, automatically selected when the framebuffer contains only pure black/white pixels
- Display refresh, sleep, and ready-wait commands

## Board configuration

- New PlatformIO environment `seeed_reTerminal_E1003` extending `esp32_base` with PSRAM support and the FastEPD rendering backend
- Updated `bb_epaper` dependency to `3d3df73aa2`