### PR TITLE
Fix MAX_IMAGE_SIZE for all X-class boards (E1003, PaperS3, etc.)

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -46,8 +46,8 @@
 
 #define DISPLAY_BMP_IMAGE_SIZE 48062 // in bytes - 62 bytes - header; 48000 bytes - bitmap (480*800 1bpp) / 8
 #define DEFAULT_IMAGE_SIZE 48000
-#if defined(BOARD_TRMNL_X) || defined(BOARD_TRMNL_X_EPDIY)
-#define MAX_IMAGE_SIZE 750000 // Use PSRAM on the ESP32-S3
+#if defined(BOARD_X_CLASS)
+#define MAX_IMAGE_SIZE 750000 // Use PSRAM on the ESP32-S3 (all X-class boards have PSRAM)
 #else
 #define MAX_IMAGE_SIZE 90000 // largest compressed image we can receive
 #endif


### PR DESCRIPTION
## Problem

`MAX_IMAGE_SIZE` (the cap on a downloaded image before the firmware rejects it) is gated on `BOARD_TRMNL_X` / `BOARD_TRMNL_X_EPDIY`:

```c
#if defined(BOARD_TRMNL_X) || defined(BOARD_TRMNL_X_EPDIY)
#define MAX_IMAGE_SIZE 750000 // Use PSRAM on the ESP32-S3
#else
#define MAX_IMAGE_SIZE 90000  // largest compressed image we can receive
#endif
```

But several X-class boards only define `BOARD_X_CLASS` (not `BOARD_TRMNL_X`): **reTerminal E1003**, PaperS3, SensoriaS3, SensoriaC5, Lilygo T5Pro. Those fall through to the **90 KB** cap meant for small 4 MB displays.

On the E1003 (1872×1404 panel) every render is ~184 KB, so each image is rejected:

```
Content size: 188357
188357 bytes received in 12 milliseconds
E: Receiving failed; file size too big: 188357
```

The device boots, joins WiFi, calls the API, and downloads the image fine — then discards it and sleeps without updating. Symptom: the panel shows a cached sub-90 KB image once and never refreshes again.

## Fix

Gate the larger cap on `BOARD_X_CLASS`, which **all** X-class boards define. They are all ESP32-S3 with PSRAM and share the same SPIRAM malloc sdkconfig (`CONFIG_SPIRAM_USE_MALLOC=y`, `CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL=16384`), so the image buffer is allocated from PSRAM exactly as on `BOARD_TRMNL_X`. This fixes the E1003 and the other affected X-class boards in one change.

## Which boards are affected

The mainline `TRMNL_X` boards were never broken — they define `BOARD_TRMNL_X`, so they already get the 750 KB cap and accept the same large server-rendered images. Only the X-class boards that define `BOARD_X_CLASS` *without* `BOARD_TRMNL_X` fell through to the 90 KB default, which is why this went unnoticed:

| Already correct (750 KB) | Broken → fixed by this PR (was 90 KB) |
|---|---|
| `TRMNL_X` | `TRMNL_X_E1003` |
| `TRMNL_X_dev` | `TRMNL_X_PAPERS3` |
| `TRMNL_X_dev_no_qa` | `TRMNL_X_SENSORIAS3` |
| `TRMNL_X_EPDIY` | `TRMNL_X_SENSORIAC5` |
| | `TRMNL_X_LILYGO_T5PRO` |

That `TRMNL_X` already runs at 750 KB and renders large images is itself confirmation the fix is correct: the service sends >90 KB images to X-class panels, and the S3+PSRAM hardware handles them — the affected boards are simply identical hardware that was left off the `#if` list.

## Testing

Built and flashed `TRMNL_X_E1003` to reTerminal E1003 hardware. Before: every cycle logged `Receiving failed; file size too big: 188357`. After: the 184 KB image downloads and renders, and the display refreshes normally each cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
