### PR TITLE
Add WiFi-Band and WiFi-SSID headers

### DIFF
--- a/lib/trmnl/include/api-client/request_headers.h
+++ b/lib/trmnl/include/api-client/request_headers.h
@@ -19,6 +19,11 @@ HttpHeaderList buildDisplayHeaders(const ApiDisplayInputs &inputs);
 HttpHeaderList buildSetupHeaders(const ApiSetupInputs &inputs);
 HttpHeaderList buildLogHeaders(const ApiLogInputs &inputs);
 
+// Percent-encode a string per RFC 3986 (unreserved chars pass through, all
+// others become %XX). Used to make arbitrary values — e.g. a Wi-Fi SSID with
+// spaces, ':' or control bytes — safe inside an HTTP header value.
+String percentEncode(const String &value);
+
 // Format a header list as a newline-separated "Name: value" string with no
 // trailing newline, as expected by Modem::httpGet() (TRMNL X 5 GHz path).
 String formatHeaders(const HttpHeaderList &headers);

--- a/lib/trmnl/include/api_types.h
+++ b/lib/trmnl/include/api_types.h
@@ -76,6 +76,7 @@ struct ApiDisplayInputs
   String firmwareVersion;
   String model;
   int rssi;
+  String wifiBand;
   int displayWidth;
   int displayHeight;
   SPECIAL_FUNCTION specialFunction;

--- a/lib/trmnl/include/api_types.h
+++ b/lib/trmnl/include/api_types.h
@@ -77,6 +77,7 @@ struct ApiDisplayInputs
   String model;
   int rssi;
   String wifiBand;
+  String wifiSSID;
   int displayWidth;
   int displayHeight;
   SPECIAL_FUNCTION specialFunction;

--- a/lib/trmnl/src/api-client/request_headers.cpp
+++ b/lib/trmnl/src/api-client/request_headers.cpp
@@ -27,6 +27,8 @@ HttpHeaderList buildDisplayHeaders(const ApiDisplayInputs &inputs)
   headers.push_back({"RSSI", String(inputs.rssi)});
   if (inputs.wifiBand.length() > 0)
     headers.push_back({"WiFi-Band", inputs.wifiBand});
+  if (inputs.wifiSSID.length() > 0)
+    headers.push_back({"WiFi-SSID", percentEncode(inputs.wifiSSID)});
   headers.push_back({"Temperature-Profile", "true"});
   headers.push_back({"Width", String(inputs.displayWidth)});
   headers.push_back({"Height", String(inputs.displayHeight)});
@@ -55,6 +57,29 @@ HttpHeaderList buildLogHeaders(const ApiLogInputs &inputs)
   headers.push_back({"Access-Token", inputs.apiKey});
   headers.push_back({"Content-Type", "application/json"});
   return headers;
+}
+
+String percentEncode(const String &value)
+{
+  static const char hex[] = "0123456789ABCDEF";
+  String out;
+  out.reserve(value.length());
+  for (size_t i = 0; i < value.length(); ++i)
+  {
+    unsigned char c = (unsigned char)value[i];
+    if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+        (c >= '0' && c <= '9') || c == '-' || c == '.' || c == '_' || c == '~')
+    {
+      out += (char)c;
+    }
+    else
+    {
+      out += '%';
+      out += hex[c >> 4];
+      out += hex[c & 0x0F];
+    }
+  }
+  return out;
 }
 
 String formatHeaders(const HttpHeaderList &headers)

--- a/lib/trmnl/src/api-client/request_headers.cpp
+++ b/lib/trmnl/src/api-client/request_headers.cpp
@@ -25,6 +25,8 @@ HttpHeaderList buildDisplayHeaders(const ApiDisplayInputs &inputs)
   headers.push_back({"Image-Cached", inputs.imageCached ? "true" : "false"});
   headers.push_back({"Wake-Time", String(inputs.prevWakeTime)});
   headers.push_back({"RSSI", String(inputs.rssi)});
+  if (inputs.wifiBand.length() > 0)
+    headers.push_back({"WiFi-Band", inputs.wifiBand});
   headers.push_back({"Temperature-Profile", "true"});
   headers.push_back({"Width", String(inputs.displayWidth)});
   headers.push_back({"Height", String(inputs.displayHeight)});

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -1580,6 +1580,7 @@ ApiDisplayInputs loadApiDisplayInputs(Preferences &preferences)
   inputs.macAddress = device_mac_address();
   inputs.rssi = WiFi.RSSI(); // may be overridden below
   inputs.wifiBand = "2.4"; // may be overridden below
