### PR TITLE
Connect to strongest AP on multi-AP (mesh) networks

### DIFF
--- a/lib/wificaptive/src/connect.cpp
+++ b/lib/wificaptive/src/connect.cpp
@@ -180,6 +180,16 @@ WifiConnectionResult initiateConnectionAndWaitForOutcome(const WifiCredentials c
     // always start with a clean state - disable any previous configuration
     disableWpa2Enterprise();
 
+    // Pick the strongest AP when an SSID is broadcast by multiple access points
+    // (mesh/roaming networks). The arduino-esp32 default is WIFI_FAST_SCAN, which
+    // associates with the FIRST AP found for the SSID regardless of signal strength,
+    // so the device can latch onto a weak/distant AP. WIFI_ALL_CHANNEL_SCAN scans
+    // every channel first, then WIFI_CONNECT_AP_BY_SIGNAL connects to the AP with the
+    // highest RSSI. Trade-off: a full-channel scan adds ~1-2s to each connect, which is
+    // an acceptable cost for reliably joining the nearest AP. See issue #285.
+    WiFi.setScanMethod(WIFI_ALL_CHANNEL_SCAN);
+    WiFi.setSortMethod(WIFI_CONNECT_AP_BY_SIGNAL);
+
     wl_status_t beginResult;
 
     if (credentials.isEnterprise)


### PR DESCRIPTION
The arduino-esp32 default scan method is WIFI_FAST_SCAN, which associates with the first AP found for a matching SSID regardless of signal strength. On networks where one SSID is broadcast by multiple APs (mesh/roaming), the device could latch onto a weak/distant AP instead of the nearest one, as reported with logs in issue #285.

Set WIFI_ALL_CHANNEL_SCAN + WIFI_CONNECT_AP_BY_SIGNAL before WiFi.begin() in initiateConnectionAndWaitForOutcome(), which is the single funnel for every connection path (autoConnect last-used, autoConnect fallback cycling, captive portal connect, and portal reconnect). esp-idf now scans all channels and associates with the highest-RSSI AP for the SSID.

Trade-off: a full-channel scan adds ~1-2s per connect vs fast scan.

Refs #285