### PR TITLE
Add printf attribute to logging functions and fix any warnings

### DIFF
--- a/lib/trmnl/include/compiler_attrs.h
+++ b/lib/trmnl/include/compiler_attrs.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <inttypes.h>
+
 #if defined(__GNUC__) || defined(__clang__)
 #  define PRINTF_LIKE(fmt, args) __attribute__((format(printf, fmt, args)))
 #else

--- a/lib/trmnl/include/compiler_attrs.h
+++ b/lib/trmnl/include/compiler_attrs.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#if defined(__GNUC__) || defined(__clang__)
+#  define PRINTF_LIKE(fmt, args) __attribute__((format(printf, fmt, args)))
+#else
+#  define PRINTF_LIKE(fmt, args)
+#endif

--- a/lib/trmnl/include/compiler_attrs.h
+++ b/lib/trmnl/include/compiler_attrs.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <inttypes.h>
+
 #if defined(__GNUC__) || defined(__clang__)
-#  define PRINTF_LIKE(fmt, args) __attribute__((format(printf, fmt, args)))
+#define PRINTF_LIKE(fmt, args) __attribute__((format(printf, fmt, args)))
 #else
-#  define PRINTF_LIKE(fmt, args)
+#define PRINTF_LIKE(fmt, args)
 #endif

--- a/lib/trmnl/include/string_utils.h
+++ b/lib/trmnl/include/string_utils.h
@@ -1,5 +1,6 @@
 #pragma once
 
 #include <cstdarg>
+#include <compiler_attrs.h>
 
-void format_message_truncated(char* buffer, int max_size, const char* format, va_list args);
+void format_message_truncated(char* buffer, int max_size, const char* format, va_list args) PRINTF_LIKE(3, 0);

--- a/lib/trmnl/include/string_utils.h
+++ b/lib/trmnl/include/string_utils.h
@@ -1,9 +1,10 @@
 #pragma once
 
 #include <Arduino.h>
+#include <compiler_attrs.h>
 #include <cstdarg>
 
-void format_message_truncated(char *buffer, int max_size, const char *format, va_list args);
+void format_message_truncated(char *buffer, int max_size, const char *format, va_list args) PRINTF_LIKE(3, 0);
 
 // Escape special characters (\,") for use inside quoted ESP-AT string parameter.
 // https://docs.espressif.com/projects/esp-at/en/latest/esp32/AT_Command_Set/index.html

--- a/lib/trmnl/include/trmnl_log.h
+++ b/lib/trmnl/include/trmnl_log.h
@@ -1,6 +1,8 @@
 
 #pragma once
 
+#include <compiler_attrs.h>
+
 enum LogLevel {
     LOG_VERBOSE = 0,
     LOG_INFO = 1,
@@ -15,7 +17,7 @@ enum LogMode
     LOG_SUBMIT_OR_STORE
 };
 
