### PR TITLE
Add Seeed reTerminal E1004 support

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -46,7 +46,7 @@
 
 #define DISPLAY_BMP_IMAGE_SIZE 48062 // in bytes - 62 bytes - header; 48000 bytes - bitmap (480*800 1bpp) / 8
 #define DEFAULT_IMAGE_SIZE 48000
-#if defined(BOARD_TRMNL_X) || defined(BOARD_TRMNL_X_EPDIY)
+#if defined(BOARD_TRMNL_X) || defined(BOARD_TRMNL_X_EPDIY) || defined(BOARD_SEEED_RETERMINAL_E1004)
 #define MAX_IMAGE_SIZE 750000 // Use PSRAM on the ESP32-S3
 #else
 #define MAX_IMAGE_SIZE 90000 // largest compressed image we can receive
@@ -161,9 +161,14 @@ enum WIFI_CONNECT_RETRY_TIME // Time to sleep before trying to connect to the Wi
 #define PIN_VBAT_SWITCH 40
 #define VBAT_SWITCH_LEVEL HIGH
 #define DEVICE_MODEL "reTerminal E1003"
+#elif defined(BOARD_SEEED_RETERMINAL_E1004)
+#define DEVICE_MODEL "reTerminal E1004"
+#define PIN_INTERRUPT 4        // wake button (GPIO4)
+#define PIN_VBAT_SWITCH 21     // battery measurement load switch enable
+#define VBAT_SWITCH_LEVEL HIGH // load switch enable pin active level
 #endif
 
-#if defined(BOARD_XIAO_EPAPER_DISPLAY) || defined(BOARD_SEEED_RETERMINAL_E1001) || defined(BOARD_SEEED_RETERMINAL_E1002)
+#if defined(BOARD_XIAO_EPAPER_DISPLAY) || defined(BOARD_SEEED_RETERMINAL_E1001) || defined(BOARD_SEEED_RETERMINAL_E1002) || defined(BOARD_SEEED_RETERMINAL_E1004)
 #define PIN_BATTERY 1
 #elif defined(BOARD_XTEINK_X4)
 #define PIN_BATTERY 0

--- a/platformio.ini
+++ b/platformio.ini
@@ -11,13 +11,13 @@ lib_deps =
 	bblanchon/ArduinoJson@7.4.2
 	bitbank2/PNGdec@^1.1.6
 	bitbank2/JPEGDEC@^1.8.4
-	bitbank2/bb_epaper@^2.1.7
 ;	https://github.com/bitbank2/bb_epaper.git#5aaf81fddec42c7775b0599e80808498aee3168b
 
 ; Dependencies for all device builds
 [deps_app]
 lib_deps =
 	${deps_common.lib_deps}
+	bitbank2/bb_epaper@^2.1.7
 	bitbank2/bb_scd41@1.3.2
 	https://github.com/bitbank2/bb_temperature.git#20ed72ee5a8db05c0ac23b68d6d601a537aee9ae
 	ESP32Async/ESPAsyncWebServer@3.7.7

--- a/platformio.ini
+++ b/platformio.ini
@@ -638,6 +638,39 @@ build_flags =
 	-D ARDUINO_USB_CDC_ON_BOOT=0
 	-D PNG_MAX_BUFFERED_PIXELS=6432
 
