### PR TITLE
POST new development firmware to core via admin API

### DIFF
--- a/.github/workflows/publish-dev-firmware.yml
+++ b/.github/workflows/publish-dev-firmware.yml
@@ -94,6 +94,16 @@ jobs:
           aws s3 cp "$FLASH_FILE" "${DEST}/${FLASH_FILE}"
           aws s3 cp latest.json "${DEST}/latest.json" --content-type application/json --cache-control no-cache
 
+      - name: Notify TRMNL of new dev firmware
+        env:
+          TRMNL_ADMIN_API_TOKEN: ${{ secrets.TRMNL_ADMIN_API_TOKEN }}
+        run: |
+          curl --fail-with-body -sS -X POST \
+            -H "Access-Token: ${TRMNL_ADMIN_API_TOKEN}" \
+            -H "Content-Type: application/json" \
+            --data @latest.json \
+            https://trmnl.com/admin_api/development_firmwares
+
       - name: Prune old firmware (keep 50 newest .bin)
         run: |
           PREFIX="${{ matrix.folder }}/dev/"


### PR DESCRIPTION
Adds a final build step to `POST /admin_api/development_firmwares` with the latest dev build, which immediately promotes it to the `development` release channel.