### PR TITLE
Adding webp file support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,10 @@
 cmake_minimum_required(VERSION 3.16.0)
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(trmnl-firmware)
+
+# libwebp is pulled in via FetchContent from src/CMakeLists.txt. Its static archives
+# are empty under this ESP-IDF/CMake build, so link the decoder object targets directly.
+set(_trmnl_project_elf "${CMAKE_PROJECT_NAME}.elf")
+if(TARGET "${_trmnl_project_elf}" AND TARGET webpdecode AND TARGET webpdspdecode AND TARGET webputilsdecode)
+    target_link_libraries("${_trmnl_project_elf}" PRIVATE webpdecode webpdspdecode webputilsdecode)
+endif()

--- a/include/webp_decode.h
+++ b/include/webp_decode.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** True if buffer looks like a RIFF/WEBP container. */
+int is_webp_buffer(const uint8_t *data, int size);
+
+/**
+ * Decode WebP into the FastEPD framebuffer (4-bpp) when `BOARD_X_CLASS` is defined.
+ * On other boards returns WEBP_ERR_DECODE (server should not send WebP there).
+ * @param decode_to_previous 0 = current buffer; non-zero = previous buffer (partial updates).
+ * @return 0 on success, negative WEBP_ERR_* codes on failure.
+ */
+int webp_to_epd(const uint8_t *data, int size, int decode_to_previous);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,43 @@
 # This file was automatically generated for projects
 # without default 'CMakeLists.txt' file.
 
