### PR TITLE
Rescope unnecessary globals

### DIFF
--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -78,7 +78,6 @@ const char *szHTTPErrors[] = {
 };
 
 bool pref_clear = false;
-bool bModemNeeded = false;
 String new_filename = "";
 ApiDisplayResult apiDisplayResult;
 uint8_t *buffer = nullptr;
@@ -86,17 +85,13 @@ char filename[1024];      // image URL
 char binUrl[1024];        // update URL
 char message_buffer[128]; // message to show on the screen
 uint32_t time_since_sleep;
-image_err_e png_res = PNG_DECODE_ERR;
-bmp_err_e bmp_res = BMP_NOT_BMP;
 static float vBatt;
 bool status = false;          // need to download a new image
 bool update_firmware = false; // need to download a new firmware
 bool reset_firmware = false;  // need to reset credentials
 bool send_log = false;        // need to send logs
-bool double_click = false;
 bool log_retry = false;                                              // need to log connection retry
 esp_sleep_wakeup_cause_t wakeup_reason = ESP_SLEEP_WAKEUP_UNDEFINED; // wake-up reason
-MSG current_msg = NONE;
 SPECIAL_FUNCTION special_function = SF_NONE;
 RTC_DATA_ATTR int iPrevWakeTime = 0; // total wake time of the last cycle (for statistics collection)
 RTC_DATA_ATTR bool bUsedCachedImage = false; // if the last image displayed was read from cache (for statistics collection)
@@ -812,6 +807,7 @@ void bl_init(void)
 #endif
   Log_info("BL init success");
 #ifdef BOARD_TRMNL_X
+  bool bModemNeeded = false;
   Log.info("%s [%d]: Checking if we need to use the ESP32-C5 modem...\r\n", __FILE__, __LINE__);
   if (WifiCaptivePortal.isSaved()) {
     // WiFi saved, connection
@@ -871,6 +867,7 @@ void bl_init(void)
   }
   Log_info("preferences end");
   #ifndef BOARD_TRMNL_X
+  bool double_click = false;
   if (gpio_wakeup)
   {
     Log_info("GPIO wakeup detected (%d)", wakeup_reason);
@@ -1217,6 +1214,8 @@ void bl_init(void)
 #endif // BOARD_TRMNL_X
 
   WiFi.mode(WIFI_STA); // explicitly set mode, esp defaults to STA+AP
+
+  MSG current_msg = NONE;
 
 // uncdcomment this to hardcode WiFi credentials (useful for testing wifi errors, etc.)
 // #define HARDCODED_WIFI
@@ -1641,6 +1640,8 @@ void load_prev_image(void)
  */
 static https_request_err_e downloadAndShow()
 {
+  image_err_e png_res = PNG_DECODE_ERR;
+  bmp_err_e bmp_res = BMP_NOT_BMP;
   auto apiDisplayInputs = loadApiDisplayInputs(preferences);
 
 #ifdef BOARD_TRMNL_X

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -55,7 +55,6 @@ SCD41 scd41;
 BBTemp bbt;
 bool bCO2 = false;
 int iSensorType = -1;
-long lSampleTime;
 int lastCO2 = 0, lastSCDTemp = 0, lastTemp = 0, lastSCDHumid = 0, lastHumid = 0, lastPressure = 0, lastType = -1, lastTime = 0;
 #endif // SENSOR_SDA
 const char *szHTTPErrors[] = {
@@ -77,7 +76,6 @@ const char *szHTTPErrors[] = {
     "HTTPS_OUT_OF_MEMORY"
 };
 
-bool pref_clear = false;
 String new_filename = "";
 ApiDisplayResult apiDisplayResult;
 uint8_t *buffer = nullptr;
@@ -89,7 +87,6 @@ static float vBatt;
 bool status = false;          // need to download a new image
 bool update_firmware = false; // need to download a new firmware
 bool reset_firmware = false;  // need to reset credentials
-bool send_log = false;        // need to send logs
 bool log_retry = false;                                              // need to log connection retry
 esp_sleep_wakeup_cause_t wakeup_reason = ESP_SLEEP_WAKEUP_UNDEFINED; // wake-up reason
 SPECIAL_FUNCTION special_function = SF_NONE;
@@ -170,7 +167,6 @@ void process_iqs323_data(void);
 IQS323 iqs323;
 #define IQS323_I2C_ADDRESS 0x44
 // Sensor states
-iqs323_ch_states button_states[3];
 uint16_t slider_position = 65535;
 iqs323_gesture_events slider_event = IQS323_GESTURE_NONE;
 bool otg_message = false;
@@ -569,7 +565,6 @@ void check_channel_states(void)
           }
           break;
         }
-        button_states[i] = IQS323_CH_TOUCH;
       } else {
         // Slide mode
         if ((slider_event == IQS323_GESTURE_TAP || slider_event == IQS323_GESTURE_HOLD)) {
@@ -596,7 +591,6 @@ void check_channel_states(void)
             Log_info("Next button pressed");
             break;
           }
-          button_states[i] = IQS323_CH_TOUCH;
         }
       }
     }
