### PR TITLE
Add level to submitted log JSON

### DIFF
--- a/include/bl.h
+++ b/include/bl.h
@@ -1,6 +1,8 @@
 #ifndef BL_H
 #define BL_H
 
+#include "trmnl_log.h"
+
 /**
  * @brief Function to init business logic module
  * @param none
@@ -23,7 +25,7 @@ enum LogAction {
   LOG_ACTION_SUBMIT_OR_STORE
 };
 
-void logWithAction(LogAction action, const char *message, time_t time, int line, const char *file);
+void logWithAction(LogAction action, LogLevel level, const char *message, time_t time, int line, const char *file);
 
 bool submitLogString(const char *log_buffer);
 bool storeLogString(const char *log_buffer);

--- a/lib/trmnl/include/api_types.h
+++ b/lib/trmnl/include/api_types.h
@@ -4,6 +4,7 @@
 #include <ArduinoJson.h>
 #include "special_function.h"
 #include "hardware_types.h"
+#include "trmnl_log.h"
 
 enum class ApiSetupOutcome
 {
@@ -127,4 +128,5 @@ struct LogWithDetails
   String filenameNew;
   bool logRetry;
   int retryAttempt;
+  LogLevel level;
 };

--- a/lib/trmnl/include/trmnl_log.h
+++ b/lib/trmnl/include/trmnl_log.h
@@ -1,11 +1,13 @@
 
 #pragma once
 
-enum LogLevel {
+enum LogLevel
+{
     LOG_VERBOSE = 0,
     LOG_INFO = 1,
-    LOG_ERROR = 2,
-    LOG_FATAL = 3
+    LOG_WARN = 2,
+    LOG_ERROR = 3,
+    LOG_FATAL = 4
 };
 
 enum LogMode
@@ -15,7 +17,7 @@ enum LogMode
     LOG_SUBMIT_OR_STORE
 };
 
-void log_impl(LogLevel level, LogMode mode, const char* file, int line, const char* format, ...);
+void log_impl(LogLevel level, LogMode mode, const char *file, int line, const char *format, ...);
 
 #define _LOG_IMPL(level, mode, format, ...) \
     log_impl(level, mode, __FILE__, __LINE__, format, ##__VA_ARGS__)
@@ -28,6 +30,8 @@ void log_impl(LogLevel level, LogMode mode, const char* file, int line, const ch
 /** Log to serial and store locally for later submission */
 #define Log_info(format, ...) _LOG_IMPL(LOG_INFO, LOG_STORE_ONLY, format, ##__VA_ARGS__)
 /** Log to serial and store locally for later submission */
+#define Log_warn(format, ...) _LOG_IMPL(LOG_WARN, LOG_STORE_ONLY, format, ##__VA_ARGS__)
+/** Log to serial and store locally for later submission */
 #define Log_error(format, ...) _LOG_IMPL(LOG_ERROR, LOG_STORE_ONLY, format, ##__VA_ARGS__)
 /** Log to serial and store locally for later submission */
 #define Log_fatal(format, ...) _LOG_IMPL(LOG_FATAL, LOG_STORE_ONLY, format, ##__VA_ARGS__)
