### PR TITLE
Fix RSSI measurement on 5 GHz networks

### DIFF
--- a/lib/trmnl_x/include/modem.h
+++ b/lib/trmnl_x/include/modem.h
@@ -59,4 +59,7 @@ public:
 
   // Returns the MAC address of the ESP32-C5 station, or empty string on failure.
   String getMacAddress();
+
+  // Returns the RSSI (dBm) of the currently joined AP, (replaces WiFi.RSSI() on TRMNL_X)
+  int32_t getSignalRssi();
 };

--- a/lib/trmnl_x/src/modem.cpp
+++ b/lib/trmnl_x/src/modem.cpp
@@ -981,4 +981,37 @@ String Modem::getMacAddress() {
   Serial.printf("[MODEM] MAC: %s\n", mac.c_str());
   return mac;
 }
+// ---------------------------------------------------------------------------
+// getSignalRssi(): AT+CWJAP? — RSSI (dBm) of the joined AP, 0 if not connected
+// ---------------------------------------------------------------------------
+int32_t Modem::getSignalRssi() {
+  while (ModemSerial.available()) ModemSerial.read();  // flush
+
+  sendCommand("AT+CWJAP?");
+  String resp = waitForResponse("OK", 3000);
+
+  // Response (when connected):
+  //   +CWJAP:"ssid","bssid",<channel>,<rssi>,<pci_en>,...\r\nOK
+  // When not connected: "No AP\r\nOK" (no +CWJAP: line).
+  int idx = resp.indexOf("+CWJAP:");
+  if (idx < 0) {
+    Serial.println("[MODEM] getSignalRssi: not connected / parse failed");
+    return 0;
+  }
+
+  // Skip the two quoted fields (ssid, bssid), then channel, to reach rssi.
+  int q2 = resp.indexOf('"', resp.indexOf('"', idx) + 1); // end of ssid
+  int q4 = resp.indexOf('"', resp.indexOf('"', q2 + 1) + 1); // end of bssid
+  int cChannel = resp.indexOf(',', q4 + 1);    // comma before channel
+  int cRssi    = resp.indexOf(',', cChannel + 1); // comma before rssi
+  int cEnd     = resp.indexOf(',', cRssi + 1);    // comma after rssi (or -1)
+  if (q2 < 0 || q4 < 0 || cChannel < 0 || cRssi < 0) {
+    Serial.println("[MODEM] getSignalRssi: field parse failed");
+    return 0;
+  }
+
+  int32_t rssi = resp.substring(cRssi + 1, cEnd >= 0 ? cEnd : resp.length()).toInt();
+  Serial.printf("[MODEM] RSSI: %d dBm\n", rssi);
+  return rssi;
+}
 #endif // BOARD_TRMNL_X

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -1607,6 +1607,12 @@ ApiDisplayInputs loadApiDisplayInputs(Preferences &preferences)
   inputs.firmwareVersion = String(FW_VERSION_STRING);
 
   inputs.rssi = WiFi.RSSI();
+#ifdef BOARD_TRMNL_X
+  // On the 5 GHz path the ESP32-C5 modem owns the Wi-Fi link, so the host's
+  // WiFi.RSSI() reads 0; query the modem for the real signal strength.
+  if (g_modem && WifiCaptivePortal.getLastCredentials().is5GHz)
+    inputs.rssi = g_modem->getSignalRssi();
+#endif // BOARD_TRMNL_X
   inputs.displayWidth = display_width();
   inputs.displayHeight = display_height();
   inputs.model = DEVICE_MODEL;


### PR DESCRIPTION
`WiFi.RSSI()` is not applicable when TRMNL X is on a 5 GHz network. It always returns `0`.

We currently have 792 out of 5,162 X devices reporting RSSI 0.

This PR fetches the RSSI from the ESP32-C5 instead.

Tested and confirmed working on X.

```
>>> GET /api/display  from 192.168.1.234
    Host: 192.168.1.24:8888
    User-Agent: ESP32HTTPClient
    Connection: close
    Accept-Encoding: identity;q=1,chunked;q=0.1,*;q=0
    ID: *redacted*
    Content-Type: application/json
    Update-Source: powercycle
    Access-Token: *redacted*
    Refresh-Rate: 900
    Battery-Voltage: 4.32
    Battery-Count: 2
    Battery-Charging: 0
    USB-Connected: true
    Percent-Charged: 99
    Battery-Health: 99
    Battery-Current: -744
    Battery-Temp: 27.50
    Battery-Capacity: 11280/11400
    FW-Version: 1.8.5
    Model: x
    Image-Cached: false
    Wake-Time: 0
    RSSI: -69 <-------- fixed!
    Temperature-Profile: true
    Width: 1872
    Height: 1404
```