@@ -763,7 +757,6 @@ void sensor_init(void)
         lastSCDTemp = scd41.temperature();
         lastSCDHumid = scd41.humidity();
         Log.info("%s [%d]: Got SCD41 sample: CO2 = %dppm\r\n", __FILE__, __LINE__, lastCO2);
-        lSampleTime = millis(); // measure the time - it needs 5 seconds to generate a sample
     } else {
         Log.info("%s [%d]: SCD41 sample failed\r\n", __FILE__, __LINE__);
         lastCO2 = 0;
@@ -851,14 +844,6 @@ void bl_init(void)
   if (res)
   {
     Log_info("preferences init success (%d free entries)", preferences.freeEntries());
-    if (pref_clear)
-    {
-      res = preferences.clear(); // if needed to clear the saved data
-      if (res)
-        Log_info("preferences cleared success");
-      else
-        Log_fatal("preferences clearing error");
-    }
   }
   else
   {
@@ -2101,11 +2086,6 @@ static https_request_err_e downloadAndShow()
   if (result == HTTPS_UNABLE_TO_CONNECT)
   {
     Log_error_submit("unable to connect");
-  }
-
-  if (send_log)
-  {
-    send_log = false;
   }
 
   Log_info("Returned result - %s", szHTTPErrors[result]);

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -99,11 +99,7 @@ extern char filename[];
 extern Preferences preferences;
 extern ApiDisplayResult apiDisplayResult;
 uint32_t iTempProfile;
-static int i426Workaround = 0;
 static uint8_t *pDither;
-
-// Runtime control for light sleep (true = enabled, false = disabled)
-static bool g_light_sleep_enabled = true;
 
 /**
  * @brief Function to init the display
@@ -440,7 +436,9 @@ void display_sleep(uint32_t u32Millis)
 #ifdef DO_NOT_LIGHT_SLEEP
     delay(u32Millis);
 #else
-    if (!g_light_sleep_enabled) {
+    // Runtime control for light sleep (true = enabled, false = disabled)
+    static bool light_sleep_enabled = true;
+    if (!light_sleep_enabled) {
         delay(u32Millis);
     } else {
         esp_sleep_enable_timer_wakeup(u32Millis * 1000L);
@@ -1589,6 +1587,7 @@ void display_show_image(uint8_t *image_buffer, int data_size, bool bWait)
     auto height = display_height();
 //    uint32_t *d32;
     bool bAlloc = false;
+    static int i426Workaround = 0;
 #ifdef BB_EPAPER
     int iRefreshMode = REFRESH_FULL; // assume full (slow) refresh
 #else

--- a/src/qa.cpp
+++ b/src/qa.cpp
@@ -21,7 +21,6 @@ const int samples = 1000;
 const int intervalMs = 7000; // 7s
 const int sample_interval = 1; //1 ms
 const int temperature_threshold = 35; // 35 by Celsium
-float initialTemp = 0;
 static bool radioOn = false;
 
 volatile bool stopRequested = false;

--- a/src/qa.cpp
+++ b/src/qa.cpp
@@ -21,12 +21,8 @@ const int samples = 1000;
 const int intervalMs = 7000; // 7s
 const int sample_interval = 1; //1 ms
 const int temperature_threshold = 35; // 35 by Celsium
-bool result = false;
 float initialTemp = 0;
 static bool radioOn = false;
-
-float tempDiff = 0;
-float voltageDiff = 0;
 
 volatile bool stopRequested = false;
 
@@ -196,7 +192,10 @@ static void loadCPUAndRadio(uint32_t ms) {
 
 #ifdef BOARD_TRMNL_X
 bool startQA(){
-  
+  bool result = false;
+  float tempDiff = 0;
+  float voltageDiff = 0;
+
   bool wifiSaved = checkForSavedCredentials();
 
   if(wifiSaved){
@@ -282,6 +281,9 @@ bool startQA(){
 }
 #else
 bool startQA(){
+  bool result = false;
+  float tempDiff = 0;
+  float voltageDiff = 0;
 
   int32_t rssi = 0;
   if (findNetwork("TRMNL_QA", &rssi)) {


### PR DESCRIPTION
This PR cleans up a few global variables that can be straightforwardly moved into function scope.

It also removes some dead globals and their accompanying conditional branches.