### PR TITLE
Pin libraries to specific versions

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -5,13 +5,14 @@ default_envs = trmnl
 ;	Third-party Dependencies
 ;       ========================
 
-; Common dependencies for all environments
+; Common dependencies for all environments. DO NOT use caret (^) version specifiers here, 
+; as they can cause unexpected updates. Instead, specify exact versions.
 [deps_common]
 lib_deps =
 	bblanchon/ArduinoJson@7.4.2
-	bitbank2/PNGdec@^1.1.6
-	bitbank2/JPEGDEC@^1.8.4
-	bitbank2/bb_epaper@^2.1.7
+	bitbank2/PNGdec@1.1.6
+	bitbank2/JPEGDEC@1.8.4
+	bitbank2/bb_epaper@2.1.9
 ;	https://github.com/bitbank2/bb_epaper.git#5aaf81fddec42c7775b0599e80808498aee3168b
 
 ; Dependencies for all device builds
@@ -52,7 +53,7 @@ test_framework = unity
 test_ignore = integration/*
 lib_deps =
 	${deps_common.lib_deps}
-	fabiobatsilva/ArduinoFake@^0.4.0
+	fabiobatsilva/ArduinoFake@0.4.0
 build_flags =
 	-D ARDUINOJSON_ENABLE_ARDUINO_STRING=1
 	-std=gnu++11


### PR DESCRIPTION
PlatformIO has no concept of a lockfile, so there's no way to know what library version is pulled in.

To prevent issues with unattended upgrades that break things, let's pin the libraries to explicit versions and upgrade them manually so that we can validate the changes.