### PR TITLE
Add USB and charging status to OG gen2

### DIFF
--- a/include/display.h
+++ b/include/display.h
@@ -65,8 +65,6 @@ uint8_t tca9535_interrupt_clear();
 void config_bma530_interrupt();
 void config_tca95535_pins_for_lp();
 void enter_shipment_sleep();
-bool check_usb_power();
-bool is_charging();
 void BQ27427_reset();
 void otg_turn_on();
 void otg_turn_off();

--- a/include/power.h
+++ b/include/power.h
@@ -1,22 +1,6 @@
-#ifndef POWER_H
-#define POWER_H
+#pragma once
 
-/// USB / VBUS presence. UNKNOWN on boards without USB-detection support.
-enum class UsbStatus
-{
-  UNKNOWN,      // not implemented / not readable on this board
-  CONNECTED,    // VBUS (USB) power present
-  DISCONNECTED, // running on battery
-};
-
-/// Battery charge state reported by the charger IC (BQ25616 on TRMNL X / gen2).
-enum class ChargingStatus
-{
-  UNKNOWN,      // not implemented / not readable on this board
-  CHARGING,     // actively charging
-  NOT_CHARGING, // charge complete, disabled, or no battery
-  FAULT,        // charger fault — not yet implemented
-};
+#include <hardware_types.h>
 
 /// @brief Resolve USB/VBUS presence for the running board.
 ///        Safe to call on any board with no guards at the call site — returns
@@ -29,5 +13,3 @@ UsbStatus get_usb_status(void);
 ///        Safe to call on any board with no guards at the call site — returns
 ///        UNKNOWN where the hardware isn't supported.
 ChargingStatus get_charging_status(void);
-
-#endif // POWER_H

--- a/include/power.h
+++ b/include/power.h
@@ -1,0 +1,33 @@
+#ifndef POWER_H
+#define POWER_H
+
+/// USB / VBUS presence. UNKNOWN on boards without USB-detection support.
+enum class UsbStatus
+{
+  UNKNOWN,      // not implemented / not readable on this board
+  CONNECTED,    // VBUS (USB) power present
+  DISCONNECTED, // running on battery
+};
+
+/// Battery charge state reported by the charger IC (BQ25616 on TRMNL X / gen2).
+enum class ChargingStatus
+{
+  UNKNOWN,      // not implemented / not readable on this board
+  CHARGING,     // actively charging
+  NOT_CHARGING, // charge complete, disabled, or no battery
+  FAULT,        // charger fault — not yet implemented
+};
+
+/// @brief Resolve USB/VBUS presence for the running board.
+///        Safe to call on any board with no guards at the call site — returns
+///        UNKNOWN where the hardware isn't supported.
+///          - TRMNL X: BQ25616 read via the TCA9535 I/O expander
+///          - gen2:    BQ25616 read via a dedicated ESP32-C5 GPIO
+UsbStatus get_usb_status(void);
+
+/// @brief Resolve the battery charge state for the running board.
+///        Safe to call on any board with no guards at the call site — returns
+///        UNKNOWN where the hardware isn't supported.
+ChargingStatus get_charging_status(void);
+
+#endif // POWER_H

--- a/lib/trmnl/include/api_types.h
+++ b/lib/trmnl/include/api_types.h
@@ -3,6 +3,7 @@
 #include <Arduino.h>
 #include <ArduinoJson.h>
 #include "special_function.h"
+#include "hardware_types.h"
 
 enum class ApiSetupOutcome
 {
@@ -63,9 +64,9 @@ struct ApiDisplayInputs
   uint32_t refreshRate;
   String macAddress;
   float batteryVoltage;
+  ChargingStatus chargingStatus;
 #ifdef BOARD_TRMNL_X
   int batteryCount;
-  int batteryCharging;
   int batteryCurrent;
   int currentBatteryCapacity;
   int maxBatteryCapacity;
@@ -81,7 +82,7 @@ struct ApiDisplayInputs
   int displayWidth;
   int displayHeight;
   SPECIAL_FUNCTION specialFunction;
-  bool usbConnected;
+  UsbStatus usbStatus;
   bool imageCached;
   int prevWakeTime;
 };

