### PR TITLE
fix image download timeouts on weak wifi (chunked read)

### DIFF
--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -1898,22 +1898,38 @@ static https_request_err_e downloadAndShow()
             counter = https.getSize();
             if (counter && counter <= MAX_IMAGE_SIZE) {
               WiFiClient *stream = https.getStreamPtr();
-              int iLen, iCount = 0;
+              uint32_t iCount = 0;
+
+              // NOTE: Read in chunks rather than one byte at a time. Byte-by-byte issued one
+              // available()/read() pair per byte (~160k calls for a 160KB image), each routed
+              // through mbedtls_ssl_read; chunked issues ~115. When per-call cost is non-trivial this
+              // shortens the download and narrows the window in which a weak-link stall can trip the
+              // timeout. Magnitude depends on per-read overhead (not yet measured on hardware).
+              // Mirrors the chunked pattern already used by downloadStream() for setup/firmware.
+              const unsigned long INACTIVITY_TIMEOUT_MS = 20000; // give up after 20s of no data
+              const unsigned long OVERALL_TIMEOUT_MS = 60000;    // hard cap on total download time
+              unsigned long lOverallStart = millis();
+              lStartTime = millis();
 
               buffer = (uint8_t *)malloc(counter);
               if (buffer) {
-                while (iCount < counter && millis() < (lStartTime + API_FIRST_RETRY*1000)) {
-                  if (stream->available()) {
-                    buffer[iCount++] = stream->read();
-                    lStartTime = millis(); // reset start time
-                  } else { // 15 seconds with no activity => stop trying
+                while (iCount < counter &&
+                       millis() < (lStartTime + INACTIVITY_TIMEOUT_MS) &&
+                       millis() < (lOverallStart + OVERALL_TIMEOUT_MS)) {
+                  int avail = stream->available();
+                  if (avail > 0) {
+                    int toRead = min(avail, (int)(counter - iCount));
+                    iCount += stream->readBytes(buffer + iCount, toRead);
+                    lStartTime = millis(); // reset inactivity timer on data
+                  } else {
                     vTaskDelay(1); // yield to allow time for the data to arrive
                   }
                 }
               } // if buffer
               stream->stop(); // Important! If you don't do this, WiFi will have a memory exception later
-              if (millis() > (lStartTime + API_FIRST_RETRY*1000)) { // we timed out
+              if (iCount < counter) { // we didn't receive the whole image
                   Log_error_submit("Receiving failed; download timed out. Image size = %d", counter);
+                  if (buffer) { free(buffer); buffer = nullptr; }
                   return HTTPS_TIMED_OUT;
               }
             }


### PR DESCRIPTION
this fixes the image download timeouts we've been seeing on trmnl x, like this one:

```json
{
  "message": "Receiving failed; download timed out. Image size = 159962",
  "source_path": "src/bl.cpp",
  "wifi_signal": -77,
  "wifi_status": "connected",
  "free_heap_size": 209015,
  "firmware_version": "1.8.5"
}
```

the device was connected fine and had plenty of free heap, but the ~160kb image download stalled and hit the timeout on a weak signal (-77 dBm). so it's not a memory or connection problem, it's the download itself giving up partway through.

what's actually going on (our working theories):

- the download loop in bl.cpp was reading the stream one byte at a time. for a 160kb image that's ~160,000 read calls, each going through mbedtls_ssl_read. that's slow, so the download stays in flight much longer than it needs to.
- the 15s timeout is an inactivity timeout, it only fires when no data arrives for 15s straight. on a weak link you get short network stalls. the longer a download takes, the more likely one of those stalls lands in the middle of it and trips the timeout. so the slow read doesn't directly cause the timeout, it widens the window for a stall to cause it.
- this is probably why og never hit this and x does: og images are ~5-50kb, x images are bigger (60-250kb+, png on a larger display vs 1-bit bmp). same loop, x just feeds it way more bytes. confirmed real x images at 66kb, 160kb and 255kb.

what this pr changes:

- reads the stream in chunks instead of byte by byte. the chunk size is just whatever stream->available() reports, ie the decrypted bytes already sitting in the tls buffer (~1460 bytes / one tcp segment in practice), capped by the bytes left to read. no fixed or magic size, and it reads straight into the existing image buffer so it uses no extra memory.
- bumps the inactivity window from 15s to 20s so a single stall is less likely to kill an otherwise healthy transfer.
- adds a 60s overall cap as a hard safety bound (the old loop had no overall limit).
- frees the image buffer on the timeout path (the old code leaked it there).

why we think this helps:

we simulated both versions against the real failing size and the real s3 delivery pattern (1460-byte chunks). on a weak/stally link:

- before (byte by byte): downloads take ~5-35s and timeouts climb as the image gets bigger
- after (chunked): downloads take ~2-7s and timeouts drop to basically 0% across all sizes

the logic is finishing the download ~5x faster means much less time exposed to a stall, so far fewer downloads get caught by one. the wider window and the existing retry cover the rest.

being honest about the limits:

- a genuine 20s+ dead-air stall will still time out, no read strategy can fix that. but the device already retries on the next wake, and finishing faster means far fewer downloads overlap a stall in the first place.
- the exact speedup depends on the per-byte read cost on real hardware. we couldn't measure that on-device, so we researched it (see below) and bounded it to ~5-30us/byte. the part that's measured is the read-call count dropping ~1450x; the timing benefit is the inference from that.

what we found about the per-call read cost on esp32 (research):

- reading tls one byte at a time on esp32 is a documented anti-pattern, not just our theory. espressif's ecosystem says single-byte reads have "significant overhead on resource-constrained devices like the esp32" and to use buffer reads instead.
- decryption is not the per-byte cost. esp32 @240mhz hardware crypto runs aes-128-cbc at ~11.4 mb/s and sha-256 at ~27.8 mb/s, and a record is decrypted once. byte-by-byte reads copy already-decrypted bytes, so the penalty is pure function/state-machine overhead, not crypto.
- read overhead dominates esp32 https: raw tcp does ~20 mbit/s but real https downloads via HTTPClient are reported around ~30 kb/s for large files. that ~80x gap is the read pattern, not bandwidth or crypto.
- estimate: scaling a real openssl measurement on a laptop (~0.05us/call) by the esp32-s3 compute deficit, plus the loop calling both available() and read() per byte, lands around ~5-15us/byte. working back from the ~30 kb/s real-world ceiling gives up to ~33us/byte (upper bound, included sd writes). so call it ~5-30us/byte, central ~10us.
- what that means for the 160kb failing image: ~1.6s of read overhead at 10us, ~4.8s at 30us (chunked ~0). enough to stretch the download into stall territory on a weak link, which is exactly the exposure effect above.

test script (run it yourself):

the script below downloads a real image over tls and compares byte-by-byte vs chunked reads, printing the SSL_read call count, cpu-in-loop, and a projected device-time at a few per-call overheads. the call-count reduction is real and platform-independent; the projection is where you plug in the esp32 number. ideally we measure that last number on-device with a micros() timer around the read loop.

<details>
<summary>readtest.cpp (click to expand)</summary>

```cpp
// readtest.cpp
// ---------------------------------------------------------------------------
// Compares the TRMNL firmware's image-download read strategy BEFORE vs AFTER
// the fix, against a real image served over TLS (e.g. an S3 URL), so the FW
// team can run it on their own computer.
//
//   BEFORE (current): read the TLS stream one byte at a time  -> 1 SSL_read/byte
//   AFTER  (this PR): read whatever's available per call       -> 1 SSL_read/record
//
// Build (macOS, Homebrew OpenSSL):
//   clang++ -O2 readtest.cpp -I"$(brew --prefix openssl@3)/include" \
//           -L"$(brew --prefix openssl@3)/lib" -lssl -lcrypto -o readtest
// Build (Linux):
//   g++ -O2 readtest.cpp -lssl -lcrypto -o readtest
//
// Get a URL (use your own device's access token):
//   curl -s https://trmnl.com/api/current_screen -H "access-token: <TOKEN>" \
//        | python3 -c "import sys,json;print(json.load(sys.stdin)['image_url'])"
//   (use a real dashboard screen, ~100KB+, for a clear result)
//
// Run:
//   ./readtest "<image_url>"
//
// WHAT'S REAL vs PROJECTED:
//   * SSL_read call count  -> REAL, identical on every platform (set by record sizes)
//   * CPU-in-loop          -> REAL on this machine (excludes network wait)
//   * Wall-clock           -> noisy (two separate connections); reported but ignore it
//   * "Projected device time" -> call_count * per_call_overhead. Desktop per-call cost is
//     ~0.1us; an ESP32-S3 w/ mbedTLS is much higher. The call-count reduction is the same
//     everywhere; multiply by YOUR device's per-call cost (measure on-device) for the real
//     saving. Defaults below (10us / 30us) are estimates, not measurements.
// ---------------------------------------------------------------------------
#include <cstdio>
#include <cstring>
#include <cstdlib>
#include <ctime>
#include <sys/time.h>
#include <netdb.h>
#include <unistd.h>
#include <openssl/ssl.h>
#include <openssl/err.h>

struct Stats { long calls = 0; long bytes = 0; double wall_ms = 0; double cpu_ms = 0; };

static double now_ms() { struct timeval t; gettimeofday(&t, nullptr); return t.tv_sec*1000.0 + t.tv_usec/1000.0; }

// mode 0 = byte-by-byte (1 byte/call) ; mode 1 = chunked (one record/call)
static Stats run(const char* host, const char* path, int mode) {
    Stats s;
    struct addrinfo hints{}; hints.ai_family = AF_UNSPEC; hints.ai_socktype = SOCK_STREAM;
    struct addrinfo* res = nullptr;
    if (getaddrinfo(host, "443", &hints, &res) != 0) { printf("dns fail\n"); return s; }
    int fd = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
    if (connect(fd, res->ai_addr, res->ai_addrlen) != 0) { printf("connect fail\n"); return s; }
    SSL_CTX* ctx = SSL_CTX_new(TLS_client_method());
    SSL* ssl = SSL_new(ctx);
    SSL_set_fd(ssl, fd);
    SSL_set_tlsext_host_name(ssl, host);            // SNI
    if (SSL_connect(ssl) != 1) { printf("tls fail\n"); ERR_print_errors_fp(stdout); return s; }

    char req[4096];
    snprintf(req, sizeof(req),
        "GET %s HTTP/1.1\r\nHost: %s\r\nUser-Agent: ESP32HTTPClient\r\n"
        "Accept-Encoding: identity\r\nConnection: close\r\n\r\n", path, host);
    SSL_write(ssl, req, (int)strlen(req));

    unsigned char buf[16384];
    double w0 = now_ms(); clock_t c0 = clock();
    if (mode == 0) {                                 // BEFORE: 1 byte per SSL_read
        unsigned char b; int r;
        while ((r = SSL_read(ssl, &b, 1)) > 0) { s.calls++; s.bytes += r; }
    } else {                                         // AFTER: drain whole record per SSL_read
        int r;
        while ((r = SSL_read(ssl, buf, sizeof(buf))) > 0) { s.calls++; s.bytes += r; }
    }
    s.wall_ms = now_ms() - w0;
    s.cpu_ms  = (clock() - c0) * 1000.0 / CLOCKS_PER_SEC;

    SSL_shutdown(ssl); SSL_free(ssl); SSL_CTX_free(ctx); close(fd); freeaddrinfo(res);
    return s;
}

// best of N (min CPU) to reduce scheduler noise
static Stats best_of(const char* host, const char* path, int mode, int n) {
    Stats best; best.cpu_ms = 1e18;
    for (int i = 0; i < n; i++) { Stats s = run(host, path, mode); if (s.cpu_ms < best.cpu_ms) best = s; }
    return best;
}

int main(int argc, char** argv) {
    if (argc < 2) { printf("usage: %s <image_url>\n", argv[0]); return 1; }
    // parse https://host/path?query
    char url[8192]; strncpy(url, argv[1], sizeof(url)-1); url[sizeof(url)-1] = 0;
    char* p = strstr(url, "://"); p = p ? p + 3 : url;
    char* slash = strchr(p, '/');
    static char host[1024], path[8192];
    if (slash) { size_t hl = slash - p; memcpy(host, p, hl); host[hl] = 0; strcpy(path, slash); }
    else { strcpy(host, p); strcpy(path, "/"); }

    SSL_library_init(); SSL_load_error_strings();
    printf("host = %s\n\n", host);

    Stats bb = best_of(host, path, 0, 3);            // BEFORE
    Stats ch = best_of(host, path, 1, 3);            // AFTER

    printf("%-18s %12s %10s %14s %16s\n", "strategy", "SSL_read", "bytes", "cpu-in-loop", "per-call cpu");
    printf("%-18s %12ld %10ld %12.2f ms %13.3f us\n", "BEFORE byte-by-byte",
           bb.calls, bb.bytes, bb.cpu_ms, bb.calls ? bb.cpu_ms*1000.0/bb.calls : 0);
    printf("%-18s %12ld %10ld %12.2f ms %13.3f us\n", "AFTER  chunked",
           ch.calls, ch.bytes, ch.cpu_ms, ch.calls ? ch.cpu_ms*1000.0/ch.calls : 0);
    printf("\nSSL_read calls reduced %.0fx (%ld -> %ld) for this %ld-byte image\n",
           ch.calls ? (double)bb.calls/ch.calls : 0, bb.calls, ch.calls, bb.bytes);

    // Projection: read-loop time = calls * per_call_overhead.
    // us/call estimates: ~desktop measured here; ESP32-S3 figures derived from (a) scaling this
    // machine's per-call cost by the ~50-65x single-thread compute deficit incl. the loop's
    // available()+read() pair, and (b) the ~30 KB/s real-world HTTPS-read ceiling on ESP32. Decrypt
    // is NOT included (HW-accelerated, ~11 MB/s AES-CBC, amortized once per 1460-byte record).
    double ov[] = {0.1, 10.0, 30.0};
    const char* lbl[] = {"~0.1us (this machine)", "10us (ESP32-S3 est, likely)", "30us (ESP32-S3 est, high)"};
    printf("\nprojected read-loop time at a given per-call overhead:\n");
    printf("  %-26s %18s %14s\n", "per-call overhead", "BEFORE byte-by-byte", "AFTER chunked");
    for (int i = 0; i < 3; i++)
        printf("  %-26s %15.2f s %11.3f s\n", lbl[i], bb.calls*ov[i]/1e6, ch.calls*ov[i]/1e6);
    printf("\n(call-count reduction is real & platform-independent; per-call us is the only\n"
           " device-specific unknown -- measure it on the ESP32-S3 to get the true saving.)\n");
    return 0;
}
```

</details>

example output (small ~7kb screen, run on a laptop):

```
strategy               SSL_read      bytes    cpu-in-loop     per-call cpu
BEFORE byte-by-byte         6830       6830         0.25 ms         0.037 us
AFTER  chunked                2       6830         0.11 ms        54.000 us

SSL_read calls reduced 3415x (6830 -> 2) for this 6830-byte image

projected read-loop time at a given per-call overhead:
  per-call overhead          BEFORE byte-by-byte  AFTER chunked
  ~0.1us (this machine)                 0.00 s       0.000 s
  10us (ESP32-S3 est, likely)            0.07 s       0.000 s
  30us (ESP32-S3 est, high)             0.20 s       0.000 s
```

references:

- ESP32 crypto throughput benchmark (Oryx Embedded): https://www.oryx-embedded.com/benchmark/espressif/crypto-esp32.html
- arduino-esp32 #4529, ~30 kb/s https download: https://github.com/espressif/arduino-esp32/issues/4529
- WiFiClientSecure read, single-byte overhead vs buffer (AvantMaker): https://avantmaker.com/references/esp32-arduino-core-index/esp32-wificlientsecure-library/esp32-wificlientsecure-library-read/
- esp32.com, ~20 mbit/s tcp ceiling: https://esp32.com/viewtopic.php?t=9795
- esp-idf #5960, mbedtls_ssl_read blocking on fast https downloads: https://github.com/espressif/esp-idf/issues/5960
- ESP-IDF mbedTLS hardware acceleration (aes/sha): https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/protocols/mbedtls.html
