### PR TITLE
Fixed 2-bit gray updates on 4.26 inch panels

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -156,6 +156,9 @@ enum WIFI_CONNECT_RETRY_TIME // Time to sleep before trying to connect to the Wi
 #define PIN_INTERRUPT 3        // the green button
 #define PIN_VBAT_SWITCH 21     // load switch enable pin for battery voltage measurement
 #define VBAT_SWITCH_LEVEL HIGH // load switch enable pin active level
+#elif defined(BOARD_SEEED_STICKY)
+#define DEVICE_MODEL "reTerminal Sticky"
+#define PIN_INTERRUPT 4        // the power button
 #elif defined(BOARD_SEEED_RETERMINAL_E1003)
 #define PIN_INTERRUPT 3 // green button
 #define PIN_VBAT_SWITCH 40

--- a/platformio.ini
+++ b/platformio.ini
@@ -193,6 +193,7 @@ extra_scripts =
 build_flags =
 	${env:esp32_base.build_flags}
 	-D BOARD_XTEINK_X4
+	-D MINI_EPD
 	-D PNG_MAX_BUFFERED_PIXELS=6432
 	-D ARDUINOJSON_ENABLE_ARDUINO_STRING=1
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -564,6 +564,40 @@ build_flags =
 	-D USE_FAKE_BATTERY_VOLTAGE
 	-D MINI_EPD
 
+[env:seeed_sticky]
+board = esp32s3_n16r8
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.37/platform-espressif32.zip
+board_build.f_cpu = 240000000L
+board_build.f_flash   = 80000000L
+board_build.flash_mode = qio
+board_build.partitions = trmnl_x_partitions.csv
+board_build.filesystem = spiffs
+upload_speed = 460800
+extra_scripts =
+	scripts/extra/git_version.py
+	post:scripts/extra/post_build_x.py
+custom_include_git_hash = ${sysenv.INCLUDE_GIT_HASH_IN_VERSION_NUMBER}
+board_build.extra_flags =
+	-D BOARD_HAS_PSRAM
+	-D DARDUINO_RUNNING_CORE=1
+	-D ARDUINO_EVENT_RUNNING_CORE=1
+build_flags =
+;	-D ARDUINO_USB_MODE=0
+;	-D ARDUINO_USB_CDC_ON_BOOT=0
+	-D BOARD_SEEED_STICKY
+	-D PNG_MAX_BUFFERED_PIXELS=6432
+	-D USE_FAKE_BATTERY_VOLTAGE
+	-D MINI_EPD2
+;    -D DEV_FIRMWARE=1
+;    -D WAIT_FOR_SERIAL=1
+;    -D DO_NOT_LIGHT_SLEEP=1
+
+board_build.embed_txtfiles =
+    managed_components/espressif__esp_insights/server_certs/https_server.crt
+	managed_components/espressif__esp_rainmaker/server_certs/rmaker_mqtt_server.crt
+    managed_components/espressif__esp_rainmaker/server_certs/rmaker_claim_service_server.crt
+    managed_components/espressif__esp_rainmaker/server_certs/rmaker_ota_server.crt
+
 [env:TRMNL_7inch5_OG_DIY_Kit]
 extends = env:esp32_base
 board = seeed_xiao_esp32s3
@@ -615,10 +649,13 @@ board_build.extra_flags =
 build_flags =
         ${env:esp32_base.build_flags}
         -D BOARD_WAVESHARE_397
-        -D WAIT_FOR_SERIAL=1
-        -D ARDUINOJSON_ENABLE_ARDUINO_STRING=1
-        -D ARDUINO_USB_MODE=1
-        -D ARDUINO_USB_CDC_ON_BOOT=1
+		-D MINI_EPD2
+;		-D DEV_FIRMWARE
+;       -D DO_NOT_LIGHT_SLEEP
+;        -D WAIT_FOR_SERIAL=1
+;        -D ARDUINOJSON_ENABLE_ARDUINO_STRING=1
+;        -D ARDUINO_USB_MODE=1
+;        -D ARDUINO_USB_CDC_ON_BOOT=1
         -D PNG_MAX_BUFFERED_PIXELS=6432
 
 

--- a/src/DEV_Config.h
+++ b/src/DEV_Config.h
@@ -103,7 +103,15 @@
    #define EPD_RST_PIN  46
    #define EPD_DC_PIN   9
    #define EPD_BUSY_PIN 3
