### PR TITLE
Add ESP32-M075 GDP075FW1 BYOD target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,9 @@ jobs:
       - name: build (trmnl)
         run: pio run -j ${{ runner.os == 'Windows' && '1' || '4' }} -v
 
+      - name: build (esp32_m075_gdp075fw1)
+        run: pio run -e esp32_m075_gdp075fw1 -j ${{ runner.os == 'Windows' && '1' || '4' }} -v
+
       #- name: build (TRMNL_X)
       #  run: pio run -e TRMNL_X -j ${{ runner.os == 'Windows' && '1' || '4' }} -v
 

--- a/README.md
+++ b/README.md
@@ -251,6 +251,57 @@ There are technical and non-technical options to flashing firmware.
 
 ![Image Alt text](/pics/bin_folder.png "Bin")
 
+### Good Display GDP075FW1 / ESP32-M075
+
+The `esp32_m075_gdp075fw1` PlatformIO environment supports ESP32-M075-style
+controller boards paired with the Good Display GDP075FW1 7.5 inch 800x480
+four-color e-paper panel.
+
+This target has been tested with the WiFi version of the
+[GDP075FW1/GDP075FU1 7.5 inch 4-color e-paper tag](https://buy-lcd.com/products/gdp075fu1).
+
+```bash
+pio run -e esp32_m075_gdp075fw1
+```
+
+When registering this target as a TRMNL BYOD device, select
+`Waveshare 7.5" B/W/R/Y` as the device type. That profile requests four-color
+content from the TRMNL service and has been tested with this panel.
+
+This target uses the following e-paper pins:
+
+| Signal | GPIO |
+| --- | --- |
+| SCK | 18 |
+| MOSI | 23 |
+| CS | 27 |
+| RESET | 12 |
+| DC | 14 |
+| BUSY | 13 |
+
+The target currently builds without a configured wake button and reports a
+fixed battery voltage. If your board exposes a wake button or battery gauge,
+add those pins before relying on button wake or battery telemetry.
+
+Because this target has no configured button input, the firmware WiFi reset
+long-press flow is not available. Holding the tested board's reset button only
+resets the ESP32; it does not clear saved WiFi or API settings. To force the
+device back into captive portal setup mode, erase the NVS settings partition
+for this target and then reset or power-cycle the board:
+
+```bash
+uvx esptool \
+  --chip esp32 \
+  --port /dev/ttyUSB0 \
+  --baud 115200 \
+  erase-region 0x9000 0x5000
+```
+
+Replace `/dev/ttyUSB0` with your serial port. Keep the `0x` prefixes on both
+address values; they are hexadecimal, and decimal `5000` is not a
+4096-byte-aligned erase size. This clears saved WiFi, API key, friendly ID, and
+custom API server preferences without reflashing the firmware.
+
 ## **Uploading guide (PlatformIO)**
 
 1. Put the TRMNL into flashing mode.
@@ -263,6 +314,36 @@ There are technical and non-technical options to flashing firmware.
 ![Image Alt text](/pics/fs.jpg "FS")
 
 3. Click on "PlatformIO: Upload" button.
+
+## **Uploading guide (esptool)**
+
+You can also flash a built firmware image directly with
+[esptool](https://docs.espressif.com/projects/esptool/en/latest/esp32/).
+This is useful for third-party ESP32 boards such as the Good Display
+GDP075FW1 / ESP32-M075 setup.
+
+From the repository root, replace `/dev/ttyUSB0` with your serial port and run:
+
+```bash
+uvx esptool \
+  --chip esp32 \
+  --port /dev/ttyUSB0 \
+  --baud 115200 \
+  --before default-reset \
+  --after hard-reset \
+  write-flash -z \
+  --flash-mode dio \
+  --flash-freq 40m \
+  --flash-size 4MB \
+  0x1000 .pio/build/esp32_m075_gdp075fw1/bootloader.bin \
+  0x8000 .pio/build/esp32_m075_gdp075fw1/partitions.bin \
+  0xe000 "$HOME/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin" \
+  0x10000 .pio/build/esp32_m075_gdp075fw1/firmware.bin
+```
+
+If `460800` baud fails during flash detection or writing, retry at `115200`.
+On Linux, your user must have permission to access the serial device, commonly
+by membership in the `dialout` or `uucp` group.
 
 ## **Uploading guide (ESP32 Flash Download Tool)**
 

--- a/include/config.h
+++ b/include/config.h
@@ -118,6 +118,10 @@ enum WIFI_CONNECT_RETRY_TIME // Time to sleep before trying to connect to the Wi
 #define PIN_INTERRUPT 33
 #define DEVICE_MODEL "waveshare"
 #define FAKE_BATTERY_VOLTAGE
+#elif defined(BOARD_ESP32_M075_GDP075FW1)
+#define PIN_INTERRUPT 0
+#define DEVICE_MODEL "esp32_m075_gdp075fw1"
+#define FAKE_BATTERY_VOLTAGE
 #elif defined(BOARD_WAVESHARE_397)
 #define PIN_INTERRUPT 0
 #define DEVICE_MODEL "Waveshare_397"

--- a/platformio.ini
+++ b/platformio.ini
@@ -124,6 +124,17 @@ build_flags =
 	${env:esp32_base.build_flags}
 	-D BOARD_WAVESHARE_ESP32_DRIVER
 
+[env:esp32_m075_gdp075fw1]
+extends = env:esp32dev
+extra_scripts = scripts/git_version.py
+custom_include_git_hash = true
+build_flags =
+	${env:esp32_base.build_flags}
+	-D BOARD_ESP32_M075_GDP075FW1
+	-D BOARD_ESP32_M075_GDP075FW1_NO_BUTTON
+	-D PNG_MAX_BUFFERED_PIXELS=6432
+	-D ARDUINOJSON_ENABLE_ARDUINO_STRING=1
+
 [env:trmnl]
 extends = env:esp32-c3-devkitc-02
 extra_scripts =

--- a/src/DEV_Config.h
+++ b/src/DEV_Config.h
@@ -93,6 +93,14 @@
    #define EPD_DC_PIN   9
    #define EPD_BUSY_PIN 3
 #define FAKE_BATTERY_VOLTAGE
+#elif defined(BOARD_ESP32_M075_GDP075FW1)
+   // Good Display GDP075FW1 / ESP32-M075 board.
+   #define EPD_SCK_PIN  18
+   #define EPD_MOSI_PIN 23
+   #define EPD_CS_PIN   27
+   #define EPD_RST_PIN  12
+   #define EPD_DC_PIN   14
+   #define EPD_BUSY_PIN 13
 #elif defined(BOARD_SEEED_XIAO_ESP32C3)
    // Pin definition for Seeed XIAO ESP32C3 Board
    #define EPD_SCK_PIN  8

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -854,6 +854,10 @@ void bl_init(void)
   #ifndef BOARD_TRMNL_X
   if (gpio_wakeup)
   {
+#ifdef BOARD_ESP32_M075_GDP075FW1_NO_BUTTON
+    wait_for_serial();
+    Log_info("GPIO wakeup (%d) ignored; board has no configured button", wakeup_reason);
+#else
     Log_info("GPIO wakeup detected (%d)", wakeup_reason);
     auto button = read_button_presses();
     wait_for_serial();
@@ -874,6 +878,7 @@ void bl_init(void)
       resetDeviceCredentials();
     }
     Log_info("button handling end");
+#endif
   }
   else
   {
@@ -3261,6 +3266,7 @@ void goToSleep(void)
   preferences.end();
   esp_sleep_enable_timer_wakeup((uint64_t)time_to_sleep * SLEEP_uS_TO_S_FACTOR);
   // Configure GPIO pin for wakeup
+#ifndef BOARD_ESP32_M075_GDP075FW1_NO_BUTTON
 #if CONFIG_IDF_TARGET_ESP32
   #define BUTTON_PIN_BITMASK(GPIO) (1ULL << GPIO)  // 2 ^ GPIO_NUMBER in hex
   esp_sleep_enable_ext1_wakeup(BUTTON_PIN_BITMASK(PIN_INTERRUPT), ESP_EXT1_WAKEUP_ALL_LOW);
@@ -3270,6 +3276,7 @@ void goToSleep(void)
   esp_sleep_enable_ext0_wakeup((gpio_num_t)PIN_INTERRUPT, 0);
 #else
 #error "Unsupported ESP32 target for GPIO wakeup configuration"
+#endif
 #endif
 #ifdef BOARD_XTEINK_X4
   gpio_hold_en(GPIO_NUM_13); // MOSFET enabling the battery power
@@ -3287,6 +3294,7 @@ static void goToSleepButtonOnly(void)
   WiFi.mode(WIFI_OFF);
   filesystem_deinit();
   preferences.end();
+#ifndef BOARD_ESP32_M075_GDP075FW1_NO_BUTTON
 #if CONFIG_IDF_TARGET_ESP32
   #define BUTTON_PIN_BITMASK_BTN(GPIO) (1ULL << GPIO)
   esp_sleep_enable_ext1_wakeup(BUTTON_PIN_BITMASK_BTN(PIN_INTERRUPT), ESP_EXT1_WAKEUP_ALL_LOW);
@@ -3296,6 +3304,9 @@ static void goToSleepButtonOnly(void)
   esp_sleep_enable_ext0_wakeup((gpio_num_t)PIN_INTERRUPT, 0);
 #else
 #error "Unsupported ESP32 target for GPIO wakeup configuration"
+#endif
+#else
+  esp_sleep_enable_timer_wakeup((uint64_t)SLEEP_TIME_TO_SLEEP * SLEEP_uS_TO_S_FACTOR);
 #endif
 #ifdef BOARD_XTEINK_X4
   gpio_hold_en(GPIO_NUM_13);

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -31,7 +31,7 @@ BBEPAPER bbep(EP397_800x480);
     {EP75R_800x480, EP75R_800x480}, // b = darker grays
 };
 BBEPAPER bbep(EP75R_800x480);
-#elif defined(BOARD_TRMNL_4CLR)
+#elif defined(BOARD_TRMNL_4CLR) || defined(BOARD_ESP32_M075_GDP075FW1)
     {EP75YR_800x480, EP75YR_800x480}, // default (for original EPD)
     {EP75YR_800x480, EP75YR_800x480}, // a = uses built-in fast + 4-gray
     {EP75YR_800x480, EP75YR_800x480}, // b = darker grays
@@ -996,7 +996,7 @@ int png_draw_6clr(PNGDRAW *pDraw)
 } /* png_draw_6clr() */
 #endif // E1002 (Spectra6 only)
 
