### PR TITLE
Drop WiFi-SSID header

### DIFF
--- a/include/wifi_network.h
+++ b/include/wifi_network.h
@@ -5,7 +5,6 @@
 
 struct WiFiStatus
 {
-  String ssid; // connected network SSID ("" if unknown)
   int rssi;    // signal strength in dBm
   String band; // "2.4" or "5"
 };

--- a/lib/trmnl/include/api-client/request_headers.h
+++ b/lib/trmnl/include/api-client/request_headers.h
@@ -19,11 +19,6 @@ HttpHeaderList buildDisplayHeaders(const ApiDisplayInputs &inputs);
 HttpHeaderList buildSetupHeaders(const ApiSetupInputs &inputs);
 HttpHeaderList buildLogHeaders(const ApiLogInputs &inputs);
 
-// Percent-encode a string per RFC 3986 (unreserved chars pass through, all
-// others become %XX). Used to make arbitrary values — e.g. a Wi-Fi SSID with
-// spaces, ':' or control bytes — safe inside an HTTP header value.
-String percentEncode(const String &value);
-
 // Format a header list as a newline-separated "Name: value" string with no
 // trailing newline, as expected by Modem::httpGet() (TRMNL X 5 GHz path).
 String formatHeaders(const HttpHeaderList &headers);

--- a/lib/trmnl/include/api_types.h
+++ b/lib/trmnl/include/api_types.h
@@ -77,7 +77,6 @@ struct ApiDisplayInputs
   String model;
   int rssi;
   String wifiBand;
-  String wifiSSID;
   int displayWidth;
   int displayHeight;
   SPECIAL_FUNCTION specialFunction;

--- a/lib/trmnl/src/api-client/request_headers.cpp
+++ b/lib/trmnl/src/api-client/request_headers.cpp
@@ -27,8 +27,6 @@ HttpHeaderList buildDisplayHeaders(const ApiDisplayInputs &inputs)
   headers.push_back({"RSSI", String(inputs.rssi)});
   if (inputs.wifiBand.length() > 0)
     headers.push_back({"WiFi-Band", inputs.wifiBand});
-  if (inputs.wifiSSID.length() > 0)
-    headers.push_back({"WiFi-SSID", percentEncode(inputs.wifiSSID)});
   headers.push_back({"Temperature-Profile", "true"});
   headers.push_back({"Width", String(inputs.displayWidth)});
   headers.push_back({"Height", String(inputs.displayHeight)});
@@ -57,29 +55,6 @@ HttpHeaderList buildLogHeaders(const ApiLogInputs &inputs)
   headers.push_back({"Access-Token", inputs.apiKey});
   headers.push_back({"Content-Type", "application/json"});
   return headers;
-}
-
-String percentEncode(const String &value)
-{
-  static const char hex[] = "0123456789ABCDEF";
-  String out;
-  out.reserve(value.length());
-  for (size_t i = 0; i < value.length(); ++i)
-  {
-    unsigned char c = (unsigned char)value[i];
-    if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
-        (c >= '0' && c <= '9') || c == '-' || c == '.' || c == '_' || c == '~')
-    {
-      out += (char)c;
-    }
-    else
-    {
-      out += '%';
-      out += hex[c >> 4];
-      out += hex[c & 0x0F];
-    }
-  }
-  return out;
 }
 
 String formatHeaders(const HttpHeaderList &headers)

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -1585,7 +1585,6 @@ ApiDisplayInputs loadApiDisplayInputs(Preferences &preferences)
   WiFiStatus wifi = getWiFiStatus();
   inputs.rssi = wifi.rssi;
   inputs.wifiBand = wifi.band;
-  inputs.wifiSSID = wifi.ssid;
   inputs.batteryVoltage = vBatt; //readBatteryVoltage();
   inputs.firmwareVersion = String(FW_VERSION_STRING);
   inputs.displayWidth = display_width();

