### PR TITLE
serial log connection attempt failure.

### DIFF
--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -1666,7 +1666,7 @@ static https_request_err_e downloadAndShow()
       if (apiDisplayResult.error != HTTPS_UNABLE_TO_CONNECT &&
           apiDisplayResult.error != HTTPS_RESPONSE_CODE_INVALID)
         break;
-      Log_error("Connection attempt %d/5 failed: %s", attempt, apiDisplayResult.error_detail.c_str());
+      Log_error_serial("Connection attempt %d/5 failed: %s", attempt, apiDisplayResult.error_detail.c_str());
       if (attempt < 5) delay(2000);
     }
   }


### PR DESCRIPTION
Seeing a surge in log activity, I see that we send log related to connection attempts starting with this [commit](https://github.com/usetrmnl/trmnl-firmware/commit/0eb67b3b82ccc23e9231cdedd7533ecb982c44db). This PR serial logs the same, as storage is unnecessary when subsequent attempts is success. Log Activity in the server indicates that the device is successfully able to connect after a couple of attempts.