--- a/lib/trmnl/include/hardware_types.h
+++ b/lib/trmnl/include/hardware_types.h
@@ -1,0 +1,22 @@
+#pragma once
+
+//
+// Device-agnostic hardware types and enums
+//
+
+/// USB / VBUS presence. UNKNOWN on boards without USB-detection support.
+enum class UsbStatus
+{
+    UNKNOWN,      // not implemented / not readable on this board
+    CONNECTED,    // VBUS (USB) power present
+    DISCONNECTED, // running on battery
+};
+
+/// Battery charge state reported by the charger IC (BQ25616 on TRMNL X / gen2).
+enum class ChargingStatus
+{
+    UNKNOWN,      // not implemented / not readable on this board
+    CHARGING,     // actively charging
+    NOT_CHARGING, // charge complete, disabled, or no battery
+    FAULT,        // charger fault — not yet implemented
+};

--- a/lib/trmnl/src/api-client/request_headers.cpp
+++ b/lib/trmnl/src/api-client/request_headers.cpp
@@ -10,10 +10,15 @@ HttpHeaderList buildDisplayHeaders(const ApiDisplayInputs &inputs)
   headers.push_back({"Access-Token", inputs.apiKey});
   headers.push_back({"Refresh-Rate", String(inputs.refreshRate)});
   headers.push_back({"Battery-Voltage", String(inputs.batteryVoltage)});
+
+  if (inputs.chargingStatus != ChargingStatus::UNKNOWN)
+    headers.push_back({"Battery-Charging", String(inputs.chargingStatus == ChargingStatus::CHARGING ? "1" : "0")});
+
+  if (inputs.usbStatus != UsbStatus::UNKNOWN)
+    headers.push_back({"USB-Connected", inputs.usbStatus == UsbStatus::CONNECTED ? "true" : "false"});
+
 #ifdef BOARD_TRMNL_X
   headers.push_back({"Battery-Count", String(inputs.batteryCount)});
-  headers.push_back({"Battery-Charging", String(inputs.batteryCharging)});
-  headers.push_back({"USB-Connected", inputs.usbConnected ? "true" : "false"});
   headers.push_back({"Percent-Charged", String(inputs.stateOfCharge)});
   headers.push_back({"Battery-Health", String(inputs.stateOfHealth)});
   headers.push_back({"Battery-Current", String(inputs.batteryCurrent)});

--- a/lib/wificaptive/src/WifiCaptive.cpp
+++ b/lib/wificaptive/src/WifiCaptive.cpp
@@ -4,6 +4,7 @@
 #define _NO_DEV_CONFIG_
 #define UWORD   uint16_t
 #include "../../../include/display.h"
+#include "../../../include/power.h"
 #include "WebServer.h"
 #include "wifi-helpers.h"
 #include "esp_event.h"