+[env:seeed_reTerminal_E1004]
+extends = env:esp32_base
+board = seeed_xiao_esp32s3
+framework = arduino
+extra_scripts = post:scripts/extra/post_build_seeed.py
+; override the default build flags, removing the USB_MODE and CDC_ON_BOOT flags
+board_build.extra_flags =
+	-D ARDUINO_XIAO_ESP32S3
+	-D BOARD_HAS_PSRAM
+	-D DARDUINO_RUNNING_CORE=1
+	-D ARDUINO_EVENT_RUNNING_CORE=1
+build_flags =
+	${env:esp32_base.build_flags}
+	-D BOARD_SEEED_RETERMINAL_E1004
+	-D DEV_FIRMWARE=1
+	-D DO_NOT_LIGHT_SLEEP=1
+	-D ARDUINO_USB_MODE=0
+	-D ARDUINO_USB_CDC_ON_BOOT=0
+	-D PNG_MAX_BUFFERED_PIXELS=14984
+; Explicit deps_app list MINUS the registry bb_epaper, replaced by the E1004
+; branch (which adds the EP133A_SPECTRA_1200x1600 panel for the E1004). This
+; avoids pulling two copies of bb_epaper into the build.
+lib_deps =
+	bblanchon/ArduinoJson@7.4.2
+	bitbank2/PNGdec@^1.1.6
+	bitbank2/JPEGDEC@^1.8.4
+	bitbank2/bb_scd41@1.3.2
+	https://github.com/bitbank2/bb_temperature.git#20ed72ee5a8db05c0ac23b68d6d601a537aee9ae
+	ESP32Async/ESPAsyncWebServer@3.7.7
+	https://github.com/thijse/Arduino-Log.git#3f4fcf5a345c1d542e56b88c0ffcb2bd2a5b0bd0
+	https://github.com/limengdu/bb_epaper.git#codex/e1004-t133a01
+lib_ignore = bb_spi_lcd
+
 
 [env:trmnl_gen2]
 board = esp32c5_n16r8

--- a/platformio.ini
+++ b/platformio.ini
@@ -440,7 +440,7 @@ lib_deps =
 
 lib_ignore = bb_epaper
 
-[env:seeed_reTerminal_E1003]
+[env:TRMNL_X_E1003]
 board = esp32s3_n16r8
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.37/platform-espressif32.zip
 board_build.f_cpu = 240000000L

--- a/platformio.ini
+++ b/platformio.ini
@@ -440,7 +440,7 @@ lib_deps =
 
 lib_ignore = bb_epaper
 
-[env:TRMNL_X_E1003]
+[env:seeed_reTerminal_E1003]
 board = esp32s3_n16r8
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.37/platform-espressif32.zip
 board_build.f_cpu = 240000000L

--- a/scripts/extra/post_build_seeed.py
+++ b/scripts/extra/post_build_seeed.py
@@ -4,10 +4,13 @@ from pathlib import Path
 
 def post_build(source, target, env):
     build_dir = Path(env.subst("$BUILD_DIR"))
