### PR TITLE
OTA regression

### DIFF
--- a/lib/trmnl/include/ota_schedule.h
+++ b/lib/trmnl/include/ota_schedule.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <stdint.h>
+#include <persistence_interface.h>
+
+constexpr uint32_t OTA_RETRY_INTERVAL_SECONDS = 24UL * 60 * 60;
+#define OTA_LAST_ATTEMPT_KEY "last_ota"
+
+bool otaAttemptDue(uint32_t now, uint32_t lastOta);
+uint32_t otaLastAttempt(Persistence &persistence);
+void otaRecordAttempt(Persistence &persistence, uint32_t now);

--- a/lib/trmnl/src/ota_schedule.cpp
+++ b/lib/trmnl/src/ota_schedule.cpp
@@ -1,0 +1,19 @@
+#include <ota_schedule.h>
+
+bool otaAttemptDue(uint32_t now, uint32_t lastOta)
+{
+  if (lastOta == 0) return true;
+  if (now == 0) return false;
+  return (now - lastOta) >= OTA_RETRY_INTERVAL_SECONDS;
+}
+
+uint32_t otaLastAttempt(Persistence &persistence)
+{
+  return persistence.readUint(OTA_LAST_ATTEMPT_KEY, 0);
+}
+
+void otaRecordAttempt(Persistence &persistence, uint32_t now)
+{
+  if (now != 0)
+    persistence.writeUint(OTA_LAST_ATTEMPT_KEY, now);
+}

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -28,6 +28,7 @@
 #include "api-client/submit_log.h"
 #include <api-client/setup.h>
 #include <special_function.h>
+#include <ota_schedule.h>
 #include <api_response_parsing.h>
 #include "logging_parcers.h"
 #include <SPIFFS.h>