-#define FAKE_BATTERY_VOLTAGE
+   #define FAKE_BATTERY_VOLTAGE
+#elif defined(BOARD_SEEED_STICKY)
+   #define EPD_SCK_PIN  13
+   #define EPD_MOSI_PIN 14
+   #define EPD_CS_PIN   15
+   #define EPD_RST_PIN  17
+   #define EPD_DC_PIN   16
+   #define EPD_BUSY_PIN 18
+   #define FAKE_BATTERY_VOLTAGE
 #elif defined(BOARD_SEEED_XIAO_ESP32C3)
    // Pin definition for Seeed XIAO ESP32C3 Board
    #define EPD_SCK_PIN  8

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -798,6 +798,13 @@ void sensor_init(void)
  */
 void bl_init(void)
 {
+#ifdef BOARD_SEEED_STICKY
+  pinMode(45, OUTPUT); // power hold (DATA)
+  pinMode(46, OUTPUT); // power lock (CLK)
+  digitalWrite(45, 1);
+  digitalWrite(46, 0);
+  digitalWrite(46, 1); // Hold the battery power enabled for after the user releases the power button
+#endif
 #ifdef BOARD_TRMNL_X
   uint32_t init_time = esp_cpu_get_cycle_count() / esp_rom_get_cpu_ticks_per_us();
 #else

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -14,7 +14,7 @@
 #include <SPIFFS.h>
 #define FS SPIFFS
 const DISPLAY_PROFILE dpList[4] = { // 1-bit and 2-bit display types for each profile
-#if defined ( BOARD_XTEINK_X4 ) || defined ( MINI_EPD )
+#ifdef MINI_EPD
     {EP426_800x480, EP426_800x480_4GRAY}, // default (for original EPD)
     {EP426_800x480, EP426_800x480_4GRAY}, // a = uses built-in fast + 4-gray
     {EP426_800x480, EP426_800x480_4GRAY}, // b = darker grays
@@ -99,7 +99,6 @@ extern char filename[];
 extern Preferences preferences;
 extern ApiDisplayResult apiDisplayResult;
 uint32_t iTempProfile;
-static int i426Workaround = 0;
 static uint8_t *pDither;
 
 // Runtime control for light sleep (true = enabled, false = disabled)
@@ -1538,6 +1537,10 @@ PNG *png = new PNG();
                 } // temp profile needs the second plane written
             } else { // 2-bpp (or greater, but reduced to 2-bpp)
                 bbep.setPanelType(dpList[iTempProfile].TwoBit);
+#ifdef MINI_EPD
+                Log_info("2-bit 4.26 re-init");
+                bbep.initIO(EPD_DC_PIN, EPD_RST_PIN, EPD_BUSY_PIN, EPD_CS_PIN, EPD_MOSI_PIN, EPD_SCK_PIN, 8000000);
+#endif
                 rc = REFRESH_FULL; // 4gray mode must be full refresh
                 iUpdateCount = 0; // grayscale mode resets the partial update counter
                 bbep.startWrite(PLANE_0); // start writing image data to plane 0
@@ -1615,12 +1618,10 @@ void display_show_image(uint8_t *image_buffer, int data_size, bool bWait)
     }
 #endif
 #ifdef BB_EPAPER
-    if (i426Workaround) {
-        // After a partial update, the 4.26" 800x480 needs to be 'reset' to accept writes
-        // This is only needed if the user pressed the WAKE button and there will be 2 updates
-        // while the power is on
+#ifdef MINI_EPD
+        Log_info("4.26 1-bit re-init");
         bbep.initIO(EPD_DC_PIN, EPD_RST_PIN, EPD_BUSY_PIN, EPD_CS_PIN, EPD_MOSI_PIN, EPD_SCK_PIN, 8000000);
-    }
+#endif // MINI_EPD
 #endif // BB_EPAPER
     if (isPNG == true && data_size < MAX_IMAGE_SIZE)
     {
@@ -1667,7 +1668,7 @@ void display_show_image(uint8_t *image_buffer, int data_size, bool bWait)
 #endif
         }
 #ifdef BB_EPAPER
-#if defined( BOARD_XTEINK_X4 ) || defined( MINI_EPD )
+#ifdef MINI_EPD
         bbep.writePlane(PLANE_FALSE_DIFF);
 #else
         bbep.writePlane(); // send image data to the EPD
@@ -1693,7 +1694,7 @@ void display_show_image(uint8_t *image_buffer, int data_size, bool bWait)
         Log_info("%s [%d]: Forcing fast refresh (not partial) since the TRMNL refresh_rate is set to > 30 min\n", __FILE__, __LINE__);
         iRefreshMode = REFRESH_FAST;
     }