@@ -230,9 +231,9 @@ bool WifiCaptive::startPortal()
 // Take different action for timeout (go to sleep)
     if ((millis() - lTime) > PORTAL_TIMEOUT) {
 #ifdef BOARD_TRMNL_X
-        if (check_usb_power()) {
+        if (get_usb_status() == UsbStatus::CONNECTED) {
             showMessageWithLogo(READY_TO_SHIP);
-            while (check_usb_power()) {
+            while (get_usb_status() == UsbStatus::CONNECTED) {
             Serial.println("USB power still detected, waiting...");
             delay(2000);
             }

--- a/scripts/http_proxy.py
+++ b/scripts/http_proxy.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Logging HTTP-to-HTTPS proxy for on-device integration tests.
+
+Receives plain HTTP requests from the firmware, prints every detail to
+stdout (method, path, all headers including HTTPClient implicit ones,
+request body), then forwards the request to the real backend over HTTPS
+and returns the response.
+
+Use this to see *exactly* what the firmware put on the wire — including
+headers HTTPClient adds for you under the hood (Content-Type,
+User-Agent, Connection, etc.) — without changing what backend it talks
+to. The firmware's WiFiClient (plain HTTP) is fine here because the
+proxy upgrades to TLS for the upstream call.
+
+Usage:
+  scripts/http_proxy.py
+  scripts/http_proxy.py --port 8888 --upstream https://trmnl.app
+  scripts/http_proxy.py --upstream https://httpbin.org
+
+Point the firmware at this proxy by overriding the API URL — e.g. in
+test_config.h:
+
+  #define TEST_BACKEND_URL "http://192.168.1.42:8888"
+
+(use the dev machine's LAN IP — not localhost — since the firmware is
+on a separate host)
+"""
+import argparse
+import http.client
+import socket
+import ssl
+import sys
+import urllib.parse
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+UPSTREAM = "https://trmnl.app"   # overridable via --upstream
+
+
+def _truncate(s: str, max_len: int = 4096) -> str:
+    if len(s) <= max_len:
+        return s
+    return s[:max_len] + f"... <{len(s) - max_len} more bytes truncated>"
+
+
+class ProxyHandler(BaseHTTPRequestHandler):
+    upstream: str = UPSTREAM
+
+    # ---- logging ---------------------------------------------------------
+
+    def _log_request(self, body: bytes):
+        peer = self.client_address[0]
+        bar = "=" * 70
+        print(f"\n{bar}")
+        print(f">>> {self.command} {self.path}  from {peer}")
+        # self.headers is an email.message.Message backed by an ordered list,
+        # so .items() yields every header occurrence — duplicates included.
+        for k, v in self.headers.items():
+            print(f"    {k}: {v}")
+        if body:
+            try:
+                decoded = body.decode("utf-8")
+                print(f"    body ({len(body)} bytes):")
+                for line in _truncate(decoded).splitlines() or [""]:
+                    print(f"      {line}")
+            except UnicodeDecodeError:
+                print(f"    body: <{len(body)} non-UTF-8 bytes>")
+        sys.stdout.flush()
+
+    def _log_response(self, status: int, headers: list, body: bytes):
+        print(f"<<< {status}  ({len(body)} bytes)")
+        for k, v in headers:
+            print(f"    {k}: {v}")
+        sys.stdout.flush()
+
+    # ---- forwarding ------------------------------------------------------
+
+    def _forward(self, body: bytes):
+        parsed = urllib.parse.urlparse(self.upstream)
+        is_https = parsed.scheme == "https"
+        port = parsed.port or (443 if is_https else 80)
+
+        if is_https:
+            # Cert verification deliberately disabled — this proxy is a test
+            # instrument, not a production HTTPS client. Avoids the macOS
+            # "unable to get local issuer certificate" error without making
+            # the user install certifi or run "Install Certificates.command".
+            ctx = ssl.create_default_context()
+            ctx.check_hostname = False
+            ctx.verify_mode = ssl.CERT_NONE
+            conn = http.client.HTTPSConnection(parsed.hostname, port, context=ctx, timeout=20)
+        else:
+            conn = http.client.HTTPConnection(parsed.hostname, port, timeout=20)
+
+        # Build outbound headers as a list of tuples (not a dict) so duplicate
+        # header names from the firmware survive end-to-end instead of being
+        # silently collapsed.
+        # - skip Host + Content-Length here and re-set them below ourselves.
+        #   NOTE: the low-level putrequest/putheader/endheaders API does NOT
+        #   auto-add Content-Length the way the high-level conn.request() does
+        #   (that magic lives in _send_request, which we bypass). If we drop
+        #   the incoming Content-Length and don't re-add it, the upstream gets
+        #   no body framing and reads a zero-length body -> the backend sees an
+        #   empty request (e.g. /api/log stores `{}`). So recompute it from the
+        #   actual bytes we're forwarding.
+        # - force Accept-Encoding: identity so the upstream sends plain bytes
+        #   (gzipped responses would confuse the firmware's JSON parser)
+        skip = {"host", "content-length", "accept-encoding"}
+        outbound_headers = [(k, v) for k, v in self.headers.items() if k.lower() not in skip]
+        outbound_headers.append(("Host", parsed.hostname))
+        outbound_headers.append(("Accept-Encoding", "identity"))
+        outbound_headers.append(("Content-Length", str(len(body))))
+
+        try:
+            # Use the low-level API instead of conn.request(...): the high-level
+            # call iterates `headers` as if it were a dict (it does
+            # `for k in headers: k.lower()`), so passing a list of tuples
+            # crashes with "'tuple' object has no attribute 'lower'", and a
+            # dict would collapse duplicates. putheader() in a loop puts each
+            # occurrence on the wire verbatim.
+            conn.putrequest(self.command, self.path,
+                            skip_host=True, skip_accept_encoding=True)
+            for k, v in outbound_headers:
+                conn.putheader(k, v)
+            conn.endheaders(body)
+            resp = conn.getresponse()
+            resp_body = resp.read()
+            resp_headers = resp.getheaders()
+            self._log_response(resp.status, resp_headers, resp_body)
+
+            self.send_response(resp.status)
+            # Strip headers that would confuse the client given we may have
+            # rewritten body framing. Recompute Content-Length from the
+            # actual bytes we'll write.
+            drop = {"transfer-encoding", "connection", "content-length", "content-encoding"}
+            for k, v in resp_headers:
+                if k.lower() in drop:
+                    continue
+                self.send_header(k, v)
+            self.send_header("Content-Length", str(len(resp_body)))
+            self.end_headers()
+            self.wfile.write(resp_body)
+        except Exception as e:
+            print(f"!!! upstream request failed: {e}")
+            self.send_error(502, f"upstream failed: {e}")
+        finally:
+            conn.close()
+
+    # ---- HTTP methods ----------------------------------------------------
+
+    def _read_body(self) -> bytes:
+        length = int(self.headers.get("Content-Length", "0") or 0)
+        return self.rfile.read(length) if length else b""
+
+    def do_GET(self):    self._handle()
+    def do_POST(self):   self._handle()
+    def do_PUT(self):    self._handle()
+    def do_DELETE(self): self._handle()
+    def do_PATCH(self):  self._handle()
+    def do_HEAD(self):   self._handle()
+
+    def _handle(self):
+        body = self._read_body()
+        self._log_request(body)
+        self._forward(body)
+
+    # Silence the default access-log noise (we already print our own).
+    def log_message(self, *_args):
+        pass
+
+
+def make_handler(upstream: str):
+    return type("BoundHandler", (ProxyHandler,), {"upstream": upstream})
+
+
+def discover_local_ips() -> list:
+    """Return a sorted list of plausible LAN IPv4 addresses on this host,
+    with the most likely outbound-default one first. Excludes loopback.
+    """
+    found = []
+    # The reliable trick: open a UDP socket "to" a public address; the
+    # kernel picks the outbound interface and we read its IP. No packets
+    # actually leave the machine.
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.connect(("8.8.8.8", 80))
+        primary = s.getsockname()[0]
+        s.close()
+        if primary and not primary.startswith("127."):
+            found.append(primary)
+    except OSError:
+        pass
+
+    # Also scan all interfaces via getaddrinfo on our hostname — picks up
+    # multiple LAN addresses (wifi + ethernet + tailscale + etc).
+    try:
+        host = socket.gethostname()
+        for info in socket.getaddrinfo(host, None, socket.AF_INET):
+            ip = info[4][0]
+            if ip and not ip.startswith("127.") and ip not in found:
+                found.append(ip)
+    except OSError:
+        pass
+
+    return found
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--port", type=int, default=8888)
+    ap.add_argument("--bind", default="0.0.0.0",
+                    help="Interface to bind. Default 0.0.0.0 so the device on the LAN can reach it.")
+    ap.add_argument("--upstream", default=UPSTREAM,
+                    help=f"Upstream backend URL (default: {UPSTREAM})")
+    args = ap.parse_args()
+
+    server = ThreadingHTTPServer((args.bind, args.port), make_handler(args.upstream))
+    print(f"logging proxy listening on http://{args.bind}:{args.port}  "
+          f"-> {args.upstream}")
+
+    ips = discover_local_ips()
+    if ips:
+        print()
+        print("Paste ONE of these into test/integration/test_config.h "
+              "(pick the LAN your device is on):")
+        print()
+        for ip in ips:
+            print(f'    #define TEST_BACKEND_URL "http://{ip}:{args.port}"')
+        print()
+    else:
+        print("(couldn't auto-detect a LAN IP — point firmware at "
+              f"http://<dev-machine-LAN-IP>:{args.port})")
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nshutting down")
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/DEV_Config.h
+++ b/src/DEV_Config.h
@@ -78,6 +78,7 @@
   #define SENSOR_SDA 11
   #define SENSOR_SCL 12
   #define BQ25616_STAT_PIN 24
+  #define BQ25616_PG_PIN 25
 #elif defined(BOARD_XTEINK_X4)
   #define EPD_SCK_PIN  8
   #define EPD_MOSI_PIN 10

--- a/src/api-client/display.cpp
+++ b/src/api-client/display.cpp
@@ -14,7 +14,6 @@ extern int lastCO2, lastSCDTemp, lastTemp, lastSCDHumid, lastHumid, lastPressure
 const char *szDevices[] = {"None", "AHT20", "BMP180", "BME280", "BMP388", "SHT3X", "HDC1080", "HTS221", "MCP9808","BME68x","SHTC3"};
 const char *szMakers[] = {"None", "ASAIR", "Bosch", "Bosch", "Bosch", "Sensirion", "TI", "STMicro","MicroChip","Bosch","Sensirion"};
 #endif // SENSOR_SDA
-bool check_usb_power();
 
 void addHeaders(HTTPClient &https, ApiDisplayInputs &inputs)
 {

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -1595,12 +1595,11 @@ ApiDisplayInputs loadApiDisplayInputs(Preferences &preferences)
   inputs.specialFunction = special_function;
   inputs.imageCached = bUsedCachedImage;
   inputs.prevWakeTime = iPrevWakeTime;
-
-  inputs.usbConnected = (get_usb_status() == UsbStatus::CONNECTED);
+  inputs.usbStatus = get_usb_status();
+  inputs.chargingStatus = get_charging_status();
 
 #ifdef BOARD_TRMNL_X
   inputs.batteryCount = battery_count;
-  inputs.batteryCharging = (get_charging_status() == ChargingStatus::CHARGING); // 1 charging, 0 not charging
   if (lipo._initialized) { // only report SoC if battery was detected and BQ27427 initialized successfully
     inputs.stateOfCharge = lipo.soc();
     inputs.stateOfHealth = lipo.soh();

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -2,6 +2,7 @@
 #include <WiFi.h>
 #include <bl.h>
 #include <wifi_network.h>
+#include <power.h>
 #include <device_id.h>
 #include <trmnl_log.h>
 #include <types.h>
@@ -1057,7 +1058,7 @@ void bl_init(void)
   }
 #ifdef BOARD_TRMNL_X
   battery_count = detect_battery_count();
-  battery_charging = is_charging();
+  battery_charging = (get_charging_status() == ChargingStatus::CHARGING);
   Log_info("BATTERY COUNT: %d", battery_count);
   Log_info("BATTERY CHARGING: %s", battery_charging ? "YES" : "NO");
 
@@ -1594,12 +1595,12 @@ ApiDisplayInputs loadApiDisplayInputs(Preferences &preferences)
   inputs.specialFunction = special_function;
   inputs.imageCached = bUsedCachedImage;
   inputs.prevWakeTime = iPrevWakeTime;
-  inputs.usbConnected = false;
-  
+
+  inputs.usbConnected = (get_usb_status() == UsbStatus::CONNECTED);
+
 #ifdef BOARD_TRMNL_X
-  inputs.usbConnected = check_usb_power();
   inputs.batteryCount = battery_count;
-  inputs.batteryCharging = battery_charging; // 1 charging, 0 not charging
+  inputs.batteryCharging = (get_charging_status() == ChargingStatus::CHARGING); // 1 charging, 0 not charging
   if (lipo._initialized) { // only report SoC if battery was detected and BQ27427 initialized successfully
     inputs.stateOfCharge = lipo.soc();
     inputs.stateOfHealth = lipo.soh();

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1,5 +1,6 @@
 #include <Arduino.h>
 #include <display.h>
+#include <power.h>
 #include <PNGdec.h>
 #include <JPEGDEC.h>
 #include <Preferences.h>
@@ -221,9 +222,6 @@ void otg_turn_off()
     Log_info("OTG turned off");
 }
 
-#define BQ25616_PG_PIN    0    // TCA9535 P0_0 — open-drain, LOW = VBUS OK
-#define BQ25616_STAT_PIN  2    // TCA9535 P0_2 — open-drain, LOW = charging in progress
-
 #define BAT_DET_PIN       7    // TCA9535 P0_7 in bbep pin numbering
 #define BAT_CHARGE_MS     2    // drive HIGH for 2 ms to charge RC network
 #define BAT_TIMEOUT_US    6000 // no battery if pin is still HIGH after this
@@ -383,12 +381,6 @@ void enter_shipment_sleep()
     Serial.flush();
 }
 
-bool check_usb_power()
-{
-    bbep.ioPinMode(BQ25616_PG_PIN, INPUT);
-    return (bbep.ioRead(BQ25616_PG_PIN) == 0);
-}
-
 #define PIN_ESP32C5_SPI_BOOT 4
 #define PIN_ESP32C5_USB_BOOT 5
 #define PIN_ESP32C5_EN 6
@@ -426,20 +418,6 @@ void modem_reset_target(void) {
 
 #endif
 
-#ifdef BQ25616_STAT_PIN
-// Returns true while BQ25616 is actively charging (STAT LOW).
-// HIGH = charge complete or charge disabled; blinking = fault (reads as HIGH).
-bool is_charging()
-{
-#ifdef BOARD_TRMNL_X
-    bbep.ioPinMode(BQ25616_STAT_PIN, INPUT);
-    return (bbep.ioRead(BQ25616_STAT_PIN) == 0);
-#else // OG GEN2
-    pinMode(BQ25616_STAT_PIN, INPUT);
-    return (digitalRead(BQ25616_STAT_PIN) == 0);
-#endif
-}
-#endif // BQ25616_STAT_PIN
 /**
  * @brief Enable or disable light sleep at runtime
  * @param enabled true to enable light sleep, false to disable
@@ -1675,7 +1653,7 @@ void display_show_image(uint8_t *image_buffer, int data_size, bool bWait)
             bbep.loadG5Image(image_buffer, x, y, BBEP_WHITE, BBEP_BLACK);
 #ifdef BOARD_TRMNL_X
             // Show charging indicator if the USB power is connected (whether actually charging or not)
-            if (check_usb_power()) {
+            if (get_usb_status() == UsbStatus::CONNECTED) {
                 bbep.loadG5Image(battery_small, 40, bbep.height() - 120, BBEP_WHITE, BBEP_BLACK);
             }
 #endif // BOARD_TRMNL_X

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,7 @@
 #include <Arduino.h>
 #include "bl.h"
-#include "esp_ota_ops.h" 
+#include "power.h"
+#include "esp_ota_ops.h"
 #include "qa.h"
 
 #ifdef BOARD_TRMNL_X
@@ -21,7 +22,7 @@ void setup()
    
    display_init();
 
-   if (shipmentStarted && check_usb_power()) {
+   if (shipmentStarted && get_usb_status() == UsbStatus::CONNECTED) {
       // USB connected (e.g. battery died in transit and USB revived the device)
       enter_shipment_sleep();
       saveShipmentDone();

--- a/src/power.cpp
+++ b/src/power.cpp
@@ -1,0 +1,42 @@
+#include <power.h>
+#include <Arduino.h>
+#include <DEV_Config.h> // BQ25616_PG_PIN / BQ25616_STAT_PIN (gen2)
+
+#ifdef BOARD_TRMNL_X
+#include "FastEPD.h"
+// Defined in display.cpp. On TRMNL X the BQ25616 PG/STAT lines are wired to the
+// TCA9535 I/O expander, which is reached through the FastEPD io* helpers.
+extern FASTEPD bbep;
+// TCA9535 expander pins (open-drain, LOW = active).
+#define BQ25616_PG_PIN 0   // P0_0 — LOW = VBUS OK
+#define BQ25616_STAT_PIN 2 // P0_2 — LOW = charging in progress
+#endif // BOARD_TRMNL_X
+
+UsbStatus get_usb_status(void)
+{
+#if defined(BOARD_TRMNL_X)
+  bbep.ioPinMode(BQ25616_PG_PIN, INPUT);
+  return (bbep.ioRead(BQ25616_PG_PIN) == 0) ? UsbStatus::CONNECTED : UsbStatus::DISCONNECTED;
+#elif defined(BOARD_TRMNL_GEN2)
+  // BQ25616 PG wired to a dedicated C5 GPIO; open-drain, LOW = VBUS present.
+  pinMode(BQ25616_PG_PIN, INPUT);
+  return (digitalRead(BQ25616_PG_PIN) == 0) ? UsbStatus::CONNECTED : UsbStatus::DISCONNECTED;
+#else
+  return UsbStatus::UNKNOWN;
+#endif
+}
+
+ChargingStatus get_charging_status(void)
+{
+  // BQ25616 STAT: LOW = actively charging, HIGH = charge complete/disabled.
+  // TODO: detect ChargingStatus::FAULT (a fault blinks STAT, which reads HIGH).
+#if defined(BOARD_TRMNL_X)
+  bbep.ioPinMode(BQ25616_STAT_PIN, INPUT);
+  return (bbep.ioRead(BQ25616_STAT_PIN) == 0) ? ChargingStatus::CHARGING : ChargingStatus::NOT_CHARGING;
+#elif defined(BOARD_TRMNL_GEN2)
+  pinMode(BQ25616_STAT_PIN, INPUT);
+  return (digitalRead(BQ25616_STAT_PIN) == 0) ? ChargingStatus::CHARGING : ChargingStatus::NOT_CHARGING;
+#else
+  return ChargingStatus::UNKNOWN;
+#endif
+}

--- a/src/qa.cpp
+++ b/src/qa.cpp
@@ -1,5 +1,6 @@
 #include <Arduino.h>
 #include <display.h>
+#include <power.h>
 #include "button.h"
 #include "pins.h"
 #include "config.h"
@@ -105,9 +106,9 @@ bool enableShipmentMode() {
 
   Serial.println("Waiting for USB plug-off to enter shipment mode...");
 
-  if (check_usb_power()) {
+  if (get_usb_status() == UsbStatus::CONNECTED) {
     display_show_msg(const_cast<uint8_t *>(logo_medium),READY_TO_SHIP);
-    while (check_usb_power()) {
+    while (get_usb_status() == UsbStatus::CONNECTED) {
       Serial.println("USB power still detected, waiting...");
       delay(2000);
     }

--- a/test/test_request_headers/request_headers.test.cpp
+++ b/test/test_request_headers/request_headers.test.cpp
@@ -41,7 +41,7 @@ static ApiDisplayInputs makeDisplayInputs()
   inputs.displayWidth = 800;
   inputs.displayHeight = 480;
   inputs.specialFunction = SF_NONE;
-  inputs.usbConnected = false;
+  inputs.usbStatus = UsbStatus::UNKNOWN;
   inputs.imageCached = false;
   inputs.prevWakeTime = 42;
   return inputs;


### PR DESCRIPTION
This PR adds support for the gen2 to detect USB cable and battery charging status.

It also encapsulates these detection mechanisms device-agnostic enums and functions that do not require `#ifdef`s at the call site.

- extracted USB and charging connection logic to new `power.cpp`
    - both are tri-state measurements that return `UNKNOWN` on unsupported hardware
    - added `hardware_types.h` to the `trmnl` library since these new enums are needed by both the API client and hardware itself
- added support for gen2 to read those pins
- added `scripts/http_proxy.py` to aid in debugging (this has been SUPER helpful for me)


## Todo
- [x] test on OG - no headers
- [x] test on OG gen2 - with headers
- [x] test on X - with headers
- [x] test on BWRY - no headers