+  inputs.wifiSSID = WifiCaptivePortal.getLastCredentials().ssid;
   inputs.batteryVoltage = vBatt; //readBatteryVoltage();
   inputs.firmwareVersion = String(FW_VERSION_STRING);
   inputs.displayWidth = display_width();

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -1578,8 +1578,17 @@ ApiDisplayInputs loadApiDisplayInputs(Preferences &preferences)
   }
 
   inputs.macAddress = device_mac_address();
-
+  inputs.rssi = WiFi.RSSI(); // may be overridden below
+  inputs.wifiBand = "2.4"; // may be overridden below
   inputs.batteryVoltage = vBatt; //readBatteryVoltage();
+  inputs.firmwareVersion = String(FW_VERSION_STRING);
+  inputs.displayWidth = display_width();
+  inputs.displayHeight = display_height();
+  inputs.model = DEVICE_MODEL;
+  inputs.specialFunction = special_function;
+  inputs.imageCached = bUsedCachedImage;
+  inputs.prevWakeTime = iPrevWakeTime;
+
 #ifdef BOARD_TRMNL_X
   inputs.usbConnected = check_usb_power();
   inputs.batteryCount = battery_count;
@@ -1600,25 +1609,16 @@ ApiDisplayInputs loadApiDisplayInputs(Preferences &preferences)
     inputs.currentBatteryCapacity = -1;
     inputs.maxBatteryCapacity = -1;
   }
+
+  // On the 5 GHz path the ESP32-C5 modem owns the Wi-Fi link, so the host's
+  // WiFi.RSSI() reads 0; query the modem for the real signal strength.
+  if (g_modem && WifiCaptivePortal.getLastCredentials().is5GHz) {
+    inputs.rssi = g_modem->getSignalRssi();
+    inputs.wifiBand = "5";
+  }
 #else
   inputs.usbConnected = false;
 #endif // BOARD_TRMNL_X
-
-  inputs.firmwareVersion = String(FW_VERSION_STRING);
-
-  inputs.rssi = WiFi.RSSI();
-#ifdef BOARD_TRMNL_X
-  // On the 5 GHz path the ESP32-C5 modem owns the Wi-Fi link, so the host's
-  // WiFi.RSSI() reads 0; query the modem for the real signal strength.
-  if (g_modem && WifiCaptivePortal.getLastCredentials().is5GHz)
-    inputs.rssi = g_modem->getSignalRssi();
-#endif // BOARD_TRMNL_X
-  inputs.displayWidth = display_width();
-  inputs.displayHeight = display_height();
-  inputs.model = DEVICE_MODEL;
-  inputs.specialFunction = special_function;
-  inputs.imageCached = bUsedCachedImage;
-  inputs.prevWakeTime = iPrevWakeTime;
 
   return inputs;
 }

--- a/test/test_request_headers/request_headers.test.cpp
+++ b/test/test_request_headers/request_headers.test.cpp
@@ -150,6 +150,30 @@ void test_display_headers_special_function_present_when_set(void)
   TEST_ASSERT_EQUAL_STRING("true", valueOf(headers, "special_function").c_str());
 }
 
+void test_display_headers_wifi_band_2_4(void)
+{
+  auto inputs = makeDisplayInputs();
+  inputs.wifiBand = "2.4";
+  auto headers = buildDisplayHeaders(inputs);
+  TEST_ASSERT_EQUAL_STRING("2.4", valueOf(headers, "WiFi-Band").c_str());
+}
+
+void test_display_headers_wifi_band_5(void)
+{
+  auto inputs = makeDisplayInputs();
+  inputs.wifiBand = "5";
+  auto headers = buildDisplayHeaders(inputs);
+  TEST_ASSERT_EQUAL_STRING("5", valueOf(headers, "WiFi-Band").c_str());
+}
+
+void test_display_headers_wifi_band_omitted_when_empty(void)
+{
+  auto inputs = makeDisplayInputs();
+  inputs.wifiBand = "";
+  auto headers = buildDisplayHeaders(inputs);
+  TEST_ASSERT_FALSE(has(headers, "WiFi-Band"));
+}
+
 // --- formatHeaders ---------------------------------------------------------
 
 void test_format_headers_newline_separated_no_trailing_newline(void)
@@ -198,6 +222,9 @@ void process()
   RUN_TEST(test_display_headers_image_cached_reflects_input);
   RUN_TEST(test_display_headers_special_function_omitted_when_none);
   RUN_TEST(test_display_headers_special_function_present_when_set);
+  RUN_TEST(test_display_headers_wifi_band_2_4);
+  RUN_TEST(test_display_headers_wifi_band_5);
+  RUN_TEST(test_display_headers_wifi_band_omitted_when_empty);
   RUN_TEST(test_format_headers_newline_separated_no_trailing_newline);
   RUN_TEST(test_format_headers_empty_list_is_empty_string);
   RUN_TEST(test_format_setup_headers_round_trip);

