### PR TITLE
Adjust gen2 flash size to 16MB

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.16.0)
 # sdkconfig.defaults lives under sdkconfigs/ (per-target configs are redirected there
 # via board_build.esp-idf.sdkconfig_path in platformio.ini). Must be set before project().
-set(SDKCONFIG_DEFAULTS "${CMAKE_SOURCE_DIR}/sdkconfigs/sdkconfig.defaults")
+# Only set the default when an env hasn't supplied its own SDKCONFIG_DEFAULTS chain
+# (via board_build.cmake_extra_args), so board-specific overrides can layer on top.
+if(NOT DEFINED SDKCONFIG_DEFAULTS)
+    set(SDKCONFIG_DEFAULTS "${CMAKE_SOURCE_DIR}/sdkconfigs/sdkconfig.defaults")
+endif()
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(trmnl-firmware)

--- a/platformio.ini
+++ b/platformio.ini
@@ -655,6 +655,7 @@ build_flags =
 [env:trmnl_gen2]
 board = esp32c5_n16r8
 board_build.esp-idf.sdkconfig_path = sdkconfigs/sdkconfig.${this.__env__}
+board_build.cmake_extra_args = -DSDKCONFIG_DEFAULTS="sdkconfigs/sdkconfig.defaults;sdkconfigs/sdkconfig.defaults.trmnl_gen2"
 framework = arduino, espidf
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.37/platform-espressif32.zip
 # monitor_speed = 115200

--- a/sdkconfigs/sdkconfig.defaults.trmnl_gen2
+++ b/sdkconfigs/sdkconfig.defaults.trmnl_gen2
@@ -1,0 +1,6 @@
+# Flash overrides for env:trmnl_gen2.
+# Layered on top of sdkconfig.defaults via board_build.cmake_extra_args in platformio.ini.
+
+CONFIG_ESPTOOLPY_FLASHSIZE_4MB=n
+CONFIG_ESPTOOLPY_FLASHSIZE_16MB=y
+CONFIG_ESPTOOLPY_FLASHSIZE="16MB"


### PR DESCRIPTION
The gen2 device is an `esp32c5_n16r8` which has 16 MB of flash, larger than the OG with only 4 MB.

This adds a new sdkconfig file that overrides that config value for gen2. The `sdkconfigs/sdkconfig.trmnl_gen2` file is still gitignore'd since it is automatically generated from the `sdkconfig.defaults*` files.

Note! The SPIFFs partition table is still only 4 MB! So we are not taking advantage of all the flash space yet. I leave that to @bitbank2 whenever we get to it.