@@ -39,6 +43,8 @@ void log_impl(LogLevel level, LogMode mode, const char* file, int line, const ch
 #define Log_verbose_submit(format, ...) _LOG_IMPL(LOG_VERBOSE, LOG_SUBMIT_OR_STORE, format, ##__VA_ARGS__)
 /** Log to serial and attempt to submit to API, else store locally. */
 #define Log_info_submit(format, ...) _LOG_IMPL(LOG_INFO, LOG_SUBMIT_OR_STORE, format, ##__VA_ARGS__)
+/** Log to serial and attempt to submit to API, else store locally. */
+#define Log_warn_submit(format, ...) _LOG_IMPL(LOG_WARN, LOG_SUBMIT_OR_STORE, format, ##__VA_ARGS__)
 /** Log to serial and attempt to submit to API, else store locally. */
 #define Log_error_submit(format, ...) _LOG_IMPL(LOG_ERROR, LOG_SUBMIT_OR_STORE, format, ##__VA_ARGS__)
 /** Log to serial and attempt to submit to API, else store locally. */
@@ -54,6 +60,8 @@ void log_impl(LogLevel level, LogMode mode, const char* file, int line, const ch
 #define Log_verbose_serial(format, ...) _LOG_IMPL(LOG_VERBOSE, LOG_SERIAL_ONLY, format, ##__VA_ARGS__)
 /** Log to serial only (no storage, no submission) */
 #define Log_info_serial(format, ...) _LOG_IMPL(LOG_INFO, LOG_SERIAL_ONLY, format, ##__VA_ARGS__)
+/** Log to serial only (no storage, no submission) */
+#define Log_warn_serial(format, ...) _LOG_IMPL(LOG_WARN, LOG_SERIAL_ONLY, format, ##__VA_ARGS__)
 /** Log to serial only (no storage, no submission) */
 #define Log_error_serial(format, ...) _LOG_IMPL(LOG_ERROR, LOG_SERIAL_ONLY, format, ##__VA_ARGS__)
 /** Log to serial only (no storage, no submission) */

--- a/lib/trmnl/src/serialize_log.cpp
+++ b/lib/trmnl/src/serialize_log.cpp
@@ -31,6 +31,9 @@ String serialize_log(const LogWithDetails &input)
   case LOG_INFO:
     json_log["level"] = "info";
     break;
+  case LOG_WARN:
+    json_log["level"] = "warn";
+    break;
   case LOG_ERROR:
     json_log["level"] = "error";
     break;

--- a/lib/trmnl/src/serialize_log.cpp
+++ b/lib/trmnl/src/serialize_log.cpp
@@ -26,7 +26,7 @@ String serialize_log(const LogWithDetails &input)
   switch (input.level)
   {
   case LOG_VERBOSE:
-    json_log["level"] = "verbose";
+    json_log["level"] = "debug";
     break;
   case LOG_INFO:
     json_log["level"] = "info";

--- a/lib/trmnl/src/serialize_log.cpp
+++ b/lib/trmnl/src/serialize_log.cpp
@@ -23,6 +23,25 @@ String serialize_log(const LogWithDetails &input)
   json_log["free_heap_size"] = input.deviceStatusStamp.free_heap_size;
   json_log["max_alloc_size"] = input.deviceStatusStamp.max_alloc_size;
 
+  switch (input.level)
+  {
+  case LOG_VERBOSE:
+    json_log["level"] = "verbose";
+    break;
+  case LOG_INFO:
+    json_log["level"] = "info";
+    break;
+  case LOG_ERROR:
+    json_log["level"] = "error";
+    break;
+  case LOG_FATAL:
+    json_log["level"] = "fatal";
+    break;
+  default:
+    json_log["level"] = "info";
+    break;
+  }
+
   if (input.logRetry)
   {
     json_log["retry"] = input.retryAttempt;

--- a/lib/trmnl/src/test_logger.cpp
+++ b/lib/trmnl/src/test_logger.cpp
@@ -11,6 +11,7 @@ void log_impl(LogLevel level, LogMode mode, const char* file, int line, const ch
     
     const char* level_str = (level == LOG_VERBOSE) ? "verbose" : 
                            (level == LOG_INFO) ? "info" : 
+                           (level == LOG_WARN) ? "warn" :
                            (level == LOG_ERROR) ? "error" : "fatal";
     
     printf("  [test log:%s] %s:%d ", level_str, file, line);

--- a/src/app_logger.cpp
+++ b/src/app_logger.cpp
@@ -55,6 +55,9 @@ void log_impl(LogLevel level, LogMode mode, const char* file, int line, const ch
     case LOG_INFO:
         Log.infoln(serial_buffer);
         break;
+    case LOG_WARN:
+        Log.warningln(serial_buffer);
+        break;
     case LOG_ERROR:
         Log.errorln(serial_buffer);
         break;

--- a/src/app_logger.cpp
+++ b/src/app_logger.cpp
@@ -16,9 +16,9 @@ static void handle_store_submit(LogLevel level, const char *clean_message, const
     if (level >= store_submit_threshold)
     {
         if (mode == LOG_STORE_ONLY) {
-            logWithAction(LOG_ACTION_STORE, clean_message, getTime(), line, file);
+            logWithAction(LOG_ACTION_STORE, level, clean_message, getTime(), line, file);
         } else {
-            logWithAction(LOG_ACTION_SUBMIT_OR_STORE, clean_message, getTime(), line, file);
+            logWithAction(LOG_ACTION_SUBMIT_OR_STORE, level, clean_message, getTime(), line, file);
         }
     }
 }

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -3809,7 +3809,7 @@ DeviceStatusStamp getDeviceStatusStamp()
   return deviceStatus;
 }
 
-void logWithAction(LogAction action, const char *message, time_t time, int line, const char *file)
+void logWithAction(LogAction action, LogLevel level, const char *message, time_t time, int line, const char *file)
 {
   uint32_t log_id = preferences.getUInt(PREFERENCES_LOG_ID_KEY, 1);
 
@@ -3823,7 +3823,8 @@ void logWithAction(LogAction action, const char *message, time_t time, int line,
       .filenameCurrent = preferences.getString(PREFERENCES_FILENAME_KEY, ""),
       .filenameNew = new_filename,
       .logRetry = log_retry,
-      .retryAttempt = log_retry ? preferences.getInt(PREFERENCES_CONNECT_API_RETRY_COUNT) : 0};
+      .retryAttempt = log_retry ? preferences.getInt(PREFERENCES_CONNECT_API_RETRY_COUNT) : 0,
+      .level = level};
 
   String json_string = serialize_log(input);
 

--- a/test/test_serialize_log/serialize_log.test.cpp
+++ b/test/test_serialize_log/serialize_log.test.cpp
@@ -27,6 +27,7 @@ LogWithDetails input = {
     .logId = 456,
     .filenameCurrent = "current.png",
     .filenameNew = "new.png",
+    .level = LogLevel::LOG_INFO,
 };
 
 String compact(String input)
@@ -55,7 +56,8 @@ void test_serialize_log(void)
     "battery_voltage": 4.2,
     "wake_reason": "Timer",
     "free_heap_size": 50000,
-    "max_alloc_size": 40000
+    "max_alloc_size": 40000,
+    "level": "info"
   })");
 
   auto result = serialize_log(input);
@@ -85,7 +87,8 @@ void test_serialize_log_with_retry(void)
     "wake_reason": "Timer",
     "free_heap_size": 50000,
     "max_alloc_size": 40000,
-    "retry": 2
+    "level": "info",
+    "retry": 2,
   })");
 
   String result = serialize_log(inputWithRetry);


### PR DESCRIPTION
Addresses #133.

All `Log_{info|warn|error|fatal}_submit()` calls will have their `level` information tacked on when submitting to the server.

Invocation counts in the codebase:

1. `Log_verbose_submit` - 0
2. `Log_info_submit` - 1
3. `Log_error_submit` - 29
4. `Log_error_submit` - 1

## Todo
- [x] Test on device