--- a/test/test_request_headers/request_headers.test.cpp
+++ b/test/test_request_headers/request_headers.test.cpp
@@ -174,6 +174,31 @@ void test_display_headers_wifi_band_omitted_when_empty(void)
   TEST_ASSERT_FALSE(has(headers, "WiFi-Band"));
 }
 
+void test_display_headers_wifi_ssid_present(void)
+{
+  auto inputs = makeDisplayInputs();
+  inputs.wifiSSID = "MyNetwork";
+  auto headers = buildDisplayHeaders(inputs);
+  TEST_ASSERT_EQUAL_STRING("MyNetwork", valueOf(headers, "WiFi-SSID").c_str());
+}
+
+void test_display_headers_wifi_ssid_percent_encoded(void)
+{
+  auto inputs = makeDisplayInputs();
+  inputs.wifiSSID = "My Wi-Fi: café";
+  auto headers = buildDisplayHeaders(inputs);
+  // space, ':' and the UTF-8 bytes of 'é' (0xC3 0xA9) are escaped
+  TEST_ASSERT_EQUAL_STRING("My%20Wi-Fi%3A%20caf%C3%A9", valueOf(headers, "WiFi-SSID").c_str());
+}
+
+void test_display_headers_wifi_ssid_omitted_when_empty(void)
+{
+  auto inputs = makeDisplayInputs();
+  inputs.wifiSSID = "";
+  auto headers = buildDisplayHeaders(inputs);
+  TEST_ASSERT_FALSE(has(headers, "WiFi-SSID"));
+}
+
 // --- formatHeaders ---------------------------------------------------------
 
 void test_format_headers_newline_separated_no_trailing_newline(void)
@@ -191,6 +216,24 @@ void test_format_headers_empty_list_is_empty_string(void)
 {
   HttpHeaderList headers;
   TEST_ASSERT_EQUAL_STRING("", formatHeaders(headers).c_str());
+}
+
+// --- percentEncode ---------------------------------------------------------
+
+void test_percent_encode_passes_through_unreserved(void)
+{
+  TEST_ASSERT_EQUAL_STRING("abcXYZ09-._~", percentEncode("abcXYZ09-._~").c_str());
+}
+
+void test_percent_encode_escapes_reserved_and_control(void)
+{
+  // space, ':', '\n', '%' must all be escaped (uppercase hex)
+  TEST_ASSERT_EQUAL_STRING("a%20b%3A%0A%25", percentEncode("a b:\n%").c_str());
+}
+
+void test_percent_encode_empty_is_empty(void)
+{
+  TEST_ASSERT_EQUAL_STRING("", percentEncode("").c_str());
 }
 
 void test_format_setup_headers_round_trip(void)
@@ -225,8 +268,14 @@ void process()
   RUN_TEST(test_display_headers_wifi_band_2_4);
   RUN_TEST(test_display_headers_wifi_band_5);
   RUN_TEST(test_display_headers_wifi_band_omitted_when_empty);
+  RUN_TEST(test_display_headers_wifi_ssid_present);
+  RUN_TEST(test_display_headers_wifi_ssid_percent_encoded);
+  RUN_TEST(test_display_headers_wifi_ssid_omitted_when_empty);
   RUN_TEST(test_format_headers_newline_separated_no_trailing_newline);
   RUN_TEST(test_format_headers_empty_list_is_empty_string);
+  RUN_TEST(test_percent_encode_passes_through_unreserved);
+  RUN_TEST(test_percent_encode_escapes_reserved_and_control);
+  RUN_TEST(test_percent_encode_empty_is_empty);
   RUN_TEST(test_format_setup_headers_round_trip);
   UNITY_END();
 }


### PR DESCRIPTION
Fixes #378. This PR adds the `WiFi-Band` and `WiFi-SSID` headers to the `/api/display` request.

`WiFi-Band` reports the _currently-connected_ band. This means that a user can configure 5 GHz, but it may fall back to 2.4 GHz on connection failure.

SSIDs may contain non-ASCII characters, which are not compatible with HTTP headers, so we resort to URL-style percent escaping per [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986)

## Examples (captured on the wire)

I have two separate networks set up at home with distinct SSIDs:

```
    WiFi-Band: 2.4
    WiFi-SSID: Hidden%20Orchard%202.4

    WiFi-Band: 5
    WiFi-SSID: Hidden%20Orchard%205
```

## Todo
- [x] test OG
- [x] test X 2.4 GHz
- [x] test X 5 GHz