### PR TITLE
Better /scripts

### DIFF
--- a/scripts/flash_merged.sh
+++ b/scripts/flash_merged.sh
@@ -44,7 +44,7 @@ fi
 echo ""
 echo "⚡ Flashing firmware (chip: $CHIP, mode: $MODE_LABEL)..."
 
-if $ESPTOOL --chip "$CHIP" --baud "$BAUD_RATE" "${EXTRA_OPTS[@]}" write_flash "${WRITE_OPTS[@]}" 0x0000 "$FIRMWARE_FILE"; then
+if PYTHONIOENCODING=utf-8 $ESPTOOL --chip "$CHIP" --baud "$BAUD_RATE" "${EXTRA_OPTS[@]}" write_flash "${WRITE_OPTS[@]}" 0x0000 "$FIRMWARE_FILE"; then
     echo ""
     echo "✅ Flash completed successfully!"
     echo "🔄 Device will reboot automatically"

--- a/scripts/flash_merged.sh
+++ b/scripts/flash_merged.sh
@@ -2,19 +2,39 @@
 
 set -e
 
-if [ $# -eq 0 ]; then
-    echo "Usage: $0 <merged_firmware.bin>"
-    echo "  merged_firmware.bin: path to merged firmware file"
-    echo ""
-    echo "Example:"
-    echo "  $0 my-image.bin"
+if [ $# -lt 1 ] || [ $# -gt 2 ]; then
+    cat <<'EOF'
+Usage: scripts/flash_merged.sh <merged_firmware.bin> [chip]
+  merged_firmware.bin: path to merged firmware file
+  chip:                (optional) target chip, e.g. esp32c3 (trmnl) or esp32s3 (TRMNL_X).
+                       Defaults to 'auto' so esptool detects the connected chip.
+
+Env vars:
+  NO_STUB=1   Flash via the ROM loader instead of the stub flasher (slower, but
+              works around "chip stopped responding" on large writes over the
+              ESP32-S3 USB-Serial/JTAG link). Implies --no-compress.
+
+Examples:
+  scripts/flash_merged.sh my-image.bin                 # auto-detect chip
+  scripts/flash_merged.sh my-image.bin esp32s3         # force ESP32-S3 (TRMNL_X)
+  NO_STUB=1 scripts/flash_merged.sh my-image.bin esp32s3
+EOF
     exit 1
 fi
 
 FIRMWARE_FILE="$1"
+CHIP="${2:-auto}"
 BAUD_RATE=$((115200 * 4))
 ESPTOOL="pio pkg exec -p tool-esptoolpy esptool.py -- "
-ESPTOOL_CMD="$ESPTOOL --chip esp32c3 --baud $BAUD_RATE"
+
+WRITE_OPTS=()
+EXTRA_OPTS=()
+MODE_LABEL="stub"
+if [ "${NO_STUB:-0}" != "0" ]; then
+    EXTRA_OPTS+=(--no-stub)
+    WRITE_OPTS+=(--no-compress)
+    MODE_LABEL="no-stub"
+fi
 
 if [ ! -f "$FIRMWARE_FILE" ]; then
     echo "Error: Firmware file not found: $FIRMWARE_FILE"
@@ -22,11 +42,9 @@ if [ ! -f "$FIRMWARE_FILE" ]; then
 fi
 
 echo ""
-echo "⚡ Flashing firmware..."
+echo "⚡ Flashing firmware (chip: $CHIP, mode: $MODE_LABEL)..."
 
-$ESPTOOL_CMD write_flash 0x0000 "$FIRMWARE_FILE"
-
-if [ $? -eq 0 ]; then
+if $ESPTOOL --chip "$CHIP" --baud "$BAUD_RATE" "${EXTRA_OPTS[@]}" write_flash "${WRITE_OPTS[@]}" 0x0000 "$FIRMWARE_FILE"; then
     echo ""
     echo "✅ Flash completed successfully!"
     echo "🔄 Device will reboot automatically"
@@ -34,6 +52,11 @@ if [ $? -eq 0 ]; then
 else
     echo ""
     echo "❌ Flash failed!"
+    if [ "${NO_STUB:-0}" = "0" ]; then
+        echo "💡 If it died mid-write with \"chip stopped responding\" (common on ESP32-S3"
+        echo "   USB-Serial/JTAG with large images), retry with the ROM loader:"
+        echo "     NO_STUB=1 $0 $FIRMWARE_FILE $CHIP"
+    fi
     echo ""
     exit 1
 fi

--- a/scripts/merge_firmware.sh
+++ b/scripts/merge_firmware.sh
@@ -2,47 +2,96 @@
 
 set -e
 
-if [ $# -eq 2 ]; then
-    BUILD_DIR=$1
-    OUTPUT_NAME=$2
-else
-    echo "Usage: $0 [build_directory] [output_name]"
-    echo "  build_directory: relative path to directory containing bootloader.bin, partitions.bin, firmware.bin"
-    echo "  output_name: name for output file"
-    echo ""
-    echo "Example:"
-    echo "  $0 .pio/build/trmnl my-image.bin"
+usage() {
+    cat <<'EOF'
+Usage: scripts/merge_firmware.sh <build_directory> <output_name> [littlefs.bin] [fs_offset]
+  build_directory: path to directory containing bootloader.bin, partitions.bin, firmware.bin
+  output_name:     name for the merged output file
+  littlefs.bin:    (optional) path to a filesystem image to append
+  fs_offset:       (optional) flash offset for the filesystem image (defaults to the board profile)
+
+Board profile (chip / flash settings / partition offsets) is auto-detected from the
+build directory name. Override with the BOARD env var. Supported:
+  trmnl   -> esp32c3, dio/40m/4MB,  app @ 0x10000, fs @ 0x3B0000   (default)
+  TRMNL_X -> esp32s3, qio/80m/16MB, app @ 0x20000, fs @ 0x620000
+
+Examples:
+  scripts/merge_firmware.sh .pio/build/trmnl my-image.bin
+  scripts/merge_firmware.sh .pio/build/trmnl my-image.bin .pio/build/trmnl/littlefs.bin
+  scripts/merge_firmware.sh .pio/build/TRMNL_X trmnl_x.bin .pio/build/littlefs.bin
+  BOARD=TRMNL_X scripts/merge_firmware.sh some/dir trmnl_x.bin some/dir/littlefs.bin
+EOF
+}
+
+if [ $# -lt 2 ] || [ $# -gt 4 ]; then
+    usage
     exit 1
 fi
+
+BUILD_DIR=$1
+OUTPUT_NAME=$2
+LITTLEFS_BIN=${3:-}
+FS_OFFSET_OVERRIDE=${4:-}
+
+BOARD=${BOARD:-$(basename "$BUILD_DIR")}
+
+case "$BOARD" in
+    TRMNL_X*)
+        CHIP=esp32s3
+        FLASH_MODE=qio
+        FLASH_FREQ=80m
+        FLASH_SIZE=16MB
+        APP_OFFSET=0x20000
+        FS_OFFSET_DEFAULT=0x620000
+        ;;
+    *)  # trmnl, trmnl_4clr, xteink_x4, local, ... (ESP32-C3, min_spiffs.csv)
+        CHIP=esp32c3
+        FLASH_MODE=dio
+        FLASH_FREQ=40m
+        FLASH_SIZE=4MB
+        APP_OFFSET=0x10000
+        FS_OFFSET_DEFAULT=0x3B0000
+        ;;
+esac
+
+FS_OFFSET=${FS_OFFSET_OVERRIDE:-$FS_OFFSET_DEFAULT}
 
 # Check if build files exist
-if [ ! -f "$BUILD_DIR/bootloader.bin" ]; then
-    echo "Error: bootloader.bin not found. Run 'pio run -e trmnl' first."
-    exit 1
-fi
+for f in bootloader.bin partitions.bin firmware.bin; do
+    if [ ! -f "$BUILD_DIR/$f" ]; then
+        echo "Error: $f not found in $BUILD_DIR. Run 'pio run -e $BOARD' first."
+        exit 1
+    fi
+done
 
-if [ ! -f "$BUILD_DIR/partitions.bin" ]; then
-    echo "Error: partitions.bin not found. Run 'pio run -e trmnl' first."
-    exit 1
-fi
-
-if [ ! -f "$BUILD_DIR/firmware.bin" ]; then
-    echo "Error: firmware.bin not found. Run 'pio run -e trmnl' first."
+if [ -n "$LITTLEFS_BIN" ] && [ ! -f "$LITTLEFS_BIN" ]; then
+    echo "Error: filesystem image not found: $LITTLEFS_BIN"
+    echo "Run 'pio run -e $BOARD -t buildfs' first."
     exit 1
 fi
 
 ESPTOOL="pio pkg exec -p tool-esptoolpy esptool.py -- "
 
+echo "Board profile: $BOARD  (chip=$CHIP mode=$FLASH_MODE freq=$FLASH_FREQ size=$FLASH_SIZE app@$APP_OFFSET)"
 echo "Using esptool: $ESPTOOL"
 
-$ESPTOOL --chip esp32c3 merge_bin \
-    -o "$OUTPUT_NAME" \
-    --flash_mode dio \
-    --flash_freq 40m \
-    --flash_size 4MB \
-    0x0000 "$BUILD_DIR/bootloader.bin" \
-    0x8000 "$BUILD_DIR/partitions.bin" \
-    0x10000 "$BUILD_DIR/firmware.bin"
+MERGE_ARGS=(
+    --chip "$CHIP" merge_bin
+    -o "$OUTPUT_NAME"
+    --flash_mode "$FLASH_MODE"
+    --flash_freq "$FLASH_FREQ"
+    --flash_size "$FLASH_SIZE"
+    0x0000 "$BUILD_DIR/bootloader.bin"
+    0x8000 "$BUILD_DIR/partitions.bin"
+    "$APP_OFFSET" "$BUILD_DIR/firmware.bin"
+)
+
+if [ -n "$LITTLEFS_BIN" ]; then
+    echo "Including filesystem image $LITTLEFS_BIN at $FS_OFFSET"
+    MERGE_ARGS+=("$FS_OFFSET" "$LITTLEFS_BIN")
+fi
+
+$ESPTOOL "${MERGE_ARGS[@]}"
 
 if [ $? -eq 0 ]; then
     echo ""
@@ -50,7 +99,10 @@ if [ $? -eq 0 ]; then
     echo "📁 Location: $OUTPUT_NAME"
     echo ""
     echo "To flash this merged firmware:"
-    echo "./scripts/flash_merged.sh $OUTPUT_NAME"
+    echo "./scripts/flash_merged.sh $OUTPUT_NAME $CHIP"
+    if [ "$CHIP" = "esp32s3" ]; then
+        echo "  (if it dies mid-write with \"chip stopped responding\", use: NO_STUB=1 ./scripts/flash_merged.sh $OUTPUT_NAME $CHIP)"
+    fi
     echo ""
 else
     echo "❌ Failed to create merged firmware"

--- a/scripts/merge_firmware.sh
+++ b/scripts/merge_firmware.sh
@@ -38,7 +38,7 @@ BOARD=${BOARD:-$(basename "$BUILD_DIR")}
 case "$BOARD" in
     TRMNL_X*)
         CHIP=esp32s3
-        FLASH_MODE=qio
+        FLASH_MODE=dio
         FLASH_FREQ=80m
         FLASH_SIZE=16MB
         APP_OFFSET=0x20000


### PR DESCRIPTION
X model cannot be built/flashed with native PlatformIO toolbar because `littlefs.bin` is excluded.

this PR extends `scripts/merge_firmware` to support this 4th address, and also extends `scripts/flash_firmware` to auto select a chip based on the detected (connected) USB device.

usage (`trmnl` or `TRMNL_X` env)
1. PlatformIO toolbar > "build" (checkmark)
2. below
3. 
```sh
# OG - upload
# use PlatformIO toolbar > "upload" (right arrow)

# X - merge littlefs.bin
./scripts/merge_firmware.sh .pio/build/TRMNL_X trmnl_x.bin .pio/build/littlefs.bin

# X - upload
./scripts/flash_merged.sh trmnl_x.bin
```