+    python = env.subst("$PYTHONEXE")
+    esptool_dir = Path(env.PioPlatform().get_package_dir("tool-esptoolpy"))
+    esptool = esptool_dir / "esptool.py"
     output = build_dir / "merged_firmware.bin"
 
     subprocess.run([
-        "pio", "pkg", "exec", "-p", "tool-esptoolpy", "esptool.py", "--",
+        python, str(esptool),
         "--chip", "ESP32S3",
         "merge_bin",
         "-o", str(output),

--- a/src/DEV_Config.h
+++ b/src/DEV_Config.h
@@ -152,6 +152,19 @@
    #define EPD_EN_PIN   11
    #define EPD_BUSY_PIN 13
    #define EPD_VCC_EN   21
+#elif defined (BOARD_SEEED_RETERMINAL_E1004)
+   // Pin definition for reTerminal E1004 (13.3" T133A01, dual-chip Spectra6).
+   // The panel itself is driven by Seeed_GFX via Setup523; these mirror that
+   // wiring so this header does not fall through to the #error below.
+   #define EPD_SCK_PIN    7
+   #define EPD_MISO_PIN   8
+   #define EPD_MOSI_PIN   9
+   #define EPD_CS_PIN     10
+   #define EPD_CS1_PIN    2   // second chip-select (dual-chip controller)
+   #define EPD_DC_PIN     11
+   #define EPD_BUSY_PIN   13
+   #define EPD_RST_PIN    38
+   #define EPD_EN_PIN     12  // panel power enable
 #elif defined (BOARD_X_CLASS)
 // Parallel Eink devices don't explicitly define GPIO pins for the display here
 #else

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -35,6 +35,9 @@
 #include <api-client/display.h>
 #include <api-client/request_headers.h>
 #include "driver/gpio.h"
+#ifdef BOARD_SEEED_RETERMINAL_E1004
+#include "driver/rtc_io.h"
+#endif
 #include "esp_ota_ops.h"
 #include "esp_sntp.h"
 #include "esp_flash.h"
@@ -803,7 +806,11 @@ void bl_init(void)
 #endif
   startup_time = init_time/1000L; // convert to milliseconds
 #ifdef DEV_FIRMWARE
+  #ifdef BOARD_SEEED_RETERMINAL_E1004
+  Serial.begin(115200, SERIAL_8N1, 44, 43);
+  #else
   Serial.begin(115200);
+  #endif
   wait_for_serial();
   Log.begin(LOG_LEVEL_VERBOSE, &Serial);
 #endif
@@ -3204,6 +3211,15 @@ static bool checkAndPerformFirmwareUpdate(void)
     return false; // if we got here, it failed
 }
 
+#ifdef BOARD_SEEED_RETERMINAL_E1004
+static void configureWakeButtonForSleep(void)
+{
+  pinMode(PIN_INTERRUPT, INPUT_PULLUP);
+  rtc_gpio_pullup_en(static_cast<gpio_num_t>(PIN_INTERRUPT));
+  rtc_gpio_pulldown_dis(static_cast<gpio_num_t>(PIN_INTERRUPT));
+}
+#endif
+
 /**
  * @brief Function to sleep preparing and go to sleep
  * @param none
@@ -3264,6 +3280,9 @@ void goToSleep(void)
   pinMode(PIN_INTERRUPT, INPUT); // needed to not immediately wake up
   esp_deep_sleep_enable_gpio_wakeup(1 << PIN_INTERRUPT, ESP_GPIO_WAKEUP_GPIO_LOW);
 #elif defined(CONFIG_IDF_TARGET_ESP32S3)
+  #ifdef BOARD_SEEED_RETERMINAL_E1004
+  configureWakeButtonForSleep();
+  #endif
   esp_sleep_enable_ext0_wakeup((gpio_num_t)PIN_INTERRUPT, 0);
 #else
 #error "Unsupported ESP32 target for GPIO wakeup configuration"
@@ -3290,6 +3309,9 @@ static void goToSleepButtonOnly(void)
 #elif defined( CONFIG_IDF_TARGET_ESP32C3 ) || defined ( CONFIG_IDF_TARGET_ESP32C5 )
   esp_deep_sleep_enable_gpio_wakeup(1 << PIN_INTERRUPT, ESP_GPIO_WAKEUP_GPIO_LOW);
 #elif CONFIG_IDF_TARGET_ESP32S3
+  #ifdef BOARD_SEEED_RETERMINAL_E1004
+  configureWakeButtonForSleep();
+  #endif
   esp_sleep_enable_ext0_wakeup((gpio_num_t)PIN_INTERRUPT, 0);
 #else
 #error "Unsupported ESP32 target for GPIO wakeup configuration"
@@ -3470,7 +3492,7 @@ static float readBatteryVoltage(void)
     return -1.0;
   }
 #else
-  #if defined(BOARD_XIAO_EPAPER_DISPLAY) || defined(BOARD_SEEED_RETERMINAL_E1001) || defined(BOARD_SEEED_RETERMINAL_E1002)
+  #if defined(BOARD_XIAO_EPAPER_DISPLAY) || defined(BOARD_SEEED_RETERMINAL_E1001) || defined(BOARD_SEEED_RETERMINAL_E1002) || defined(BOARD_SEEED_RETERMINAL_E1004)
     pinMode(PIN_VBAT_SWITCH, OUTPUT);
     digitalWrite(PIN_VBAT_SWITCH, VBAT_SWITCH_LEVEL);
     delay(10); // Wait for the switch to stabilize

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -44,6 +44,12 @@ BBEPAPER bbep(EP75YR_800x480);
     {EP73_SPECTRA_800x480, EP73_SPECTRA_800x480}, // b = darker grays
 };
 BBEPAPER bbep(EP73_SPECTRA_800x480);
+#elif defined(BOARD_SEEED_RETERMINAL_E1004)
+    {EP133A_SPECTRA_1200x1600, EP133A_SPECTRA_1200x1600}, // 13.3" dual-chip Spectra6
+    {EP133A_SPECTRA_1200x1600, EP133A_SPECTRA_1200x1600},
+    {EP133A_SPECTRA_1200x1600, EP133A_SPECTRA_1200x1600},
+};
+BBEPAPER bbep(EP133A_SPECTRA_1200x1600);
 #else // TRMNL OG and GEN2
     {EP75_800x480, EP75_800x480_4GRAY}, // default (for original EPD)
     {EP75_800x480_GEN2, EP75_800x480_4GRAY_GEN2}, // a = uses built-in fast + 4-gray
@@ -51,9 +57,9 @@ BBEPAPER bbep(EP73_SPECTRA_800x480);
 };
 BBEPAPER bbep(EP75_800x480);
 #endif
-#ifdef BOARD_SEEED_RETERMINAL_E1002
+#if defined(BOARD_SEEED_RETERMINAL_E1002) || defined(BOARD_SEEED_RETERMINAL_E1004)
 uint8_t u8SpectraPal[512]; // RGB333 mapped to closest Spectra6 color
-#endif // E1002
+#endif // E1002 || E1004
 
 #else // BOARD_X_CLASS
 #include "esp_sleep.h"
@@ -118,6 +124,13 @@ void display_init(void)
 #ifdef BB_EPAPER
     bbep.setPanelType(dpList[iTempProfile].OneBit); // must be set BEFORE calling initio
     Log_info("BB e-Paper init");
+#ifdef BOARD_SEEED_RETERMINAL_E1004
+    // E1004 (13.3" dual-chip): enable panel power and register the second
+    // controller's chip-select BEFORE initIO so both controllers get initialised.
+    pinMode(EPD_EN_PIN, OUTPUT);
+    digitalWrite(EPD_EN_PIN, HIGH);
+    bbep.setCS2(EPD_CS1_PIN);
+#endif
     bbep.initIO(EPD_DC_PIN, EPD_RST_PIN, EPD_BUSY_PIN, EPD_CS_PIN, EPD_MOSI_PIN, EPD_SCK_PIN, 8000000);
 #else
 #ifdef BOARD_TRMNL_X
@@ -430,6 +443,17 @@ void display_set_light_sleep(uint8_t enabled)
 #endif
 }
 
+#ifdef BB_EPAPER
+static void display_apply_light_sleep_setting(void)
+{
+#ifdef DO_NOT_LIGHT_SLEEP
+    bbep.setLightSleep(false);
+#else
+    bbep.setLightSleep(true);
+#endif
+}
+#endif
+
 /**
  * @brief Function to sleep the ESP32 while saving power
  * @param u32Millis represents the sleep time in milliseconds
@@ -459,7 +483,7 @@ void display_reset(void)
     Log_info("e-Paper Clear start");
     bbep.fillScreen(BBEP_WHITE);
 #ifdef BB_EPAPER
-    bbep.setLightSleep(true);
+    display_apply_light_sleep_setting();
     if (!apiDisplayResult.response.maximum_compatibility) {
         bbep.refresh(REFRESH_FAST, true);
     } else {
@@ -815,7 +839,7 @@ unsigned char GetBWYRPixel(int r, int g, int b)
 } /* GetBWYRPixel() */
 #endif // BB_EPAPER
 
-#ifdef BOARD_SEEED_RETERMINAL_E1002
+#if defined(BOARD_SEEED_RETERMINAL_E1002) || defined(BOARD_SEEED_RETERMINAL_E1004)
 //
 // bb_epaper colors to map to Spectra6 colors
 // The RGB values are not correct for the panel, but for simple mapping
@@ -861,23 +885,25 @@ void CreateSpectra6Pal(void)
 //
 // Convert the RGB value into one of 6 Spectra6 colors
 //
+#endif // E1002 || E1004
+//
+// Convert an RGB pixel to a panel colour.
+// E1002 and E1004 map to the nearest of 6 Spectra colours.
+//
+#if defined(BOARD_SEEED_RETERMINAL_E1002) || defined(BOARD_SEEED_RETERMINAL_E1004)
 uint8_t GetSpectraPixel(int r, int g, int b)
 {
-uint8_t c;
-uint16_t rgb333;
-
-    rgb333 = (r>>5) + ((g & 0xe0) >> 2) + ((b & 0xe0) << 1);
-    c = u8SpectraPal[rgb333];
-    return c;
+    uint16_t rgb333 = (r>>5) + ((g & 0xe0) >> 2) + ((b & 0xe0) << 1);
+    return u8SpectraPal[rgb333];
 } /* GetSpectraPixel() */
-#endif // E1002
+#endif // E1002 || E1004
 /**
  * @brief Callback function for each line of PNG decoded
  * @param PNGDRAW structure containing the current line and relevant info
  * @return none
  */
 #ifdef BB_EPAPER
-#ifdef BOARD_SEEED_RETERMINAL_E1002
+#if defined(BOARD_SEEED_RETERMINAL_E1002) || defined(BOARD_SEEED_RETERMINAL_E1004)
 //
 // Draw the PNG image into the local framebuffer memory using the drawPixel() method
 // to do color translation and to properly format the memory layout
@@ -977,7 +1003,7 @@ int png_draw_6clr(PNGDRAW *pDraw)
         } // for x
     return 1; // continue decoding
 } /* png_draw_6clr() */
