### PR TITLE
Fix custom server pairing by clearing stale credentials on server change

### DIFF
--- a/lib/wificaptive/src/WifiCaptive.cpp
+++ b/lib/wificaptive/src/WifiCaptive.cpp
@@ -462,6 +462,18 @@ void WifiCaptive::saveApiServer(String url)
         return;
     Preferences preferences;
     preferences.begin("data", false);
+
+    // If the server URL is changing, invalidate the cached credentials so the
+    // /api/setup handshake re-runs against the new server. Otherwise the stale
+    // API key/friendly ID from the previous server are reused and pairing fails.
+    String currentUrl = preferences.getString("api_url", "");
+    if (currentUrl != url)
+    {
+        Log_info("API server changed, clearing cached credentials to force re-pairing");
+        preferences.remove("api_key");
+        preferences.remove("friendly_id");
+    }
+
     preferences.putString("api_url", url);
     preferences.end();
 }


### PR DESCRIPTION
## Problem

When a device is moved from the primary server to a custom server (or between custom servers) via the setup portal, pairing silently fails.

The `/api/setup` handshake (`getDeviceCredentials()`) only runs when the API key or friendly ID is **missing**:

```cpp
if (!preferences.isKey(PREFERENCES_API_KEY) || !preferences.isKey(PREFERENCES_FRIENDLY_ID))
{
  getDeviceCredentials();
}
```

But `WifiCaptive::saveApiServer()` overwrote only `api_url` and left the previous server's `api_key` / `friendly_id` in place. As a result the handshake was skipped and the device kept sending the **stale `Access-Token`** (issued by the old server) to the new server, so it never paired.

## Fix

`saveApiServer()` now compares the incoming URL against the stored one. If it changed, the cached `api_key` and `friendly_id` are removed before saving the new URL, forcing the setup handshake to re-run against the new server on the next cycle.

- Wi-Fi credentials and all other settings are left untouched.
- No full reset or restart is required.
- All three preferences live in the same `"data"` namespace, so they are cleared in the existing open handle.

## Notes

Leaving the custom-server field blank still means "keep the current server" (the existing early-return behavior is unchanged), so switching *back* to the primary server by clearing the field is intentionally out of scope here.