-void log_impl(LogLevel level, LogMode mode, const char* file, int line, const char* format, ...);
+void log_impl(LogLevel level, LogMode mode, const char* file, int line, const char* format, ...) PRINTF_LIKE(5, 6);
 
 #define _LOG_IMPL(level, mode, format, ...) \
     log_impl(level, mode, __FILE__, __LINE__, format, ##__VA_ARGS__)

--- a/lib/trmnl/include/trmnl_log.h
+++ b/lib/trmnl/include/trmnl_log.h
@@ -1,11 +1,13 @@
 
 #pragma once
 
+#include <compiler_attrs.h>
+
 enum LogLevel { LOG_VERBOSE = 0, LOG_INFO = 1, LOG_WARN = 2, LOG_ERROR = 3, LOG_FATAL = 4 };
 
 enum LogMode { LOG_SERIAL_ONLY, LOG_STORE_ONLY, LOG_SUBMIT_OR_STORE };
 
-void log_impl(LogLevel level, LogMode mode, const char *file, int line, const char *format, ...);
+void log_impl(LogLevel level, LogMode mode, const char *file, int line, const char *format, ...) PRINTF_LIKE(5, 6);
 
 #define _LOG_IMPL(level, mode, format, ...) log_impl(level, mode, __FILE__, __LINE__, format, ##__VA_ARGS__)
 

--- a/lib/trmnl/library.json
+++ b/lib/trmnl/library.json
@@ -1,0 +1,6 @@
+{
+  "name": "trmnl",
+  "build": {
+    "flags": ["-Wformat"]
+  }
+}

--- a/lib/trmnl/src/bmp.cpp
+++ b/lib/trmnl/src/bmp.cpp
@@ -32,7 +32,7 @@ bmp_err_e parseBMPHeader(uint8_t *data, bool &reversed)
   uint32_t dataOffset = *(uint32_t *)&data[10];
 
   // Display BMP information
-  Log_info("BMP Header Information:\r\nWidth: %d\r\nHeight: %d\r\nBits per Pixel: %d\r\nCompression Method: %d\r\nImage Data Size: %d\r\nColor Table Entries: %d\r\nData offset: %d", width, height, bitsPerPixel, compressionMethod, imageDataSize, colorTableEntries, dataOffset);
+  Log_info("BMP Header Information:\r\nWidth: %" PRIu32 "\r\nHeight: %" PRIu32 "\r\nBits per Pixel: %d\r\nCompression Method: %" PRIu32 "\r\nImage Data Size: %" PRIu32 "\r\nColor Table Entries: %" PRIu32 "\r\nData offset: %" PRIu32, width, height, bitsPerPixel, compressionMethod, imageDataSize, colorTableEntries, dataOffset);
 
   // Check if there's a color table
   if (dataOffset > 54)
@@ -44,7 +44,7 @@ bmp_err_e parseBMPHeader(uint8_t *data, bool &reversed)
     Log_info("Color table");
     for (uint32_t i = 0; i < colorTableSize; i += 4)
     {
-      Log_info("Color %d: B-%d, R-%d, G-%d, A-%d", i / 4 + 1, data[54 + i], data[55 + i], data[56 + i], data[57 + i]);
+      Log_info("Color %" PRIu32 ": B-%d, R-%d, G-%d, A-%d", i / 4 + 1, data[54 + i], data[55 + i], data[56 + i], data[57 + i]);
     }
 
     if (data[54] == 0 && data[55] == 0 && data[56] == 0 && data[57] == 0 && data[58] == 255 && data[59] == 255 && data[60] == 255 && data[61] == 0)

--- a/lib/trmnl/src/bmp.cpp
+++ b/lib/trmnl/src/bmp.cpp
@@ -1,4 +1,5 @@
 #include <bmp.h>
+#include <inttypes.h>
 #include <trmnl_log.h>
 
 /**
@@ -30,8 +31,9 @@ bmp_err_e parseBMPHeader(uint8_t *data, bool &reversed) {
   uint32_t dataOffset = *(uint32_t *)&data[10];
 
   // Display BMP information
-  Log_info("BMP Header Information:\r\nWidth: %d\r\nHeight: %d\r\nBits per Pixel: %d\r\nCompression Method: "
-           "%d\r\nImage Data Size: %d\r\nColor Table Entries: %d\r\nData offset: %d",
+  Log_info("BMP Header Information:\r\nWidth: %" PRIu32 "\r\nHeight: %" PRIu32
+           "\r\nBits per Pixel: %u\r\nCompression Method: "
+           "%" PRIu32 "\r\nImage Data Size: %" PRIu32 "\r\nColor Table Entries: %" PRIu32 "\r\nData offset: %" PRIu32,
            width, height, bitsPerPixel, compressionMethod, imageDataSize, colorTableEntries, dataOffset);
 
   // Check if there's a color table
@@ -42,7 +44,8 @@ bmp_err_e parseBMPHeader(uint8_t *data, bool &reversed) {
     // Display color table
     Log_info("Color table");
     for (uint32_t i = 0; i < colorTableSize; i += 4) {
-      Log_info("Color %d: B-%d, R-%d, G-%d, A-%d", i / 4 + 1, data[54 + i], data[55 + i], data[56 + i], data[57 + i]);
+      Log_info("Color %" PRIu32 ": B-%d, R-%d, G-%d, A-%d", i / 4 + 1, data[54 + i], data[55 + i], data[56 + i],
+               data[57 + i]);
     }
 
     if (data[54] == 0 && data[55] == 0 && data[56] == 0 && data[57] == 0 && data[58] == 255 && data[59] == 255 &&

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,4 @@
-# This file was automatically generated for projects
-# without default 'CMakeLists.txt' file.
-
 FILE(GLOB_RECURSE app_sources ${CMAKE_SOURCE_DIR}/src/*.*)
 
 idf_component_register(SRCS ${app_sources})
+target_compile_options(${COMPONENT_LIB} PRIVATE -Wformat)

--- a/src/api-client/display.cpp
+++ b/src/api-client/display.cpp
@@ -33,7 +33,7 @@ void addHeaders(HTTPClient &https, ApiDisplayInputs &inputs)
            String(inputs.batteryVoltage).c_str(),
            inputs.firmwareVersion.c_str(),
            inputs.model.c_str(),
-           String(inputs.rssi));
+           String(inputs.rssi).c_str());
 
   https.addHeader("ID", inputs.macAddress);
   https.addHeader("Content-Type", "application/json");
@@ -157,7 +157,7 @@ ApiDisplayResult fetchApiDisplay(ApiDisplayInputs &apiDisplayInputs)
         String payload = https->getString();
         size_t size = https->getSize();
         Log_info("Content size: %d", size);
-        Log_info("Free heap size: %d", ESP.getMaxAllocHeap());
+        Log_info("Free heap size: %" PRIu32, ESP.getMaxAllocHeap());
         Log_info("Payload - %s", payload.c_str());
 
         auto apiResponse = parseResponse_apiDisplay(payload);

--- a/src/api-client/display.cpp
+++ b/src/api-client/display.cpp
@@ -6,6 +6,7 @@
 #include <api_response_parsing.h>
 #include <config.h>
 #include <http_client.h>
+#include <inttypes.h>
 #include <trmnl_log.h>
 extern RTC_DATA_ATTR int iPrevWakeTime; // total wake time of the last cycle (for statistics collection)
 extern RTC_DATA_ATTR bool
@@ -131,7 +132,7 @@ ApiDisplayResult fetchApiDisplay(ApiDisplayInputs &apiDisplayInputs) {
       String payload = https->getString();
       size_t size = https->getSize();
       Log_info("Content size: %d", size);
-      Log_info("Free heap size: %d", ESP.getMaxAllocHeap());
+      Log_info("Free heap size: %" PRIu32, ESP.getMaxAllocHeap());
       Log_info("Payload - %s", payload.c_str());
 
       auto apiResponse = parseResponse_apiDisplay(payload);

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -1699,7 +1699,7 @@ static https_request_err_e downloadAndShow()
             {
               // To avoid surprising behaviour if the server returned a timeout of more than 65 seconds
               // we will send a log message back to the server and truncate the timeout to the maximum.
-              Log_info_submit("Requested image URL timeout too large (%d ms). Using maximum of %d ms.", requestedTimeout, UINT16_MAX);
+              Log_info_submit("Requested image URL timeout too large (%" PRIu32 " ms). Using maximum of %d ms.", requestedTimeout, UINT16_MAX);
               https.setTimeout(UINT16_MAX);
             }
             else
@@ -1814,13 +1814,13 @@ static https_request_err_e downloadAndShow()
 
           if (counter > MAX_IMAGE_SIZE)
           {
-            Log_error_submit("Receiving failed; file size too big: %d", counter);
+            Log_error_submit("Receiving failed; file size too big: %" PRIu32, counter);
             return HTTPS_IMAGE_FILE_TOO_BIG;
           }
 
           if (buffer == NULL)
           {
-            Log_error_submit("Failed to allocate %d bytes for image buffer", counter);
+            Log_error_submit("Failed to allocate %" PRIu32 " bytes for image buffer", counter);
             return HTTPS_OUT_OF_MEMORY;
           }
 
@@ -2014,7 +2014,7 @@ uint32_t downloadStream(WiFiClient *stream, int content_size, uint8_t *buffer)
     delay(10);
   }
 
-  Log_info("Download end: %d/%d bytes in %d ms (%d iterations)", counter, content_size, millis() - download_start, iteration_counter);
+  Log_info("Download end: %d/%d bytes in %lu ms (%d iterations)", counter, content_size, millis() - download_start, iteration_counter);
   return counter;
 }
 
@@ -2891,7 +2891,7 @@ static void downloadSetupImage()
       {
         showMessageWithLogo(WIFI_WEAK);
       }
-      Log_error_submit("Receiving failed. Read: %d", counter);
+      Log_error_submit("Receiving failed. Read: %" PRIu32, counter);
     }
 #endif // !BOARD_TRMNL_X    
     return true; });
@@ -3512,7 +3512,7 @@ static uint8_t *storedLogoOrDefault(int iType)
    BRAND *pBrand;
 
    u32Size = ESP.getFlashChipSize();
-   Log_info("%s [%d]: esp flash size: %d\r\n", __FILE__, __LINE__, u32Size);
+   Log_info("%s [%d]: esp flash size: %" PRIu32 "\r\n", __FILE__, __LINE__, u32Size);
    if (u32Size != 0) {
    pBrand = (BRAND *)malloc(sizeof(BRAND)); // DEBUG - we can leak this memory for now
    esp_flash_init(NULL);

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -1882,7 +1882,7 @@ static https_request_err_e downloadAndShow()
             {
               // To avoid surprising behaviour if the server returned a timeout of more than 65 seconds
               // we will send a log message back to the server and truncate the timeout to the maximum.
-              Log_info_submit("Requested image URL timeout too large (%d ms). Using maximum of %d ms.", requestedTimeout, UINT16_MAX);
+              Log_info_submit("Requested image URL timeout too large (%" PRIu32 " ms). Using maximum of %d ms.", requestedTimeout, UINT16_MAX);
               https.setTimeout(UINT16_MAX);
             }
             else
@@ -1989,7 +1989,7 @@ static https_request_err_e downloadAndShow()
               } // if buffer
               stream->stop(); // Important! If you don't do this, WiFi will have a memory exception later
               if (millis() > (lStartTime + API_FIRST_RETRY*1000)) { // we timed out
-                  Log_error_submit("Receiving failed; download timed out. Image size = %d", counter);
+                  Log_error_submit("Receiving failed; download timed out. Image size = %" PRIu32, counter);
                   return HTTPS_TIMED_OUT;
               }
             }
@@ -2004,13 +2004,13 @@ static https_request_err_e downloadAndShow()
 
           if (counter > MAX_IMAGE_SIZE)
           {
-            Log_error_submit("Receiving failed; file size too big: %d", counter);
+            Log_error_submit("Receiving failed; file size too big: %" PRIu32, counter);
             return HTTPS_IMAGE_FILE_TOO_BIG;
           }
 
           if (buffer == NULL)
           {
-            Log_error_submit("Failed to allocate %d bytes for image buffer", counter);
+            Log_error_submit("Failed to allocate %" PRIu32 " bytes for image buffer", counter);
             return HTTPS_OUT_OF_MEMORY;
           }
 
@@ -2213,7 +2213,7 @@ uint32_t downloadStream(WiFiClient *stream, int content_size, uint8_t *buffer)
     delay(10);
   }
 
-  Log_info("Download end: %d/%d bytes in %d ms (%d iterations)", counter, content_size, millis() - download_start, iteration_counter);
+  Log_info("Download end: %d/%d bytes in %lu ms (%d iterations)", counter, content_size, millis() - download_start, iteration_counter);
   return counter;
 }
 
@@ -3097,7 +3097,7 @@ static void downloadSetupImage()
       {
         showMessageWithLogo(WIFI_WEAK);
       }
-      Log_error_submit("Receiving failed. Read: %d", counter);
+      Log_error_submit("Receiving failed. Read: %" PRIu32, counter);
     }
 #endif // !BOARD_TRMNL_X    
     return true; });
@@ -3616,7 +3616,7 @@ static uint8_t *storedLogoOrDefault(int iType)
    BRAND *pBrand;
 
    u32Size = ESP.getFlashChipSize();
-   Log_info("%s [%d]: esp flash size: %d\r\n", __FILE__, __LINE__, u32Size);
+   Log_info("%s [%d]: esp flash size: %" PRIu32 "\r\n", __FILE__, __LINE__, u32Size);
    if (u32Size != 0) {
    pBrand = (BRAND *)malloc(sizeof(BRAND)); // DEBUG - we can leak this memory for now
    esp_flash_init(NULL);

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -112,7 +112,7 @@ void display_init(void)
 {
     Log_info("dev module start");
     iTempProfile = preferences.getUInt(PREFERENCES_TEMP_PROFILE, TEMP_PROFILE_DEFAULT);
-    Log_info("Saved temperature profile: %d", iTempProfile);
+    Log_info("Saved temperature profile: %" PRIu32, iTempProfile);
 #ifdef BB_EPAPER
     bbep.setPanelType(dpList[iTempProfile].OneBit); // must be set BEFORE calling initio
     Log_info("BB e-Paper init");
@@ -1687,7 +1687,7 @@ void display_show_image(uint8_t *image_buffer, int data_size, bool bWait)
 #ifdef BB_EPAPER
     if (iTempProfile != apiDisplayResult.response.temp_profile) {
         iTempProfile = apiDisplayResult.response.temp_profile;
-        Log_info("Saving new temperature profile (%d) to FLASH", iTempProfile);
+        Log_info("Saving new temperature profile (%" PRIu32 ") to FLASH", iTempProfile);
         preferences.putUInt(PREFERENCES_TEMP_PROFILE, iTempProfile);
     }
     if ((iUpdateCount & 7) == 0 || apiDisplayResult.response.maximum_compatibility == true) {
@@ -2371,11 +2371,11 @@ void display_show_msg_qa(uint8_t *image_buffer, const float *voltage, const floa
  */
 void display_show_msg(uint8_t *image_buffer, MSG message_type, String friendly_id, bool id, const char *fw_version, String message)
 {
-    Log_info("Free heap in display_show_msg - %d", ESP.getMaxAllocHeap());
+    Log_info("Free heap in display_show_msg - %" PRIu32, ESP.getMaxAllocHeap());
     Log_info("maximum_compatibility = %d\n", apiDisplayResult.response.maximum_compatibility);
 #ifdef BB_EPAPER
     bbep.allocBuffer(false);
-    Log_info("Free heap after bbep.allocBuffer() - %d", ESP.getMaxAllocHeap());
+    Log_info("Free heap after bbep.allocBuffer() - %" PRIu32, ESP.getMaxAllocHeap());
 #endif
 
     if (message_type == WIFI_CONNECT)

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -100,6 +100,7 @@ RTC_DATA_ATTR bool bCanDoPartial = false;
 #include "wifi_failed_qr.h"
 #include <ctype.h> //iscntrl()
 #include <api-client/display.h>
+#include <inttypes.h>
 #include <trmnl_log.h>
 #include "png_flip.h"
 #include "nicoclean_8.h"
@@ -143,7 +144,7 @@ void display_init(void)
 {
     Log_info("dev module start");
     iTempProfile = preferences.getUInt(PREFERENCES_TEMP_PROFILE, TEMP_PROFILE_DEFAULT);
-    Log_info("Saved temperature profile: %d", iTempProfile);
+    Log_info("Saved temperature profile: %" PRIu32, iTempProfile);
 #ifdef BB_EPAPER
 #ifdef BOARD_SEEED_STICKY
     pinMode(47, OUTPUT); // enable EPD power
@@ -1791,7 +1792,7 @@ void display_show_image(uint8_t *image_buffer, int data_size, bool bWait, bool b
     Log_info("Display refresh start");
     if (iTempProfile != apiDisplayResult.response.temp_profile) {
         iTempProfile = apiDisplayResult.response.temp_profile;
-        Log_info("Saving new temperature profile (%d) to FLASH", iTempProfile);
+        Log_info("Saving new temperature profile (%" PRIu32 ") to FLASH", iTempProfile);
         preferences.putUInt(PREFERENCES_TEMP_PROFILE, iTempProfile);
     }
 #ifdef BB_EPAPER
@@ -2538,11 +2539,11 @@ void display_show_msg_qa(uint8_t *image_buffer, const float *voltage, const floa
  */
 void display_show_msg(uint8_t *image_buffer, MSG message_type, String friendly_id, bool id, const char *fw_version, String message)
 {
-    Log_info("Free heap in display_show_msg - %d", ESP.getMaxAllocHeap());
+    Log_info("Free heap in display_show_msg - %" PRIu32, ESP.getMaxAllocHeap());
     Log_info("maximum_compatibility = %d\n", apiDisplayResult.response.maximum_compatibility);
 #ifdef BB_EPAPER
     bbep.allocBuffer(false);
-    Log_info("Free heap after bbep.allocBuffer() - %d", ESP.getMaxAllocHeap());
+    Log_info("Free heap after bbep.allocBuffer() - %" PRIu32, ESP.getMaxAllocHeap());
 #else
     bbep.setMode(BB_MODE_1BPP); // message screens are 1-bit
 #endif

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -148,7 +148,7 @@ bool bDel;
         strcpy(szTemp, "/"); // needed on this file operation
         strcat(szTemp, file.name());
 
-        Log_info("Comparing name %s with %s, timestamp %u, current time %u", name, file.name(), u32, (uint32_t)tt);
+        Log_info("Comparing name %s with %s, timestamp %" PRIu32 ", current time %" PRIu32, name, file.name(), u32, (uint32_t)tt);
         if (memcmp(name, szTemp, 14) == 0) { // older version of the same file
             Log_info("Deleting older version of plugin image %s - %s", name, file.name());
             bDel = true;
@@ -176,7 +176,7 @@ bool bDel;
 size_t filesystem_write_to_file(const char *name, uint8_t *in_buffer, size_t size)
 {
     uint32_t FS_freeBytes = (FS.totalBytes() - FS.usedBytes());
-    Log_info("FS free space - %d, total -%d", FS_freeBytes, FS.totalBytes());
+    Log_info("FS free space - %" PRIu32 ", total -%" PRIu32, FS_freeBytes, (uint32_t)FS.totalBytes());
     if (FS.exists(name))
     {
         Log_info("file %s exists. Deleting...", name);

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -1,5 +1,6 @@
 #include <Arduino.h>
 #include <filesystem.h>
+#include <inttypes.h>
 #include <trmnl_log.h>
 
 #if defined(BOARD_X_CLASS)
@@ -132,7 +133,8 @@ void filesystem_purge_old_file(const char *name) {
     strcpy(szTemp, "/"); // needed on this file operation
     strcat(szTemp, file.name());
 
-    Log_info("Comparing name %s with %s, timestamp %u, current time %u", name, file.name(), timestamp, (uint32_t)now);
+    Log_info("Comparing name %s with %s, timestamp %" PRIu32 ", current time %" PRIu32, name, file.name(), timestamp,
+             (uint32_t)now);
     if (strncmp(name, szTemp, 14) == 0) { // older version of the same file
       Log_info("Deleting older version of plugin image %s - %s", name, file.name());
       bDel = true;
@@ -159,7 +161,7 @@ void filesystem_purge_old_file(const char *name) {
  */
 size_t filesystem_write_to_file(const char *name, uint8_t *in_buffer, size_t size) {
   uint32_t FS_freeBytes = (FS.totalBytes() - FS.usedBytes());
-  Log_info("FS free space - %d, total -%d", FS_freeBytes, FS.totalBytes());
+  Log_info("FS free space - %" PRIu32 ", total -%zu", FS_freeBytes, FS.totalBytes());
   if (FS.exists(name)) {
     Log_info("file %s exists. Deleting...", name);
     if (FS.remove(name))


### PR DESCRIPTION
Adds a macro that enables the printf attribute on GCC/Clang.
It seems that the ESP IDF adds -Wno-format.
So this enables -Wformat for just the exe (in CMake) and just the trmnl lib (in PlatformIO).
I also fixed any warnings that came up.