### PR TITLE
Fix infinite loop in storeLogString

### DIFF
--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -3369,7 +3369,10 @@ bool storeLogString(const char *log_buffer)
   LogStoreResult store_result = storedLogs.store_log(String(log_buffer));
   if (store_result.status != LogStoreResult::SUCCESS)
   {
-    Log_error("Failed to store log: %s", store_result.message);
+    // Use the serial-only variant to avoid infinite recursion: Log_error here
+    // would route back into log_impl → handle_store_submit → logWithAction →
+    // storeLogString → store fails again → ...
+    Log_error_serial("Failed to store log: %s", store_result.message);
     return false;
   }
   return true;


### PR DESCRIPTION
I'm starting to write some hardware integration tests, and in that process I hit an infinite loop in `storeLogString()`.

If log storage fails, it attempts to log that error… in log storage. You can see the problem.

The fix is to only log that failure to serial output.