-#endif // E1002 (Spectra6 only)
+#endif // E1002 || E1004 (Spectra6)
 
 #ifdef BOARD_TRMNL_4CLR
 //
@@ -1485,20 +1511,20 @@ PNG *png = new PNG();
             Log_info("%s [%d]: Decoding %d-bpp png (current)\r\n", __FILE__, __LINE__, png->getBpp());
             // Prepare target memory window (entire display)
 #ifdef BB_EPAPER
-#ifdef BOARD_SEEED_RETERMINAL_E1002
-            CreateSpectra6Pal(); // create a fast color matching palette
+#if defined(BOARD_SEEED_RETERMINAL_E1002) || defined(BOARD_SEEED_RETERMINAL_E1004)
+            CreateSpectra6Pal(); // create a fast color matching palette (6-color only)
             if (bbep.allocBuffer() != BBEP_SUCCESS) {
                 Log_error("%s [%d]: bbep.AllocBuffer failed!\n\r", __FILE__, __LINE__);
                 return -1;
             }
-            Log_info("%s [%d]: decoding for 6-color EPD\r\n", __FILE__, __LINE__);
+            Log_info("%s [%d]: decoding for Spectra6 EPD\r\n", __FILE__, __LINE__);
             png->openRAM((uint8_t *)pPNG, iDataSize, png_draw_6clr);
             png->decode(NULL, 0);
             png->close();
             bbep.writePlane();
             delete(png); // free the decoder instance
             return REFRESH_FULL;