@@ -1429,11 +1430,12 @@ void bl_init(void)
   if (update_firmware)
   {
     uint32_t now = getTime();
-    if (now - preferences.getUInt(PREFERENCES_LAST_OTA) >= 24*60*60) {
+    if (otaAttemptDue(now, otaLastAttempt(preferencesPersistence))) {
       Log.info("%s [%d]: Last OTA attempt was > 24h ago, proceeding with download...\r\n", __FILE__, __LINE__);
       if (!checkAndPerformFirmwareUpdate()) {
         Log.info("%s [%d]: OTA update failed, storing the timestamp to prevent boot looping.\r\n", __FILE__, __LINE__);
-        preferences.putUInt(PREFERENCES_LAST_OTA, now); // store new time
+        otaRecordAttempt(preferencesPersistence, now);
+        update_firmware = false;
       }
     } else {
       Log.info("%s [%d]: Last OTA attempt was < 24h ago, skipping...\r\n", __FILE__, __LINE__);
@@ -3148,6 +3150,7 @@ static bool checkAndPerformFirmwareUpdate(void)
   }
 #endif
 
+  bool ota_ok = false;
   withHttp(binUrl, [&](HTTPClient *https, HttpError errorCode) -> bool
            {
              if (errorCode != HttpError::HTTPCLIENT_SUCCESS || !https)
@@ -3161,6 +3164,7 @@ static bool checkAndPerformFirmwareUpdate(void)
                {
                  showMessageWithLogo(WIFI_WEAK);
                }
+               return false;
              }
 
              int httpCode = https->GET();
@@ -3181,6 +3185,7 @@ static bool checkAndPerformFirmwareUpdate(void)
                    {
                      Log.info("%s [%d]: Firmware update successful. Rebooting...\r\n", __FILE__, __LINE__);
                      showMessageWithLogo(FW_UPDATE_SUCCESS);
+                     ota_ok = true;
                    }
                    else
                    {
@@ -3200,8 +3205,14 @@ static bool checkAndPerformFirmwareUpdate(void)
                  showMessageWithLogo(FW_UPDATE_FAILED);
                }
              }
-             return true; });
-    return false; // if we got here, it failed
+             else
+             {
+               Log.fatal("%s [%d]: Firmware GET failed, code: %d\r\n", __FILE__, __LINE__, httpCode);
+               showMessageWithLogo(API_FIRMWARE_UPDATE_ERROR);
+             }
+             return false;
+           });
+  return ota_ok;
 }
 
 /**

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -1726,8 +1726,7 @@ static https_request_err_e downloadAndShow()
 
   #ifdef BOARD_TRMNL_X
 // Special logic (TRMNL-X only) to download and disply the image if using a 5GHz AP
-  if (status && !update_firmware && !reset_firmware &&
-      WifiCaptivePortal.getLastCredentials().is5GHz && g_modem)
+  if (status && !reset_firmware && WifiCaptivePortal.getLastCredentials().is5GHz && g_modem)
   {
     Log_info("Downloading image via modem (5 GHz path)");
 
@@ -1797,7 +1796,7 @@ static https_request_err_e downloadAndShow()
           https.addHeader("Access-Token", apiDisplayInputs.apiKey);
         }
 
-        if (status && !update_firmware && !reset_firmware)
+        if (status && !reset_firmware)
         {
           status = false;
 

--- a/test/test_ota_schedule/ota_schedule.test.cpp
+++ b/test/test_ota_schedule/ota_schedule.test.cpp
@@ -1,0 +1,59 @@
+#include <unity.h>
+#include <ota_schedule.h>
+
+void test_first_attempt_when_never_tried(void)
+{
+  TEST_ASSERT_TRUE(otaAttemptDue(1700000000UL, 0));
+  TEST_ASSERT_TRUE(otaAttemptDue(0, 0));
+}
+
+void test_skip_when_clock_not_synced_after_prior_attempt(void)
+{
+  TEST_ASSERT_FALSE(otaAttemptDue(0, 1700000000UL));
+}
+
+void test_skip_before_retry_interval_elapsed(void)
+{
+  const uint32_t lastOta = 1700000000UL;
+  TEST_ASSERT_FALSE(otaAttemptDue(lastOta + OTA_RETRY_INTERVAL_SECONDS - 1, lastOta));
+}
+
+void test_attempt_when_retry_interval_elapsed(void)
+{
+  const uint32_t lastOta = 1700000000UL;
+  TEST_ASSERT_TRUE(otaAttemptDue(lastOta + OTA_RETRY_INTERVAL_SECONDS, lastOta));
+}
+
+void test_attempt_well_after_retry_interval(void)
+{
+  const uint32_t lastOta = 1700000000UL;
+  TEST_ASSERT_TRUE(otaAttemptDue(lastOta + OTA_RETRY_INTERVAL_SECONDS + 3600, lastOta));
+}
+
+void test_unsynced_clock_does_not_underflow_into_due(void)
+{
+  TEST_ASSERT_FALSE(otaAttemptDue(0, 1));
+}
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void process()
+{
+  UNITY_BEGIN();
+  RUN_TEST(test_first_attempt_when_never_tried);
+  RUN_TEST(test_skip_when_clock_not_synced_after_prior_attempt);
+  RUN_TEST(test_skip_before_retry_interval_elapsed);
+  RUN_TEST(test_attempt_when_retry_interval_elapsed);
+  RUN_TEST(test_attempt_well_after_retry_interval);
+  RUN_TEST(test_unsynced_clock_does_not_underflow_into_due);
+  UNITY_END();
+}
+
+int main(int argc, char **argv)
+{
+  (void)argc;
+  (void)argv;
+  process();
+  return 0;
+}


### PR DESCRIPTION
**Issue** 
Found an edge case where when OTA update fail or is skipped and if the image is not present in cache, TRMNL stays at the last displayed screen for the next 24 hrs (when the OTA update is attempted again).

**Reproduction steps**
1. checkout main branch and apply the below patch. The patch mimics the behaviour where OTA was last attempted 2 hrs back and the image if found in cache is deleted.

```
Subject: [PATCH] OTA regression
---
Index: src/bl.cpp
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/src/bl.cpp b/src/bl.cpp
--- a/src/bl.cpp	(revision 5f0684253bf7bb230987d2dd679cd35ca1993854)
+++ b/src/bl.cpp	(date 1781012199169)
@@ -1428,6 +1428,8 @@
   if (update_firmware)
   {
     uint32_t now = getTime();
+    if (now != 0)
+      preferences.putUInt(PREFERENCES_LAST_OTA, now - 3600); // TODO: remove — repro: OTA skipped (<24h)
     if (now - preferences.getUInt(PREFERENCES_LAST_OTA) >= 24*60*60) {
       Log.info("%s [%d]: Last OTA attempt was > 24h ago, proceeding with download...\r\n", __FILE__, __LINE__);
       if (!checkAndPerformFirmwareUpdate()) {
@@ -1682,6 +1684,14 @@
 
   https_request_err_e result = handleApiDisplayResponse(apiDisplayResult.response);
 
+  // TODO: remove — repro stuck EPD on master: force new-image path (no SPIFFS cache bypass)
+  if (update_firmware && apiDisplayResult.response.filename.length() > 0) {
+    char szTemp[36];
+    fixFileName(apiDisplayResult.response.filename.c_str(), szTemp);
+    filesystem_file_delete(szTemp);
+    status = true;
+  }
+
   if (!status && result == HTTPS_SUCCESS) { // this means we already have this image stored in SPIFFS
       char szTemp[36];
 #if defined( BOARD_X_CLASS ) && !defined(BOARD_SEEED_RETERMINAL_E1003)
Index: include/config.h
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/include/config.h b/include/config.h
--- a/include/config.h	(revision 5f0684253bf7bb230987d2dd679cd35ca1993854)
+++ b/include/config.h	(date 1781011748691)
@@ -3,7 +3,7 @@
 
 #define FW_MAJOR_VERSION 1
 #define FW_MINOR_VERSION 8
-#define FW_PATCH_VERSION 6
+#define FW_PATCH_VERSION 5
 
 // Helper macros for stringification
 #define STRINGIFY(x) #x
```
2. Make sure your device is eligible for firmware `1.8.6`

**Fix:**
set `update_firmware = false;` when OTA update fails and `checkAndPerformFirmwareUpdate` should return `true` only if OTA update was successful.

**Tests**
- [x] TRMNL OG
- [x] TRMNL BWRY
- [X] TRMNL X