### PR TITLE
Improved battery guage logic to speed up per-wakeup status delays

### DIFF
--- a/lib/BQ27427/src/BQ27427.cpp
+++ b/lib/BQ27427/src/BQ27427.cpp
@@ -787,22 +787,25 @@ bool BQ27427::writeBlockChecksum(uint8_t csum)
 uint8_t BQ27427::readExtendedData(uint8_t classID, uint8_t offset)
 {
 	uint8_t retData = 0;
-	if (!_userConfigControl) enterConfig(false);
-		
+//	if (!_userConfigControl) enterConfig(false);
+// Adds unnecessary delays since we're just reading data
+
 	if (!blockDataControl()) // // enable block data memory control
 		return false; // Return false if enable fails
 	if (!blockDataClass(classID)) // Write class ID using DataBlockClass()
 		return false;
 	
 	blockDataOffset(offset / 32); // Write 32-bit block offset (usually 0)
-	
-	computeBlockChecksum(); // Compute checksum going in
-	uint8_t oldCsum = blockDataChecksum();
+
+// No need to compute a checksum because we're READING data, not writing data
+//	computeBlockChecksum(); // Compute checksum going in
+//	uint8_t oldCsum = blockDataChecksum();
 	/*for (int i=0; i<32; i++)
 		Serial.print(String(readBlockData(i)) + " ");*/
 	retData = readBlockData(offset % 32); // Read from offset (limit to 0-31)
-	
-	if (!_userConfigControl) exitConfig();
+
+// Adds unnecessary delays since we're just reading data
+//	if (!_userConfigControl) exitConfig();
 	
 	return retData;
 }
@@ -995,6 +998,10 @@ bool BQ27427::applyGoldenFile(bool twoCell)
 			Serial.printf("BQ27427 golden file [%s]: WARNING — FW version != 2.02, continuing anyway\n", tag);
 		else
 			Serial.printf("BQ27427 golden file [%s]: FW version 2.02 confirmed\n", tag);
+			if (!flags() && BQ27427_FLAG_ITPOR) {
+				Serial.printf("BQ27427 No need to re-apply golden file, the power was not reset. Exiting...");
+				return true;
+			}
 	}
 
 	//------------------------------------------------------------------

--- a/lib/BQ27427/src/BQ27427.cpp
+++ b/lib/BQ27427/src/BQ27427.cpp
@@ -994,14 +994,15 @@ bool BQ27427::applyGoldenFile(bool twoCell)
 		uint8_t cmd[] = {0x02, 0x00};
 		i2cWriteBytes(0x00, cmd, 2);
 		const uint8_t exp[] = {0x02, 0x02};
-		if (!goldenFileVerify(0x00, exp, 2))
+		if (!goldenFileVerify(0x00, exp, 2)) {
 			Serial.printf("BQ27427 golden file [%s]: WARNING — FW version != 2.02, continuing anyway\n", tag);
-		else
+		} else {
 			Serial.printf("BQ27427 golden file [%s]: FW version 2.02 confirmed\n", tag);
-			if (!flags() && BQ27427_FLAG_ITPOR) {
+			if (!(flags() & BQ27427_FLAG_ITPOR)) {
 				Serial.printf("BQ27427 No need to re-apply golden file, the power was not reset. Exiting...");
 				return true;
 			}
+		}
 	}
 
 	//------------------------------------------------------------------

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -1062,44 +1062,52 @@ void bl_init(void)
   Log_info("BATTERY CHARGING: %s", battery_charging ? "YES" : "NO");
 
   if (battery_count != BATTERY_NONE) {
-    BQ27427_reset();
-    delay(300); // BQ27427 needs 250 ms to power up
-
+    bool bBQ27Alive = false;
     if (!lipo.begin(SENSOR_SDA_PIN, SENSOR_SCL_PIN)) {
-    // If communication fails, print an error message and loop forever.
-      Log_error("Error: Unable to communicate with BQ27427.");
-      gpio_dump_io_configuration(stdout, (1ULL << 39));
-      gpio_dump_io_configuration(stdout, (1ULL << 40));
-    }
-    else {
-    Log_info("Connected to BQ27427!");
-
-    if (battery_count == BATTERY_ONE) {
-      Log_info("One battery detected");
-      lipo.configureOneCell();
-    }
-    else if (battery_count == BATTERY_TWO) {
-      Log_info("Two batteries detected");
-      lipo.configureTwoCell();
-    }
-
-    // After SOFT_RESET the BQ27427 enters INITIALIZATION (ITPOR=1).
-    // The IT algorithm needs an OCV measurement (battery at rest) to
-    // transition to NORMAL mode and produce accurate capacity values.
-    // Poll for up to 5 s; under active load it may not clear until rest.
-    {
-      unsigned long t0 = millis();
-      while ((lipo.flags() & BQ27427_FLAG_ITPOR) && (millis() - t0 < 5000)) {
-        delay(100);
-      }
-      if (lipo.flags() & BQ27427_FLAG_ITPOR) {
-        Log_info("BQ27427: ITPOR still set — device in INITIALIZATION, capacity values may be stale");
+      BQ27427_reset(); // try resetting the chip
+      delay(300); // BQ27427 needs 250 ms to power up
+      if (!lipo.begin(SENSOR_SDA_PIN, SENSOR_SCL_PIN)) { // try again
+      // If communication fails, print an error message and loop forever.
+        Log_error("Error: Unable to communicate with BQ27427.");
+        gpio_dump_io_configuration(stdout, (1ULL << 39));
+        gpio_dump_io_configuration(stdout, (1ULL << 40));
       } else {
+        bBQ27Alive = true;
+      }
+    } else {
+      bBQ27Alive = true;
+    }
+    if (bBQ27Alive) {
+    Log_info("Connected to BQ27427!");
+    if (lipo.flags() & BQ27427_FLAG_ITPOR) { // it got reset, reload the 'golden file' data
+      if (battery_count == BATTERY_ONE) {
+        Log_info("One battery detected");
+        lipo.configureOneCell();
+      } else if (battery_count == BATTERY_TWO) {
+        Log_info("Two batteries detected");
+        lipo.configureTwoCell();
+      }
+
+      // After SOFT_RESET the BQ27427 enters INITIALIZATION (ITPOR=1).
+      // The IT algorithm needs an OCV measurement (battery at rest) to
+      // transition to NORMAL mode and produce accurate capacity values.
+      // Poll for up to 5 s; under active load it may not clear until rest.
+      {
+        unsigned long t0 = millis();
+        while ((lipo.flags() & BQ27427_FLAG_ITPOR) && (millis() - t0 < 5000)) {
+          delay(100);
+        }
+        if (lipo.flags() & BQ27427_FLAG_ITPOR) {
+          Log_info("BQ27427: ITPOR still set — device in INITIALIZATION, capacity values may be stale");
+        } else {
+          Log_info("BQ27427: ITPOR cleared — device in NORMAL mode");
+          lipo._initialized = true;
+        }
+      }
+    } else {
         Log_info("BQ27427: ITPOR cleared — device in NORMAL mode");
         lipo._initialized = true;
-      }
     }
-
     uint8_t energyScale = lipo.designEnergyScale();
     unsigned int soc = lipo.soc();                               // State-of-charge (%) — use this for battery level display
     unsigned int volts = lipo.voltage();                         // Battery voltage (mV)


### PR DESCRIPTION
This change patches the BQ27xxx library to remove unneeded delays. The result is 8-12 seconds of each wakeup period saved!