-#endif // E1002
+#endif // E1002 || E1004
 #ifdef BOARD_TRMNL_4CLR
             Log_info("%s [%d]: decoding for 4-color EPD\r\n", __FILE__, __LINE__);
             png->openRAM((uint8_t *)pPNG, iDataSize, png_draw_4clr);
@@ -1696,11 +1722,7 @@ void display_show_image(uint8_t *image_buffer, int data_size, bool bWait)
     if (bbep.capabilities() & (BBEP_4COLOR | BBEP_3COLOR | BBEP_7COLOR)) bWait = 1;
     if (!bWait) iRefreshMode = REFRESH_PARTIAL; // fast update when showing loading screen
     Log_info("%s [%d]: EPD refresh mode: %d\r\n", __FILE__, __LINE__, iRefreshMode);
-#ifdef DO_NOT_LIGHT_SLEEP
-    bbep.setLightSleep(false);
-#else
-    bbep.setLightSleep(true);
-#endif
+    display_apply_light_sleep_setting();
     bbep.refresh(iRefreshMode, bWait);
     if ((bbep.getPanelType() == EP426_800x480 || bbep.getPanelType() == EP397_800x480) && iRefreshMode == REFRESH_PARTIAL) {
         i426Workaround = 1; // need to re-initialize the controller for another update before sleeping
@@ -2280,6 +2302,7 @@ void display_show_msg(uint8_t *image_buffer, MSG message_type, const char *messa
     }
 #ifdef BB_EPAPER
     bbep.writePlane(PLANE_0);
+    display_apply_light_sleep_setting();
     bbep.refresh(REFRESH_FULL, true);
     bbep.freeBuffer();
 #else
@@ -2372,6 +2395,7 @@ void display_show_msg_qa(uint8_t *image_buffer, const float *voltage, const floa
 
     #ifdef BB_EPAPER
         bbep.writePlane(PLANE_0);
+        display_apply_light_sleep_setting();
         bbep.refresh(REFRESH_FULL, true);
         bbep.freeBuffer();
     #else
@@ -2415,6 +2439,7 @@ void display_show_msg(uint8_t *image_buffer, MSG message_type, String friendly_i
         bbep.fillScreen(BBEP_WHITE);
 #ifdef BB_EPAPER
         bbep.writePlane(PLANE_0);
+        display_apply_light_sleep_setting();
         if (!apiDisplayResult.response.maximum_compatibility) {
             bbep.refresh(REFRESH_FAST, true); // newer panel can handle the fast refresh
         } else {
@@ -2529,6 +2554,7 @@ void display_show_msg(uint8_t *image_buffer, MSG message_type, String friendly_i
     Log_info("Start drawing...");
 #ifdef BB_EPAPER
     bbep.writePlane(PLANE_0);
+    display_apply_light_sleep_setting();
     bbep.refresh(REFRESH_FULL, true);
     bbep.freeBuffer();
 #else


### PR DESCRIPTION
## Summary

Adds firmware support for the Seeed reTerminal E1004, a 13.3 inch 1200 x 1600 dual-chip Spectra 6 ePaper device.

Included changes:

- Add the `seeed_reTerminal_E1004` PlatformIO environment.
- Add the E1004 pin map, wake button, battery measurement switch, and UART logging path.
- Route E1004 rendering through the `bb_epaper` Spectra 6 driver path.
- Decode PNG content with the existing Spectra 6 nearest-color palette mapping instead of forcing black/white output.
- Disable `bb_epaper` light sleep before blocking refresh calls on this target to avoid RTC watchdog resets during long E1004 refreshes.
- Fix the Seeed post-build merge helper to invoke PlatformIO's packaged `esptool.py` from the active environment.

## Device parameters for hosted TRMNL support

The hosted TRMNL app will also need a Device Model / palette entry for this hardware. The firmware sends this model header:

- `Model`: `reTerminal E1004`

Suggested device parameters:

- Product: Seeed reTerminal E1004
- Display panel: 13.3 inch E Ink Spectra 6
- Panel model: T133A01
- Resolution: 1200 x 1600 pixels
- Colors: 6
- Palette: Spectra 6
- Image format: PNG
- Firmware panel enum: `EP133A_SPECTRA_1200x1600`
- Panel topology: dual-chip / dual-controller panel
- MCU board target: Seeed XIAO ESP32S3 / ESP32-S3
- Wake button: GPIO4, active low
- UART log bridge: RX GPIO44, TX GPIO43, 115200 baud
- Battery measurement load switch: GPIO21, active HIGH

Without a hosted Device Model / palette entry for this combination, BYOD registration currently fails in the TRMNL web app with `Palette is invalid`.

## Dependency

This firmware target depends on `bb_epaper` support for `EP133A_SPECTRA_1200x1600`. Until that is available in an upstream library release, this PlatformIO environment points at the E1004 support branch:

- `https://github.com/limengdu/bb_epaper.git#codex/e1004-t133a01`

Related `bb_epaper` PR:

- https://github.com/bitbank2/bb_epaper/pull/32

## Root cause fixed

During hardware validation, the unregistered-device page could render successfully but the board restarted during the long blocking E1004 refresh. The reset reason was `RTCWDT_RTC_RST`, which made the display look like it was refreshing repeatedly. The fix is to apply the existing `DO_NOT_LIGHT_SLEEP` behavior to all `bb_epaper` refresh entry points used by E1004.

## Validation

- Built successfully with `pio run -e seeed_reTerminal_E1004` on top of the current upstream `main`.
- Uploaded to real Seeed reTerminal E1004 hardware.
- Confirmed TRMNL logo rendering.
- Confirmed the MAC-not-registered screen renders and then enters sleep instead of rebooting repeatedly.
- Confirmed serial logs through the E1004 UART bridge.
- Confirmed Spectra 6 color rendering through the `bb_epaper` path during hardware testing.

Serial validation excerpt:

```text
Model: reTerminal E1004
display_show_msg2 end
Goto Sleep...
time to sleep - 900
```