+# ESP-IDF runs this file again with CMAKE_BUILD_EARLY_EXPANSION=1 to collect
+# component requirements; FetchContent is not allowed in that phase (CMake 4.x).
+if(NOT CMAKE_BUILD_EARLY_EXPANSION)
+    include(FetchContent)
+    set(WEBP_BUILD_ANIM_UTILS OFF CACHE BOOL "" FORCE)
+    set(WEBP_BUILD_CWEBP OFF CACHE BOOL "" FORCE)
+    set(WEBP_BUILD_DWEBP OFF CACHE BOOL "" FORCE)
+    set(WEBP_BUILD_GIF2WEBP OFF CACHE BOOL "" FORCE)
+    set(WEBP_BUILD_IMG2WEBP OFF CACHE BOOL "" FORCE)
+    set(WEBP_BUILD_VWEBP OFF CACHE BOOL "" FORCE)
+    set(WEBP_BUILD_WEBPINFO OFF CACHE BOOL "" FORCE)
+    set(WEBP_BUILD_LIBWEBPMUX OFF CACHE BOOL "" FORCE)
+    set(WEBP_BUILD_WEBPMUX OFF CACHE BOOL "" FORCE)
+    set(WEBP_BUILD_EXTRAS OFF CACHE BOOL "" FORCE)
+    set(WEBP_BUILD_WEBP_JS OFF CACHE BOOL "" FORCE)
+    set(WEBP_USE_THREAD OFF CACHE BOOL "" FORCE)
+    set(WEBP_ENABLE_SIMD OFF CACHE BOOL "" FORCE)
+    set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
+
+    FetchContent_Declare(
+        trmnl_libwebp
+        GIT_REPOSITORY https://github.com/webmproject/libwebp.git
+        GIT_TAG        v1.4.0
+        GIT_SHALLOW    TRUE
+    )
+    FetchContent_MakeAvailable(trmnl_libwebp)
+endif()
+
 FILE(GLOB_RECURSE app_sources ${CMAKE_SOURCE_DIR}/src/*.*)
 
 idf_component_register(SRCS ${app_sources})
+
+if(NOT CMAKE_BUILD_EARLY_EXPANSION)
+    # Linking webp to ${COMPONENT_LIB} does not reach firmware.elf: ESP-IDF links the ELF
+    # only to component targets, not transitive CMake deps. See root CMakeLists.txt.
+    target_include_directories(${COMPONENT_LIB} PRIVATE
+        "${trmnl_libwebp_SOURCE_DIR}/src"
+        "${trmnl_libwebp_BINARY_DIR}/src"
+    )
+endif()

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -16,6 +16,7 @@
 #include <Preferences.h>
 #include <cstdint>
 #include "png.h"
+#include "webp_decode.h"
 #include <bmp.h>
 #include <Update.h>
 #include <math.h>
@@ -124,6 +125,15 @@ void log_nvs_usage();
 void fixFileName(const char *src, char *dest);
 void config_gpio_for_lp();
 int png_to_epd(const uint8_t *pPNG, int iDataSize, bool bPrevious);
+
+/** Trim, lowercase; true if Content-Type starts with @p lower_prefix (e.g. image/webp;charset=utf-8). */
+static bool http_content_type_lower_starts_with(const String &hdr, const char *lower_prefix)
+{
+  String s = hdr;
+  s.trim();
+  s.toLowerCase();
+  return s.startsWith(lower_prefix);
+}
 
 static unsigned long startup_time = 0;
 
@@ -1509,13 +1519,39 @@ ApiDisplayInputs loadApiDisplayInputs(Preferences &preferences)
 
 void load_prev_image(void)
 {
-  uint8_t *buffer;
-  size_t content_size = 0; //filesystem_read_and_allocate(szPrevFile, &buffer);
-  if (content_size > 0) {
-    // Decode it into the previous buffer
-    Log.info("%s [%d]: Decoding previous image (%s) into FastEPD previous buffer\r\n", __FILE__, __LINE__, szPrevFile);
-    png_to_epd(buffer, content_size, true);
+  if (!szPrevFile[0])
+    return;
+
+  uint8_t *buffer = nullptr;
+  size_t content_size = filesystem_read_and_allocate(szPrevFile, &buffer);
+  if (!buffer || content_size == 0)
+  {
+    Log.info("%s [%d]: load_prev_image: missing or empty %s\r\n", __FILE__, __LINE__, szPrevFile);
+    return;
   }
+
+  const int n = (int)content_size;
+  Log.info("%s [%d]: Decoding previous image (%s, %d bytes) into FastEPD previous buffer\r\n", __FILE__, __LINE__,
+           szPrevFile, n);
+
+  if (n >= 12 && is_webp_buffer(buffer, n))
+  {
+    int wrc = webp_to_epd(buffer, n, 1);
+    if (wrc != 0)
+      Log.error("%s [%d]: load_prev_image WebP decode failed (%d)\r\n", __FILE__, __LINE__, wrc);
+  }
+  else if (n >= 4 && buffer[0] == 0x89 && buffer[1] == 'P' && buffer[2] == 'N' && buffer[3] == 'G')
+  {
+    png_to_epd(buffer, n, true);
+  }
+  else if (n >= 2 && buffer[0] == (char)0xff && buffer[1] == (char)0xd8)
+  {
+    Log.info("%s [%d]: load_prev_image: JPEG not loaded into previous buffer\r\n", __FILE__, __LINE__);
+  }
+  else
+    Log.info("%s [%d]: load_prev_image: unknown format for %s\r\n", __FILE__, __LINE__, szPrevFile);
+
+  free(buffer);
 } /* load_prev_image() */
 
 /**
@@ -1799,8 +1835,11 @@ static https_request_err_e downloadAndShow()
             Log.warning("%s [%d]: Content-Length not provided, using getString()\r\n", __FILE__, __LINE__);
           }
 
-          bool isPNG = https.header("Content-Type") == "image/png";
-          bool isJPEG = https.header("Content-Type") == "image/jpeg";
+          // Plugin image from /api/display: PNG, JPEG, or WebP (Content-Type prefix + RIFF/WEBP sniff).
+          const String content_type = https.header("Content-Type");
+          bool isPNG = http_content_type_lower_starts_with(content_type, "image/png");
+          bool isJPEG = http_content_type_lower_starts_with(content_type, "image/jpeg");
+          bool isWebP = http_content_type_lower_starts_with(content_type, "image/webp");
 
           Log.info("%s [%d]: Starting a download at: %d\r\n", __FILE__, __LINE__, getTime());
           heap_caps_check_integrity_all(true);
@@ -1866,27 +1905,36 @@ static https_request_err_e downloadAndShow()
             Log.info("BMP file detected");
           }
 
+          if (counter >= 12 && is_webp_buffer(buffer, (int)counter))
+          {
+            isWebP = true;
+            isPNG = false;
+            isJPEG = false;
+            Log.info("WebP file detected (RIFF/WEBP signature)");
+          }
+
           submitStoredLogs();
 
           WiFi.disconnect(true); // no need for WiFi, save power starting here
           Log.info("%s [%d]: Received successfully; WiFi off.\r\n", __FILE__, __LINE__);
 
           bool image_reverse = false;
-          if (isPNG || isJPEG)
+          if (isPNG || isJPEG || isWebP)
           {
             char szTemp[36];
             fixFileName(apiDisplayResult.response.filename.c_str(), szTemp);
             Log.info("%s [%d]: Writing %s to SPIFFS\r\n", __FILE__, __LINE__, szTemp);
             filesystem_purge_old_file(szTemp); // try to delete the old version or older than 24h
             writeImageToFile(szTemp, buffer, content_size);
-            Log.info("%s [%d]: Decoding %s\r\n", __FILE__, __LINE__, (isPNG) ? "png" : "jpeg");
+            const char *fmt = isPNG ? "png" : (isJPEG ? "jpeg" : "webp");
+            Log.info("%s [%d]: Decoding %s\r\n", __FILE__, __LINE__, fmt);
+            png_res = PNG_NO_ERR; /* WebP/PNG failures may set this inside display_show_image */
             display_show_image(buffer, content_size, true);
 //            if (payload.length() != content_size) { // we allocated this buffer
 //                Log.info("%s [%d]: Freeing the image payload we allocated\r\n", __FILE__, __LINE__, szTemp);
 //                free(buffer);
 //            }
             buffer = nullptr;
-            png_res = PNG_NO_ERR; // DEBUG
             String _curPath = preferences.getString(PREFERENCES_CURRENT_PATH_KEY, "");
             String _lastPath = preferences.getString(PREFERENCES_LAST_PATH_KEY, "");
             if (!_curPath.isEmpty() && (_curPath != String(szTemp) || _lastPath.isEmpty()))
@@ -1950,7 +1998,8 @@ static https_request_err_e downloadAndShow()
           {
           case BMP_NO_ERR:
           {
-            if (!filesystem_file_exists("/current.png"))
+            if (!filesystem_file_exists("/current.png") &&
+                !filesystem_file_exists("/current.webp"))
             {
               writeImageToFile("/current.bmp", buffer, content_size);
             }
@@ -1993,7 +2042,7 @@ static https_request_err_e downloadAndShow()
             break;
           }
 
-          if (isPNG && png_res != PNG_NO_ERR)
+          if ((isPNG || isWebP) && png_res != PNG_NO_ERR)
           {
             char szTemp[36];
             fixFileName(apiDisplayResult.response.filename.c_str(), szTemp);
@@ -2475,7 +2524,8 @@ https_request_err_e handleApiDisplayResponse(ApiDisplayResponse &apiResponse)
 
           bool image_reverse = false;
 
-          if (!filesystem_file_exists("/current.bmp") && !filesystem_file_exists("/current.png"))
+          if (!filesystem_file_exists("/current.bmp") && !filesystem_file_exists("/current.png") &&
+              !filesystem_file_exists("/current.webp"))
           {
             Log.info("%s [%d]: No current image!\r\n", __FILE__, __LINE__);
             if (buffer) {
@@ -2506,6 +2556,7 @@ https_request_err_e handleApiDisplayResponse(ApiDisplayResponse &apiResponse)
               Log_error_submit("Error parsing BMP header, code: %d", bmp_parse_result);
               return HTTPS_WRONG_IMAGE_FORMAT;
             }
+            file_size = DISPLAY_BMP_IMAGE_SIZE;
           }
           else if (filesystem_file_exists("/current.png"))
           {
@@ -2520,6 +2571,20 @@ https_request_err_e handleApiDisplayResponse(ApiDisplayResponse &apiResponse)
             if (png_parse_result != PNG_NO_ERR)
             {
               Log_error_submit("Error parsing PNG header, code: %d", png_parse_result);
+              if (buffer) {
+                free(buffer);
+                buffer = nullptr;
+              }
+              return HTTPS_WRONG_IMAGE_FORMAT;
+            }
+          }
+          else if (filesystem_file_exists("/current.webp"))
+          {
+            Log.info("%s [%d]: send_to_me WebP\r\n", __FILE__, __LINE__);
+            buffer = display_read_file("/current.webp", &file_size);
+            if (!buffer || file_size <= 0)
+            {
+              Log_error_submit("Error reading WebP image");
               if (buffer) {
                 free(buffer);
                 buffer = nullptr;

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -90,6 +90,9 @@ RTC_DATA_ATTR int iUpdateCount = 0;
 #include <ctype.h> //iscntrl()
 #include <api-client/display.h>
 #include <trmnl_log.h>
+#include "png.h"
+extern image_err_e png_res;
+#include "webp_decode.h"
 #include "png_flip.h"
 #include "nicoclean_8.h"
 #include "Inter_18.h"
@@ -1647,6 +1650,14 @@ void display_show_image(uint8_t *image_buffer, int data_size, bool bWait)
     else if (MOTOSHORT(image_buffer) == 0xffd8) {
         Log_info("Drawing JPEG");
         iRefreshMode = jpeg_to_epd(image_buffer, data_size);
+    }
+    else if (is_webp_buffer(image_buffer, data_size)) {
+        Log_info("Drawing WebP");
+        int wrc = webp_to_epd(image_buffer, data_size, 0);
+        if (wrc != 0) {
+            Log_error("%s [%d]: webp_to_epd failed (%d)\r\n", __FILE__, __LINE__, wrc);
+            png_res = PNG_DECODE_ERR;
+        }
     }
     else // uncompressed BMP or Group5 compressed image
     {

--- a/src/webp_decode.cpp
+++ b/src/webp_decode.cpp
@@ -1,0 +1,148 @@
+#include "webp_decode.h"
+
+#include <Arduino.h>
+#include <stdlib.h>
+
+enum
+{
+    WEBP_ERR_BAD_SIZE = -3,
+    WEBP_ERR_DECODE = -2,
+    WEBP_ERR_MALLOC = -1,
+    WEBP_OK = 0,
+};
+
+#if defined(BOARD_X_CLASS)
+
+#include "FastEPD.h"
+#include "config.h"
+#include "trmnl_log.h"
+#include "webp/decode.h"
+#include "webp/types.h"
+
+extern FASTEPD bbep;
+
+// Pack Y (luma) plane directly into 4-bpp framebuffer.
+// Much cheaper than RGBA: no alpha blend, no RGB→gray conversion needed.
+static void webp_y_to_4bpp_plane(const uint8_t *y_plane, int y_stride,
+                                 int w, int h, uint8_t *pBuffer, int iPitch)
+{
+    for (int y = 0; y < h; y++)
+    {
+        const uint8_t *s = y_plane + (size_t)y * y_stride;
+        uint8_t *d = &pBuffer[y * iPitch];
+        int x = 0;
+        for (; x + 1 < w; x += 2)
+        {
+            uint8_t n0 = s[x] >> 4;
+            uint8_t n1 = s[x + 1] >> 4;
+            *d++ = (uint8_t)((n0 << 4) | n1);
+        }
+        if (x < w)
+            *d = (uint8_t)((s[x] >> 4) << 4);
+    }
+}
+
+#endif /* BOARD_X_CLASS */
+
+extern "C" int is_webp_buffer(const uint8_t *data, int size)
+{
+    if (!data || size < 12)
+        return 0;
+    if (data[0] != 'R' || data[1] != 'I' || data[2] != 'F' || data[3] != 'F')
+        return 0;
+    if (data[8] != 'W' || data[9] != 'E' || data[10] != 'B' || data[11] != 'P')
+        return 0;
+    return 1;
+}
+
+extern "C" int webp_to_epd(const uint8_t *data, int size, int decode_to_previous)
+{
+#if !defined(BOARD_X_CLASS)
+    (void)data;
+    (void)size;
+    (void)decode_to_previous;
+    return WEBP_ERR_DECODE;
+#else
+#ifndef BB_EPAPER
+    if (decode_to_previous && bbep.getPreviousMode() != BB_MODE_NONE)
+        return WEBP_OK;
+#endif
+    int w = 0, h = 0;
+    if (!WebPGetInfo(data, (size_t)size, &w, &h))
+    {
+        Log_error("%s [%d]: WebPGetInfo failed\r\n", __FILE__, __LINE__);
+        return WEBP_ERR_DECODE;
+    }
+    if (w != (int)bbep.width() || h != (int)bbep.height())
+    {
+        Log_error("%s [%d]: WebP size %dx%d, need %dx%d\r\n", __FILE__, __LINE__, w, h,
+                  bbep.width(), bbep.height());
+        return WEBP_ERR_BAD_SIZE;
+    }
+
+    WebPBitstreamFeatures feat;
+    VP8StatusCode st = WebPGetFeatures(data, (size_t)size, &feat);
+    if (st != VP8_STATUS_OK)
+    {
+        Log_error("%s [%d]: WebPGetFeatures status %d\r\n", __FILE__, __LINE__, (int)st);
+        return WEBP_ERR_DECODE;
+    }
+    if (feat.has_animation)
+    {
+        Log_error("%s [%d]: Animated WebP not supported\r\n", __FILE__, __LINE__);
+        return WEBP_ERR_DECODE;
+    }
+
+    // Decode to YUV and use only the Y (luma) plane.
+    // Memory: Y = w*h, U = V = (w/2)*(h/2) ≈ 1.5x w*h total.
+    // For 1872x1404 that's ~3.9 MB vs ~10.5 MB for RGBA.
+    const int uv_w = (w + 1) / 2;
+    const int uv_h = (h + 1) / 2;
+    const size_t y_size  = (size_t)w * h;
+    const size_t uv_size = (size_t)uv_w * uv_h;
+    const size_t total   = y_size + 2 * uv_size;
+
+#ifdef CONFIG_SPIRAM
+    uint8_t *yuv_buf = (uint8_t *)ps_malloc(total);
+#else
+    uint8_t *yuv_buf = (uint8_t *)malloc(total);
+#endif
+    if (!yuv_buf)
+    {
+        Log_error("%s [%d]: WebP YUV buffer alloc failed (%u bytes)\r\n", __FILE__, __LINE__,
+                  (unsigned)total);
+        return WEBP_ERR_MALLOC;
+    }
+
+    uint8_t *y_plane = yuv_buf;
+    uint8_t *u_plane = yuv_buf + y_size;
+    uint8_t *v_plane = u_plane + uv_size;
+
+    if (!WebPDecodeYUVInto(data, (size_t)size,
+                           y_plane, y_size, w,
+                           u_plane, uv_size, uv_w,
+                           v_plane, uv_size, uv_w))
+    {
+        Log_error("%s [%d]: WebPDecodeYUVInto failed\r\n", __FILE__, __LINE__);
+        free(yuv_buf);
+        return WEBP_ERR_DECODE;
+    }
+
+    const int iPitch = bbep.width() / 2;
+    if (decode_to_previous)
+    {
+        bbep.setPreviousMode(BB_MODE_4BPP);
+        webp_y_to_4bpp_plane(y_plane, w, w, h, bbep.previousBuffer(), iPitch);
+        Log_info("%s [%d]: WebP decoded to previous 4-bpp buffer\r\n", __FILE__, __LINE__);
+    }
+    else
+    {
+        bbep.setMode(BB_MODE_4BPP);
+        webp_y_to_4bpp_plane(y_plane, w, w, h, bbep.currentBuffer(), iPitch);
+        Log_info("%s [%d]: WebP decoded to 4-bpp framebuffer\r\n", __FILE__, __LINE__);
+    }
+
+    free(yuv_buf);
+    return WEBP_OK;
+#endif
+}


### PR DESCRIPTION
This PR adds `webp` file support. webp files in some cases leaves a much smaller footprint than PNG (almost 40% smaller file size), this would lead to faster image display and longer battery life.

Tested on TRMNL X