-#ifdef BOARD_TRMNL_4CLR
+#if defined(BOARD_TRMNL_4CLR) || defined(BOARD_ESP32_M075_GDP075FW1)
 //
 // Draw the PNG image into the local framebuffer memory using the drawPixel() method
 // to do color translation and to properly format the memory layout
@@ -1103,7 +1103,7 @@ int png_draw_4clr(PNGDRAW *pDraw)
     bbep.writeData(pTemp, (pDraw->iWidth+3)/4);
     return 1; // continue decoding
 } /* png_draw4clr() */
-#endif // BOARD_TRMNL_4CLR (4 color only)
+#endif // 4 color only
 
 int png_draw(PNGDRAW *pDraw)
 {
@@ -1516,7 +1516,7 @@ PNG *png = new PNG();
             delete(png); // free the decoder instance
             return REFRESH_FULL;
 #endif // E1002
-#ifdef BOARD_TRMNL_4CLR
+#if defined(BOARD_TRMNL_4CLR) || defined(BOARD_ESP32_M075_GDP075FW1)
             Log_info("%s [%d]: decoding for 4-color EPD\r\n", __FILE__, __LINE__);
             png->openRAM((uint8_t *)pPNG, iDataSize, png_draw_4clr);
             bbep.startWrite(PLANE_1); // start writing image data
@@ -1524,7 +1524,7 @@ PNG *png = new PNG();
             png->close();
             delete(png); // free the decoder instance
             return REFRESH_FULL;
-#endif // BOARD_TRMNL_4CLR
+#endif // 4 color only
             bbep.setAddrWindow(0, 0, bbep.width(), bbep.height());
             if (png->getBpp() == 1 || (png->getBpp() == 2 && png_count_colors(png, pPNG, iDataSize) == 2)) { // 1-bit image (single plane)
                 png->close(); // use a different PNGDraw callback for color matching

--- a/src/pins.cpp
+++ b/src/pins.cpp
@@ -4,6 +4,9 @@
 
 void pins_init(void)
 {
+#ifdef BOARD_ESP32_M075_GDP075FW1_NO_BUTTON
+    return;
+#else
     gpio_config_t io_conf = {};
     io_conf.intr_type = GPIO_INTR_DISABLE;
     io_conf.mode = GPIO_MODE_INPUT;
@@ -11,4 +14,5 @@ void pins_init(void)
     io_conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
     io_conf.pull_up_en = GPIO_PULLUP_ENABLE;
     gpio_config(&io_conf);
+#endif
 }


### PR DESCRIPTION
## Summary
- add an `esp32_m075_gdp075fw1` PlatformIO target for ESP32-M075-style boards with the Good Display GDP075FW1 7.5 inch 800x480 four-color panel
- wire the panel into the existing 4-color `EP75YR_800x480` render path and document the display GPIO map
- document the TRMNL BYOD `Waveshare 7.5" B/W/R/Y` profile and working `uvx esptool` flashing commands
- document the NVS erase command needed to force WiFi captive portal setup on this no-button target, including the required hexadecimal `0x` prefixes
- add CI coverage for compiling the new board environment

## Validation
- `pio test -e native`
- `pio run -e esp32_m075_gdp075fw1`
- `pio run`
- `pio check --skip-packages --fail-on-defect high`
- Not rerun after the docs-only WiFi setup note.

## Hardware note
Tested with the WiFi version of the [GDP075FW1/GDP075FU1 7.5 inch 4-color e-paper tag](https://buy-lcd.com/products/gdp075fu1), registered through TRMNL BYOD as `Waveshare 7.5" B/W/R/Y`. That profile delivered four-color content successfully.

The target currently disables button wake and reports a fixed battery voltage until board-specific wake and battery telemetry pins are identified. On the tested board, holding the reset button only resets the ESP32 and does not clear saved WiFi/API settings, so the README documents erasing this target's NVS settings partition (`erase-region 0x9000 0x5000`) to force captive portal setup mode. The `0x` prefixes are required because the erase offset and size are hexadecimal; decimal `5000` is not 4096-byte aligned.