-    if (bbep.capabilities() & (BBEP_4COLOR | BBEP_3COLOR | BBEP_7COLOR)) bWait = 1;
+    if (bbep.capabilities() & (BBEP_4GRAY | BBEP_4COLOR | BBEP_3COLOR | BBEP_7COLOR)) bWait = 1;
     if (!bWait) iRefreshMode = REFRESH_PARTIAL; // fast update when showing loading screen
     Log_info("%s [%d]: EPD refresh mode: %d\r\n", __FILE__, __LINE__, iRefreshMode);
 #ifdef DO_NOT_LIGHT_SLEEP
@@ -1702,9 +1703,6 @@ void display_show_image(uint8_t *image_buffer, int data_size, bool bWait)
     bbep.setLightSleep(true);
 #endif
     bbep.refresh(iRefreshMode, bWait);
-    if ((bbep.getPanelType() == EP426_800x480 || bbep.getPanelType() == EP397_800x480) && iRefreshMode == REFRESH_PARTIAL) {
-        i426Workaround = 1; // need to re-initialize the controller for another update before sleeping
-    }
     if (bAlloc) {
         bbep.freeBuffer();
     }

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -20,7 +20,7 @@ const DISPLAY_PROFILE dpList[4] = { // 1-bit and 2-bit display types for each pr
     {EP426_800x480, EP426_800x480_4GRAY}, // b = darker grays
 };
 BBEPAPER bbep(EP426_800x480);
-#elif defined(BOARD_WAVESHARE_397)
+#elif defined(MINI_EPD2)
     {EP397_800x480, EP397_800x480_4GRAY}, // default (for original EPD)
     {EP397_800x480, EP397_800x480_4GRAY}, // a = uses built-in fast + 4-gray
     {EP397_800x480, EP397_800x480_4GRAY}, // b = darker grays
@@ -115,6 +115,10 @@ void display_init(void)
     iTempProfile = preferences.getUInt(PREFERENCES_TEMP_PROFILE, TEMP_PROFILE_DEFAULT);
     Log_info("Saved temperature profile: %d", iTempProfile);
 #ifdef BB_EPAPER
+#ifdef BOARD_SEEED_STICKY
+    pinMode(47, OUTPUT); // enable EPD power
+    digitalWrite(47, 1);
+#endif
     bbep.setPanelType(dpList[iTempProfile].OneBit); // must be set BEFORE calling initio
     Log_info("BB e-Paper init");
     bbep.initIO(EPD_DC_PIN, EPD_RST_PIN, EPD_BUSY_PIN, EPD_CS_PIN, EPD_MOSI_PIN, EPD_SCK_PIN, 8000000);
@@ -1537,7 +1541,7 @@ PNG *png = new PNG();
                 } // temp profile needs the second plane written
             } else { // 2-bpp (or greater, but reduced to 2-bpp)
                 bbep.setPanelType(dpList[iTempProfile].TwoBit);
-#ifdef MINI_EPD
+#if defined( MINI_EPD ) || defined (MINI_EPD2)
                 Log_info("2-bit 4.26 re-init");
                 bbep.initIO(EPD_DC_PIN, EPD_RST_PIN, EPD_BUSY_PIN, EPD_CS_PIN, EPD_MOSI_PIN, EPD_SCK_PIN, 8000000);
 #endif
@@ -1618,7 +1622,7 @@ void display_show_image(uint8_t *image_buffer, int data_size, bool bWait)
     }
 #endif
 #ifdef BB_EPAPER
-#ifdef MINI_EPD
+#if defined( MINI_EPD ) || defined (MINI_EPD2)
         Log_info("4.26 1-bit re-init");
         bbep.initIO(EPD_DC_PIN, EPD_RST_PIN, EPD_BUSY_PIN, EPD_CS_PIN, EPD_MOSI_PIN, EPD_SCK_PIN, 8000000);
 #endif // MINI_EPD
@@ -1668,7 +1672,7 @@ void display_show_image(uint8_t *image_buffer, int data_size, bool bWait)
 #endif
         }
 #ifdef BB_EPAPER
-#ifdef MINI_EPD
+#if defined( MINI_EPD ) || defined (MINI_EPD2)
         bbep.writePlane(PLANE_FALSE_DIFF);
 #else
         bbep.writePlane(); // send image data to the EPD


### PR DESCRIPTION
This is a minor fix to enable 2-bit grayscale mode to work properly on the 4.26" 800x480 panels. They require an extra 'panel init' after each update.