### PR TITLE
Fix OG / BWRY OTA failure

### DIFF
--- a/include/wifi_network.h
+++ b/include/wifi_network.h
@@ -12,4 +12,10 @@ struct WiFiStatus
 /// @brief Resolve the current Wi-Fi status
 WiFiStatus getWiFiStatus(void);
 
+/// @brief Connect using credentials saved in WifiCaptivePortal
+bool connectWithSavedCredentials(void);
+
+/// @brief Ensure WiFi is connected, reconnecting with saved credentials if needed.
+bool ensureWifiConnected(void);
+
 #endif // WIFI_NETWORK_H

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -1217,21 +1217,7 @@ void bl_init(void)
   {
     // WiFi saved, connection
     Log.info("%s [%d]: WiFi saved\r\n", __FILE__, __LINE__);
-#ifdef BOARD_TRMNL_X
-    WifiCredentials lastCreds = WifiCaptivePortal.getLastCredentials();
-    int connection_res;
-    if (lastCreds.is5GHz && g_modem)
-    {
-      Log.info("%s [%d]: 5 GHz network saved — connecting via modem\r\n", __FILE__, __LINE__);
-      connection_res = g_modem->connectToNetwork(lastCreds.ssid, lastCreds.pswd) ? 1 : 0;
-    }
-    else
-    {
-      connection_res = WifiCaptivePortal.autoConnect();
-    }
-#else
-    int connection_res = WifiCaptivePortal.autoConnect();
-#endif // BOARD_TRMNL_X
+    int connection_res = connectWithSavedCredentials() ? 1 : 0;
 
     Log.info("%s [%d]: Connection result: %d, WiFI Status: %d\r\n", __FILE__, __LINE__, connection_res, WiFi.status());
 
@@ -3149,6 +3135,15 @@ static bool checkAndPerformFirmwareUpdate(void)
   }
 #endif
 
+	showMessageWithLogo(FW_UPDATE);
+
+  if (!ensureWifiConnected())
+  {
+    Log.fatal("%s [%d]: Unable to reconnect WiFi for firmware update\r\n", __FILE__, __LINE__);
+    showMessageWithLogo(API_FIRMWARE_UPDATE_ERROR);
+    return false;
+  }
+
   bool ota_ok = false;
   withHttp(binUrl, [&](HTTPClient *https, HttpError errorCode) -> bool
            {
@@ -3176,7 +3171,6 @@ static bool checkAndPerformFirmwareUpdate(void)
                if (Update.begin(contentLength))
                {
                  Log.info("%s [%d]: Firmware update start\r\n", __FILE__, __LINE__);
-                 showMessageWithLogo(FW_UPDATE);
 
                  if (Update.writeStream(https->getStream()))
                  {

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -3135,7 +3135,7 @@ static bool checkAndPerformFirmwareUpdate(void)
   }
 #endif
 
-	showMessageWithLogo(FW_UPDATE);
+  showMessageWithLogo(FW_UPDATE);
 
   if (!ensureWifiConnected())
   {

--- a/src/wifi_network.cpp
+++ b/src/wifi_network.cpp
@@ -1,12 +1,17 @@
 #include <wifi_network.h>
 #include <WiFi.h>
 #include <WifiCaptive.h>
+#include <trmnl_log.h>
 
 #ifdef BOARD_TRMNL_X
 // Defined in bl.cpp; set once during bl_init(). Only used on the 5 GHz path.
 #include "modem.h"
 extern Modem *g_modem;
 #endif // BOARD_TRMNL_X
+
+namespace {
+constexpr unsigned long WIFI_RECONNECT_TIMEOUT_MS = 10000;
+}
 
 WiFiStatus getWiFiStatus(void)
 {
@@ -25,4 +30,43 @@ WiFiStatus getWiFiStatus(void)
 #endif // BOARD_TRMNL_X
 
   return status;
+}
+
+bool connectWithSavedCredentials(void) {
+  if (!WifiCaptivePortal.isSaved())
+    return false;
+
+#ifdef BOARD_TRMNL_X
+  if (g_modem)
+  {
+    WifiCredentials creds = WifiCaptivePortal.getLastCredentials();
+    if (creds.is5GHz)
+      return g_modem->connectToNetwork(creds.ssid, creds.pswd);
+  }
+#endif
+
+  return WifiCaptivePortal.autoConnect();
+}
+
+bool ensureWifiConnected(void) {
+  if (WiFi.status() == WL_CONNECTED)
+    return true;
+
+  Log_info("%s [%d]: WiFi disconnected, reconnecting...\r\n", __FILE__, __LINE__);
+
+  if (!WifiCaptivePortal.isSaved())
+  {
+    Log_error("%s [%d]: No saved WiFi credentials\r\n", __FILE__, __LINE__);
+    return false;
+  }
+
+  WiFi.reconnect();
+  unsigned long start = millis();
+  while (WiFi.status() != WL_CONNECTED && millis() - start < WIFI_RECONNECT_TIMEOUT_MS)
+    delay(100);
+
+  if (WiFi.status() == WL_CONNECTED)
+    return true;
+
+  return connectWithSavedCredentials();
 }


### PR DESCRIPTION
**Problem:**
FW version starting 1.7.6 (I might be wrong with version number), my TRMNL OG and now my BWRY fails to do automated OTA update. The only way for me and other users to get latest TRMNL FW is by flashing the FW manually via the flash page, while this works. It'd be nice to get updates via OTA.

**Investigation**
Watching the serial log, I see that the TRMNL OG & BWRY do not even attempt to download the FW. More debugging reveals that the WiFi is explicitly disconnected in `downloadAndShow`, but FW update happens later in the sequence.

```
WiFi.disconnect(true); // no need for WiFi, save power starting here
```

**Solution**
- Reconnect with WiFi when just before downloading the FW.
- display `showMessageWithLogo(FW_UPDATE);` just before connecting to WiFi, this is important for BWRY as it can take 10s for the screen to refresh, during which I see that BWRY acts buggy and do not update FW.

**Reproduction Steps**
- checkout to current `main`
- change the below code from
```
if (otaAttemptDue(now, otaLastAttempt(preferencesPersistence))) {
```
to 
```
if (otaAttemptDue(now, otaLastAttempt(preferencesPersistence)) || true) {
```
- build + upload the FW as 1.8.5 to receive 1.8.6
- on certain effected device you'd see FW update failure.

**Tests**
- [X] TRMNL OG
- [X] TRMNL BWRY
- [X] TRMNL X