### PR TITLE
A few small fixes

### DIFF
--- a/lib/IQS323/IQS323.h
+++ b/lib/IQS323/IQS323.h
@@ -28,7 +28,7 @@
 // Include Files
 #include "Arduino.h"
 #include "Wire.h"
-#include "./inc/iqs323_addresses.h"
+#include "./inc/IQS323_addresses.h"
 #include "rtc_wake_stub_trmnl_x.h"
 
 /* Select the EV-Kit below by changing the value of the define (default = 0):

--- a/platformio.ini
+++ b/platformio.ini
@@ -666,6 +666,11 @@ board_build.embed_txtfiles =
 lib_ldf_mode = deep
 lib_deps =
 	${deps_app.lib_deps}
+lib_ignore =
+	BMA530_SensorAPI
+	IQS323
+	trmnl_x
+	BQ27427
 
 [env:esp32-c5-devkitc-1]
 board = esp32-c5-devkitc-1

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -711,8 +711,10 @@ void process_iqs323_data(void)
 // ############################ esp32c5 modem #########################
 #include "modem.h"
 
-// File-scope modem pointer — set once during bl_init(), used by download helpers.
-static Modem* g_modem = nullptr;
+// Global modem pointer — set once during bl_init(), used by download helpers
+// here and by getWiFiStatus() in wifi_network.cpp (5 GHz path on TRMNL_X), so
+// it needs external linkage.
+Modem* g_modem = nullptr;
 // ############################ esp32c5 modem #########################
 
 // ############################ Gas gauge #############################


### PR DESCRIPTION
- fix scope of `g_modem` which broke TRMNL X build in #367 
- fix case sensitivity of `iqs323_addresses.h`
- add ignored libs to `trmnl_gen2` env (missed in #367)