### PR TITLE
Added the temp profile to the X configuration to signify less ghosting

### DIFF
--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -720,6 +720,26 @@ void bl_init(void)
                       wakeup_reason == ESP_SLEEP_WAKEUP_EXT0 ||
                       wakeup_reason == ESP_SLEEP_WAKEUP_EXT1);
 
+  Log_info("preferences start");
+  bool res = preferences.begin("data", false);
+  if (res)
+  {
+    Log_info("preferences init success (%d free entries)", preferences.freeEntries());
+    if (pref_clear)
+    {
+      res = preferences.clear(); // if needed to clear the saved data
+      if (res)
+        Log_info("preferences cleared success");
+      else
+        Log_fatal("preferences clearing error");
+    }
+  }
+  else
+  {
+    Log_fatal("preferences init failed");
+    ESP.restart();
+  }
+  Log_info("preferences end");
   #ifndef BOARD_TRMNL_X
   if (gpio_wakeup)
   {
@@ -768,26 +788,6 @@ void bl_init(void)
   }
 #endif // BOARD_TRMNL_X
 
-  Log_info("preferences start");
-  bool res = preferences.begin("data", false);
-  if (res)
-  {
-    Log_info("preferences init success (%d free entries)", preferences.freeEntries());
-    if (pref_clear)
-    {
-      res = preferences.clear(); // if needed to clear the saved data
-      if (res)
-        Log_info("preferences cleared success");
-      else
-        Log_fatal("preferences clearing error");
-    }
-  }
-  else
-  {
-    Log_fatal("preferences init failed");
-    ESP.restart();
-  }
-  Log_info("preferences end");
 #ifdef BOARD_TRMNL_X
   touchbar_tap_mode = preferences.getBool(PREFERENCES_TOUCHBAR_MODE_KEY, true);
   Log_info("Touchbar mode from preferences: %s", touchbar_tap_mode ? "Tap" : "Slide");

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1684,12 +1684,12 @@ void display_show_image(uint8_t *image_buffer, int data_size, bool bWait)
         iUpdateCount = 1; // use partial update
     }
     Log_info("Display refresh start");
-#ifdef BB_EPAPER
     if (iTempProfile != apiDisplayResult.response.temp_profile) {
         iTempProfile = apiDisplayResult.response.temp_profile;
         Log_info("Saving new temperature profile (%d) to FLASH", iTempProfile);
         preferences.putUInt(PREFERENCES_TEMP_PROFILE, iTempProfile);
     }
+#ifdef BB_EPAPER
     if ((iUpdateCount & 7) == 0 || apiDisplayResult.response.maximum_compatibility == true) {
         Log_info("%s [%d]: Forcing full refresh; desired refresh mode was: %d\r\n", __FILE__, __LINE__, iRefreshMode);
         iRefreshMode = REFRESH_FULL; // force full refresh every 8 partials
@@ -1725,7 +1725,9 @@ void display_show_image(uint8_t *image_buffer, int data_size, bool bWait)
  //       bbep.setPasses(6,6);
  //       bbep.partialUpdate(false); // we have a previous image to diff against; use a non-flickering update
  //   } else {
-        bbep.fullUpdate(((iUpdateCount & 7) == 0) ? CLEAR_SLOW : CLEAR_FAST, false);
+        int iClearMode = ((iUpdateCount & 7) == 0 || (iTempProfile > 0)) ? CLEAR_SLOW : CLEAR_FAST;
+        Log_info("fullUpdate clear mode = %d\n", iClearMode); 
+        bbep.fullUpdate(iClearMode, false);
  //   }
  }
 #endif


### PR DESCRIPTION
This change allows users to control the amount of "black/white" wiping which occurs between each image update on their X. The temperature profile setting (in the firmware area of the web portal) defaults to "default". With this setting, the X will use a single B/W wipe to clear the screen of ghosting before each image update. If the user changes it to A or B, it will use two B/W wipes to reduce ghosting.