--- a/src/wifi_network.cpp
+++ b/src/wifi_network.cpp
@@ -11,7 +11,6 @@ extern Modem *g_modem;
 WiFiStatus getWiFiStatus(void)
 {
   WiFiStatus status;
-  status.ssid = WifiCaptivePortal.getLastCredentials().ssid;
   status.rssi = WiFi.RSSI();
   status.band = WiFi.channel() >= 36 ? "5" : "2.4";
 

--- a/test/test_request_headers/request_headers.test.cpp
+++ b/test/test_request_headers/request_headers.test.cpp
@@ -174,31 +174,6 @@ void test_display_headers_wifi_band_omitted_when_empty(void)
   TEST_ASSERT_FALSE(has(headers, "WiFi-Band"));
 }
 
-void test_display_headers_wifi_ssid_present(void)
-{
-  auto inputs = makeDisplayInputs();
-  inputs.wifiSSID = "MyNetwork";
-  auto headers = buildDisplayHeaders(inputs);
-  TEST_ASSERT_EQUAL_STRING("MyNetwork", valueOf(headers, "WiFi-SSID").c_str());
-}
-
-void test_display_headers_wifi_ssid_percent_encoded(void)
-{
-  auto inputs = makeDisplayInputs();
-  inputs.wifiSSID = "My Wi-Fi: café";
-  auto headers = buildDisplayHeaders(inputs);
-  // space, ':' and the UTF-8 bytes of 'é' (0xC3 0xA9) are escaped
-  TEST_ASSERT_EQUAL_STRING("My%20Wi-Fi%3A%20caf%C3%A9", valueOf(headers, "WiFi-SSID").c_str());
-}
-
-void test_display_headers_wifi_ssid_omitted_when_empty(void)
-{
-  auto inputs = makeDisplayInputs();
-  inputs.wifiSSID = "";
-  auto headers = buildDisplayHeaders(inputs);
-  TEST_ASSERT_FALSE(has(headers, "WiFi-SSID"));
-}
-
 // --- formatHeaders ---------------------------------------------------------
 
 void test_format_headers_newline_separated_no_trailing_newline(void)
@@ -216,24 +191,6 @@ void test_format_headers_empty_list_is_empty_string(void)
 {
   HttpHeaderList headers;
   TEST_ASSERT_EQUAL_STRING("", formatHeaders(headers).c_str());
-}
-
-// --- percentEncode ---------------------------------------------------------
-
-void test_percent_encode_passes_through_unreserved(void)
-{
-  TEST_ASSERT_EQUAL_STRING("abcXYZ09-._~", percentEncode("abcXYZ09-._~").c_str());
-}
-
-void test_percent_encode_escapes_reserved_and_control(void)
-{
-  // space, ':', '\n', '%' must all be escaped (uppercase hex)
-  TEST_ASSERT_EQUAL_STRING("a%20b%3A%0A%25", percentEncode("a b:\n%").c_str());
-}
-
-void test_percent_encode_empty_is_empty(void)
-{
-  TEST_ASSERT_EQUAL_STRING("", percentEncode("").c_str());
 }
 
 void test_format_setup_headers_round_trip(void)
@@ -268,14 +225,8 @@ void process()
   RUN_TEST(test_display_headers_wifi_band_2_4);
   RUN_TEST(test_display_headers_wifi_band_5);
   RUN_TEST(test_display_headers_wifi_band_omitted_when_empty);
-  RUN_TEST(test_display_headers_wifi_ssid_present);
-  RUN_TEST(test_display_headers_wifi_ssid_percent_encoded);
-  RUN_TEST(test_display_headers_wifi_ssid_omitted_when_empty);
   RUN_TEST(test_format_headers_newline_separated_no_trailing_newline);
   RUN_TEST(test_format_headers_empty_list_is_empty_string);
-  RUN_TEST(test_percent_encode_passes_through_unreserved);
-  RUN_TEST(test_percent_encode_escapes_reserved_and_control);
-  RUN_TEST(test_percent_encode_empty_is_empty);
   RUN_TEST(test_format_setup_headers_round_trip);
   UNITY_END();
 }


### PR DESCRIPTION
Following up on feedback from #388, the `WiFi-SSID` header has been removed, for privacy concerns.