### PR TITLE
Add Seeed reTerminal E1004 support (rebased onto main + fixes, based on #410)

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -46,7 +46,7 @@
 
 #define DISPLAY_BMP_IMAGE_SIZE 48062 // in bytes - 62 bytes - header; 48000 bytes - bitmap (480*800 1bpp) / 8
 #define DEFAULT_IMAGE_SIZE 48000
-#if defined(BOARD_X_CLASS)
+#if defined(BOARD_X_CLASS) || defined(BOARD_SEEED_RETERMINAL_E1004)
 #define MAX_IMAGE_SIZE 750000 // Use PSRAM on the ESP32-S3 (all X-class boards have PSRAM)
 #else
 #define MAX_IMAGE_SIZE 90000 // largest compressed image we can receive
@@ -161,9 +161,14 @@ enum WIFI_CONNECT_RETRY_TIME // Time to sleep before trying to connect to the Wi
 #define PIN_VBAT_SWITCH 40
 #define VBAT_SWITCH_LEVEL HIGH
 #define DEVICE_MODEL "reterminal_e1003"
+#elif defined(BOARD_SEEED_RETERMINAL_E1004)
+#define DEVICE_MODEL "reterminal_e1004"
+#define PIN_INTERRUPT 4        // wake button (GPIO4)
+#define PIN_VBAT_SWITCH 21     // battery measurement load switch enable
+#define VBAT_SWITCH_LEVEL HIGH // load switch enable pin active level
 #endif
 
-#if defined(BOARD_XIAO_EPAPER_DISPLAY) || defined(BOARD_SEEED_RETERMINAL_E1001) || defined(BOARD_SEEED_RETERMINAL_E1002)
+#if defined(BOARD_XIAO_EPAPER_DISPLAY) || defined(BOARD_SEEED_RETERMINAL_E1001) || defined(BOARD_SEEED_RETERMINAL_E1002) || defined(BOARD_SEEED_RETERMINAL_E1004)
 #define PIN_BATTERY 1
 #elif defined(BOARD_XTEINK_X4)
 #define PIN_BATTERY 0

--- a/include/config.h
+++ b/include/config.h
@@ -166,6 +166,10 @@ enum WIFI_CONNECT_RETRY_TIME // Time to sleep before trying to connect to the Wi
 #define PIN_INTERRUPT 4        // wake button (GPIO4)
 #define PIN_VBAT_SWITCH 21     // battery measurement load switch enable
 #define VBAT_SWITCH_LEVEL HIGH // load switch enable pin active level
+#define HAS_ONBOARD_SHT4X
+#define SHT4X_SDA_PIN   19   // onboard SHT4x I2C (ESP32-S3 native USB pins, repurposed)
+#define SHT4X_SCL_PIN   20
+#define SHT4X_I2C_ADDR  0x44
 #endif
 
 #if defined(BOARD_XIAO_EPAPER_DISPLAY) || defined(BOARD_SEEED_RETERMINAL_E1001) || defined(BOARD_SEEED_RETERMINAL_E1002) || defined(BOARD_SEEED_RETERMINAL_E1004)

--- a/include/sht4x_read.h
+++ b/include/sht4x_read.h
@@ -1,0 +1,5 @@
+#pragma once
+
+// Read the onboard SHT4x over I2C. Returns true and writes tempC (°C) and
+// humidity (%RH) on success; false on bus error or CRC failure.
+bool sht4x_read(float &tempC, float &humidity);

--- a/lib/trmnl/include/sht4x.h
+++ b/lib/trmnl/include/sht4x.h
@@ -1,0 +1,5 @@
+#pragma once
+#include <stdint.h>
+
+// Sensirion CRC-8: polynomial 0x31, init 0xFF, no final XOR.
+uint8_t sht4x_crc8(const uint8_t *data, int len);

--- a/lib/trmnl/include/sht4x.h
+++ b/lib/trmnl/include/sht4x.h
@@ -3,3 +3,9 @@
 
 // Sensirion CRC-8: polynomial 0x31, init 0xFF, no final XOR.
 uint8_t sht4x_crc8(const uint8_t *data, int len);
+
+// Validate and convert a 6-byte SHT4x measurement frame.
+// raw[0..1]=temperature, raw[2]=CRC; raw[3..4]=humidity, raw[5]=CRC.
+// Returns false (leaving outputs unchanged) if either CRC fails.
+// Humidity is clamped to [0, 100].
+bool sht4x_convert(const uint8_t raw[6], float &tempC, float &humidity);

--- a/lib/trmnl/src/sht4x.cpp
+++ b/lib/trmnl/src/sht4x.cpp
@@ -14,3 +14,21 @@ uint8_t sht4x_crc8(const uint8_t *data, int len)
   }
   return crc;
 }
+
+bool sht4x_convert(const uint8_t raw[6], float &tempC, float &humidity)
+{
+  if (sht4x_crc8(&raw[0], 2) != raw[2]) return false;
+  if (sht4x_crc8(&raw[3], 2) != raw[5]) return false;
+
+  uint16_t rawT = (uint16_t)((raw[0] << 8) | raw[1]);
+  uint16_t rawH = (uint16_t)((raw[3] << 8) | raw[4]);
+
+  tempC = -45.0f + 175.0f * (float)rawT / 65535.0f;
+
+  float rh = -6.0f + 125.0f * (float)rawH / 65535.0f;
+  if (rh < 0.0f)   rh = 0.0f;
+  if (rh > 100.0f) rh = 100.0f;
+  humidity = rh;
+
+  return true;
+}

--- a/lib/trmnl/src/sht4x.cpp
+++ b/lib/trmnl/src/sht4x.cpp
@@ -1,0 +1,16 @@
+#include <sht4x.h>
+
+uint8_t sht4x_crc8(const uint8_t *data, int len)
+{
+  uint8_t crc = 0xFF;
+  for (int i = 0; i < len; i++) {
+    crc ^= data[i];
+    for (int b = 0; b < 8; b++) {
+      if (crc & 0x80)
+        crc = (uint8_t)((crc << 1) ^ 0x31);
+      else
+        crc = (uint8_t)(crc << 1);
+    }
+  }
+  return crc;
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,17 +12,23 @@ lib_deps =
 	bblanchon/ArduinoJson@7.4.2
 	bitbank2/PNGdec@1.1.6
 	bitbank2/JPEGDEC@1.8.4
-	bitbank2/bb_epaper@2.1.9
 ;	https://github.com/bitbank2/bb_epaper.git#5aaf81fddec42c7775b0599e80808498aee3168b
 
-; Dependencies for all device builds
-[deps_app]
+; Device dependencies EXCEPT the e-paper driver, so a board can pick its own
+; bb_epaper variant (registry vs. fork) without duplicating the whole list.
+[deps_app_base]
 lib_deps =
 	${deps_common.lib_deps}
 	bitbank2/bb_scd41@1.3.2
 	https://github.com/bitbank2/bb_temperature.git#20ed72ee5a8db05c0ac23b68d6d601a537aee9ae
 	ESP32Async/ESPAsyncWebServer@3.7.7
-    https://github.com/thijse/Arduino-Log.git#3f4fcf5a345c1d542e56b88c0ffcb2bd2a5b0bd0
+	https://github.com/thijse/Arduino-Log.git#3f4fcf5a345c1d542e56b88c0ffcb2bd2a5b0bd0
+
+; Dependencies for all device builds
+[deps_app]
+lib_deps =
+	${deps_app_base.lib_deps}
+	bitbank2/bb_epaper@^2.1.7
 
 ;       =============================
 ;	Shared configuration (global)
@@ -650,6 +656,42 @@ build_flags =
 	-D ARDUINO_USB_MODE=0
 	-D ARDUINO_USB_CDC_ON_BOOT=0
 	-D PNG_MAX_BUFFERED_PIXELS=6432
+
+[env:seeed_reTerminal_E1004]
+extends = env:esp32_base
+board = seeed_xiao_esp32s3
+framework = arduino
+extra_scripts = post:scripts/extra/post_build_seeed.py
+; override the default build flags, removing the USB_MODE and CDC_ON_BOOT flags
+board_build.extra_flags =
+	-D ARDUINO_XIAO_ESP32S3
+	-D BOARD_HAS_PSRAM
+	-D DARDUINO_RUNNING_CORE=1
+	-D ARDUINO_EVENT_RUNNING_CORE=1
+build_flags =
+	${env:esp32_base.build_flags}
+	-D BOARD_SEEED_RETERMINAL_E1004
+	-D ARDUINO_USB_MODE=0
+	-D ARDUINO_USB_CDC_ON_BOOT=0
+	-D PNG_MAX_BUFFERED_PIXELS=14984
+; Reuse the shared device deps, but swap the registry bb_epaper for the fork
+; that adds the EP133A_SPECTRA_1200x1600 panel. Pinned to a commit (not a
+; branch) for reproducible builds; pulling only the fork avoids two copies of
+; bb_epaper. TODO: drop the fork once EP133A support lands upstream.
+lib_deps =
+	${deps_app_base.lib_deps}
+	https://github.com/limengdu/bb_epaper.git#95fd94afe39cd7db32bef7c70eea06d654264ff6
+lib_ignore = bb_spi_lcd
+
+; Development variant: serial debug (DEV_FIRMWARE) and no panel light-sleep,
+; for bring-up and debugging. The plain seeed_reTerminal_E1004 env is the
+; release build.
+[env:seeed_reTerminal_E1004_dev]
+extends = env:seeed_reTerminal_E1004
+build_flags =
+	${env:seeed_reTerminal_E1004.build_flags}
+	-D DEV_FIRMWARE=1
+	-D DO_NOT_LIGHT_SLEEP=1
 
 
 [env:trmnl_gen2]

--- a/scripts/extra/post_build_seeed.py
+++ b/scripts/extra/post_build_seeed.py
@@ -4,10 +4,13 @@ from pathlib import Path
 
 def post_build(source, target, env):
     build_dir = Path(env.subst("$BUILD_DIR"))
+    python = env.subst("$PYTHONEXE")
+    esptool_dir = Path(env.PioPlatform().get_package_dir("tool-esptoolpy"))
+    esptool = esptool_dir / "esptool.py"
     output = build_dir / "merged_firmware.bin"
 
     subprocess.run([
-        "pio", "pkg", "exec", "-p", "tool-esptoolpy", "esptool.py", "--",
+        python, str(esptool),
         "--chip", "ESP32S3",
         "merge_bin",
         "-o", str(output),

--- a/src/DEV_Config.h
+++ b/src/DEV_Config.h
@@ -152,6 +152,19 @@
    #define EPD_EN_PIN   11
    #define EPD_BUSY_PIN 13
    #define EPD_VCC_EN   21
+#elif defined (BOARD_SEEED_RETERMINAL_E1004)
+   // Pin definition for reTerminal E1004 (13.3" T133A01, dual-chip Spectra6).
+   // The panel itself is driven by Seeed_GFX via Setup523; these mirror that
+   // wiring so this header does not fall through to the #error below.
+   #define EPD_SCK_PIN    7
+   #define EPD_MISO_PIN   8
+   #define EPD_MOSI_PIN   9
+   #define EPD_CS_PIN     10
+   #define EPD_CS1_PIN    2   // second chip-select (dual-chip controller)
+   #define EPD_DC_PIN     11
+   #define EPD_BUSY_PIN   13
+   #define EPD_RST_PIN    38
+   #define EPD_EN_PIN     12  // panel power enable
 #elif defined (BOARD_X_CLASS)
 // Parallel Eink devices don't explicitly define GPIO pins for the display here
 #else

--- a/src/api-client/display.cpp
+++ b/src/api-client/display.cpp
@@ -18,7 +18,7 @@ const char *szMakers[] = {"None", "ASAIR", "Bosch", "Bosch", "Bosch", "Sensirion
 extern float sht4xTempC, sht4xHumidity;
 extern int   sht4xTime;
 extern bool  sht4xValid;
-#endif
+#endif // HAS_ONBOARD_SHT4X
 
 void addHeaders(HTTPClient &https, ApiDisplayInputs &inputs)
 {

--- a/src/api-client/display.cpp
+++ b/src/api-client/display.cpp
@@ -14,6 +14,11 @@ extern int lastCO2, lastSCDTemp, lastTemp, lastSCDHumid, lastHumid, lastPressure
 const char *szDevices[] = {"None", "AHT20", "BMP180", "BME280", "BMP388", "SHT3X", "HDC1080", "HTS221", "MCP9808","BME68x","SHTC3"};
 const char *szMakers[] = {"None", "ASAIR", "Bosch", "Bosch", "Bosch", "Sensirion", "TI", "STMicro","MicroChip","Bosch","Sensirion"};
 #endif // SENSOR_SDA
+#ifdef HAS_ONBOARD_SHT4X
+extern float sht4xTempC, sht4xHumidity;
+extern int   sht4xTime;
+extern bool  sht4xValid;
+#endif
 
 void addHeaders(HTTPClient &https, ApiDisplayInputs &inputs)
 {
@@ -53,6 +58,19 @@ void addHeaders(HTTPClient &https, ApiDisplayInputs &inputs)
   }
   free(szTemp);
 #endif // SENSOR_SDA
+#ifdef HAS_ONBOARD_SHT4X
+  if (sht4xValid) {
+    char buf[256];
+    snprintf(buf, sizeof(buf),
+      "make=Sensirion;model=SHT4x;kind=temperature;value=%.2f;unit=celsius;created_at=%d,"
+      "make=Sensirion;model=SHT4x;kind=humidity;value=%.1f;unit=percent;created_at=%d",
+      sht4xTempC, sht4xTime, sht4xHumidity, sht4xTime);
+    headers.push_back({"SENSORS", buf});
+    Log_info("%s [%d] Adding SHT4x data to api request: %.2fC %.1f%%", __FILE__, __LINE__, sht4xTempC, sht4xHumidity);
+  } else {
+    Log_info("%s [%d] SHT4x data not available", __FILE__, __LINE__);
+  }
+#endif // HAS_ONBOARD_SHT4X
 
   applyHeaders(https, headers);
   logHeaders(headers);

--- a/src/api-client/display.cpp
+++ b/src/api-client/display.cpp
@@ -16,7 +16,6 @@ const char *szMakers[] = {"None", "ASAIR", "Bosch", "Bosch", "Bosch", "Sensirion
 #endif // SENSOR_SDA
 #ifdef HAS_ONBOARD_SHT4X
 extern float sht4xTempC, sht4xHumidity;
-extern int   sht4xTime;
 extern bool  sht4xValid;
 #endif // HAS_ONBOARD_SHT4X
 
@@ -60,13 +59,17 @@ void addHeaders(HTTPClient &https, ApiDisplayInputs &inputs)
 #endif // SENSOR_SDA
 #ifdef HAS_ONBOARD_SHT4X
   if (sht4xValid) {
+    // Stamp at send time: sensor_init() runs before SNTP on a cold boot, so
+    // time() is only valid here (after WiFi/clock sync). On normal timer-wake
+    // cycles the RTC retains the synced time, so this is the true sample time.
+    int createdAt = (int)time(NULL);
     char buf[256];
     snprintf(buf, sizeof(buf),
       "make=Sensirion;model=SHT4x;kind=temperature;value=%.2f;unit=celsius;created_at=%d,"
       "make=Sensirion;model=SHT4x;kind=humidity;value=%.1f;unit=percent;created_at=%d",
-      sht4xTempC, sht4xTime, sht4xHumidity, sht4xTime);
+      sht4xTempC, createdAt, sht4xHumidity, createdAt);
     headers.push_back({"SENSORS", buf});
-    Log_info("%s [%d] Adding SHT4x data to api request: %.2fC %.1f%%", __FILE__, __LINE__, sht4xTempC, sht4xHumidity);
+    Log_info("%s [%d] Adding SHT4x to request: temp=%.2f humidity=%.2f created_at=%d", __FILE__, __LINE__, sht4xTempC, sht4xHumidity, createdAt);
   } else {
     Log_info("%s [%d] SHT4x data not available", __FILE__, __LINE__);
   }

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -65,7 +65,6 @@ int lastCO2 = 0, lastSCDTemp = 0, lastTemp = 0, lastSCDHumid = 0, lastHumid = 0,
 #ifdef HAS_ONBOARD_SHT4X
 float sht4xTempC = 0.0f;
 float sht4xHumidity = 0.0f;
-int   sht4xTime = 0;
 bool  sht4xValid = false;
 #endif // HAS_ONBOARD_SHT4X
 const char *szHTTPErrors[] = {
@@ -804,9 +803,9 @@ void sensor_init(void)
 #endif // SENSOR_SDA
 #ifdef HAS_ONBOARD_SHT4X
   if (sht4x_read(sht4xTempC, sht4xHumidity)) {
-    time((time_t *)&sht4xTime);
     sht4xValid = true;
-    Log.info("%s [%d]: SHT4x: %.2fC %.1f%%\r\n", __FILE__, __LINE__, sht4xTempC, sht4xHumidity);
+    // ArduinoLog uses %F for float (%f is not supported and prints literally)
+    Log.info("%s [%d]: SHT4x temp=%F humidity=%F\r\n", __FILE__, __LINE__, sht4xTempC, sht4xHumidity);
   } else {
     sht4xValid = false;
     Log.info("%s [%d]: SHT4x read failed\r\n", __FILE__, __LINE__);

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -106,6 +106,7 @@ RTC_DATA_ATTR bool bUsedCachedImage = false; // if the last image displayed was 
 RTC_DATA_ATTR uint8_t need_to_refresh_display = 1;
 RTC_DATA_ATTR bool otg_state = false;  // Track OTG state across deep sleep
 RTC_DATA_ATTR char szPrevFile[36] = {0};
+RTC_DATA_ATTR bool last_display_ok = false; // previous cycle put a real image on the panel (for E1004 silent button reload)
 bool touchbar_tap_mode = true;  // false = "slide", true = "tap" (default)
 Preferences preferences;
 PreferencesPersistence preferencesPersistence(preferences);
@@ -1053,7 +1054,16 @@ void bl_init(void)
 
 // #endif
 
-  if (wakeup_reason != ESP_SLEEP_WAKEUP_TIMER)
+  bool show_boot_logo = (wakeup_reason != ESP_SLEEP_WAKEUP_TIMER);
+#ifdef BOARD_SEEED_RETERMINAL_E1004
+  // On the E1004 a back-button press should silently reload the next image, like
+  // a timer wake, instead of flashing the TRMNL logo. Only do so when a real
+  // image is already on the panel (the previous cycle succeeded); cold boot and
+  // error/setup screens still show the logo.
+  if (gpio_wakeup && last_display_ok)
+    show_boot_logo = false;
+#endif
+  if (show_boot_logo)
   {
     Log.info("%s [%d]: Display TRMNL logo start\r\n", __FILE__, __LINE__);
 
@@ -1358,6 +1368,9 @@ void bl_init(void)
   // OTA checking, image checking and drawing
   https_request_err_e request_result = downloadAndShow();
   Log.info("%s [%d]: request result - %s\r\n", __FILE__, __LINE__, szHTTPErrors[request_result]);
+  // Remember whether a real image reached the panel, so the next E1004 button
+  // wake can decide between a silent reload and the normal logo flow.
+  last_display_ok = (request_result == HTTPS_SUCCESS);
 
   if (request_result == HTTPS_IMAGE_FILE_TOO_BIG)
   {

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -40,6 +40,7 @@
 #ifdef BOARD_SEEED_RETERMINAL_E1004
 #include "driver/rtc_io.h"
 #endif
+#include <sht4x_read.h>
 #include "esp_ota_ops.h"
 #include "esp_sntp.h"
 #include "esp_flash.h"
@@ -61,6 +62,12 @@ int iSensorType = -1;
 long lSampleTime;
 int lastCO2 = 0, lastSCDTemp = 0, lastTemp = 0, lastSCDHumid = 0, lastHumid = 0, lastPressure = 0, lastType = -1, lastTime = 0;
 #endif // SENSOR_SDA
+#ifdef HAS_ONBOARD_SHT4X
+float sht4xTempC = 0.0f;
+float sht4xHumidity = 0.0f;
+int   sht4xTime = 0;
+bool  sht4xValid = false;
+#endif // HAS_ONBOARD_SHT4X
 const char *szHTTPErrors[] = {
     "HTTPS_NO_ERR",
     "HTTPS_RESET",
@@ -795,6 +802,16 @@ void sensor_init(void)
       bbt.stop(); // turn off the sensor to conserve power
   }
 #endif // SENSOR_SDA
+#ifdef HAS_ONBOARD_SHT4X
+  if (sht4x_read(sht4xTempC, sht4xHumidity)) {
+    time((time_t *)&sht4xTime);
+    sht4xValid = true;
+    Log.info("%s [%d]: SHT4x: %.2fC %.1f%%\r\n", __FILE__, __LINE__, sht4xTempC, sht4xHumidity);
+  } else {
+    sht4xValid = false;
+    Log.info("%s [%d]: SHT4x read failed\r\n", __FILE__, __LINE__);
+  }
+#endif // HAS_ONBOARD_SHT4X
 } /* sensor_init() */
 /**
  * @brief Function to init business logic module

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -37,6 +37,9 @@
 #include <api-client/display.h>
 #include <api-client/request_headers.h>
 #include "driver/gpio.h"
+#ifdef BOARD_SEEED_RETERMINAL_E1004
+#include "driver/rtc_io.h"
+#endif
 #include "esp_ota_ops.h"
 #include "esp_sntp.h"
 #include "esp_flash.h"
@@ -806,7 +809,11 @@ void bl_init(void)
 #endif
   startup_time = init_time/1000L; // convert to milliseconds
 #ifdef DEV_FIRMWARE
+  #ifdef BOARD_SEEED_RETERMINAL_E1004
+  Serial.begin(115200, SERIAL_8N1, 44, 43);
+  #else
   Serial.begin(115200);
+  #endif
   wait_for_serial();
   Log.begin(LOG_LEVEL_VERBOSE, &Serial);
 #endif
@@ -3226,6 +3233,15 @@ static bool checkAndPerformFirmwareUpdate(void)
   return ota_ok;
 }
 
+#ifdef BOARD_SEEED_RETERMINAL_E1004
+static void configureWakeButtonForSleep(void)
+{
+  pinMode(PIN_INTERRUPT, INPUT_PULLUP);
+  rtc_gpio_pullup_en(static_cast<gpio_num_t>(PIN_INTERRUPT));
+  rtc_gpio_pulldown_dis(static_cast<gpio_num_t>(PIN_INTERRUPT));
+}
+#endif
+
 /**
  * @brief Function to sleep preparing and go to sleep
  * @param none
@@ -3286,6 +3302,9 @@ void goToSleep(void)
   pinMode(PIN_INTERRUPT, INPUT); // needed to not immediately wake up
   esp_deep_sleep_enable_gpio_wakeup(1 << PIN_INTERRUPT, ESP_GPIO_WAKEUP_GPIO_LOW);
 #elif defined(CONFIG_IDF_TARGET_ESP32S3)
+  #ifdef BOARD_SEEED_RETERMINAL_E1004
+  configureWakeButtonForSleep();
+  #endif
   esp_sleep_enable_ext0_wakeup((gpio_num_t)PIN_INTERRUPT, 0);
 #else
 #error "Unsupported ESP32 target for GPIO wakeup configuration"
@@ -3312,6 +3331,9 @@ static void goToSleepButtonOnly(void)
 #elif defined( CONFIG_IDF_TARGET_ESP32C3 ) || defined ( CONFIG_IDF_TARGET_ESP32C5 )
   esp_deep_sleep_enable_gpio_wakeup(1 << PIN_INTERRUPT, ESP_GPIO_WAKEUP_GPIO_LOW);
 #elif CONFIG_IDF_TARGET_ESP32S3
+  #ifdef BOARD_SEEED_RETERMINAL_E1004
+  configureWakeButtonForSleep();
+  #endif
   esp_sleep_enable_ext0_wakeup((gpio_num_t)PIN_INTERRUPT, 0);
 #else
 #error "Unsupported ESP32 target for GPIO wakeup configuration"
@@ -3492,7 +3514,7 @@ static float readBatteryVoltage(void)
     return -1.0;
   }
 #else
-  #if defined(BOARD_XIAO_EPAPER_DISPLAY) || defined(BOARD_SEEED_RETERMINAL_E1001) || defined(BOARD_SEEED_RETERMINAL_E1002)
+  #if defined(BOARD_XIAO_EPAPER_DISPLAY) || defined(BOARD_SEEED_RETERMINAL_E1001) || defined(BOARD_SEEED_RETERMINAL_E1002) || defined(BOARD_SEEED_RETERMINAL_E1004)
     pinMode(PIN_VBAT_SWITCH, OUTPUT);
     digitalWrite(PIN_VBAT_SWITCH, VBAT_SWITCH_LEVEL);
     delay(10); // Wait for the switch to stabilize

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -44,6 +44,12 @@ BBEPAPER bbep(EP75YR_800x480);
     {EP73_SPECTRA_800x480, EP73_SPECTRA_800x480}, // b = darker grays
 };
 BBEPAPER bbep(EP73_SPECTRA_800x480);
+#elif defined(BOARD_SEEED_RETERMINAL_E1004)
+    {EP133A_SPECTRA_1200x1600, EP133A_SPECTRA_1200x1600}, // 13.3" dual-chip Spectra6
+    {EP133A_SPECTRA_1200x1600, EP133A_SPECTRA_1200x1600},
+    {EP133A_SPECTRA_1200x1600, EP133A_SPECTRA_1200x1600},
+};
+BBEPAPER bbep(EP133A_SPECTRA_1200x1600);
 #else // TRMNL OG and GEN2
     {EP75_800x480, EP75_800x480_4GRAY}, // default (for original EPD)
     {EP75_800x480_GEN2, EP75_800x480_4GRAY_GEN2}, // a = uses built-in fast + 4-gray
@@ -51,9 +57,9 @@ BBEPAPER bbep(EP73_SPECTRA_800x480);
 };
 BBEPAPER bbep(EP75_800x480);
 #endif
-#ifdef BOARD_SEEED_RETERMINAL_E1002
+#if defined(BOARD_SEEED_RETERMINAL_E1002) || defined(BOARD_SEEED_RETERMINAL_E1004)
 uint8_t u8SpectraPal[512]; // RGB333 mapped to closest Spectra6 color
-#endif // E1002
+#endif // E1002 || E1004
 
 #else // BOARD_X_CLASS
 #include "esp_sleep.h"
@@ -118,6 +124,13 @@ void display_init(void)
 #ifdef BB_EPAPER
     bbep.setPanelType(dpList[iTempProfile].OneBit); // must be set BEFORE calling initio
     Log_info("BB e-Paper init");
+#ifdef BOARD_SEEED_RETERMINAL_E1004
+    // E1004 (13.3" dual-chip): enable panel power and register the second
+    // controller's chip-select BEFORE initIO so both controllers get initialised.
+    pinMode(EPD_EN_PIN, OUTPUT);
+    digitalWrite(EPD_EN_PIN, HIGH);
+    bbep.setCS2(EPD_CS1_PIN);
+#endif
     bbep.initIO(EPD_DC_PIN, EPD_RST_PIN, EPD_BUSY_PIN, EPD_CS_PIN, EPD_MOSI_PIN, EPD_SCK_PIN, 8000000);
 #else
 #ifdef BOARD_TRMNL_X
@@ -430,6 +443,17 @@ void display_set_light_sleep(uint8_t enabled)
 #endif
 }
 
+#ifdef BB_EPAPER
+static void display_apply_light_sleep_setting(void)
+{
+#ifdef DO_NOT_LIGHT_SLEEP
+    bbep.setLightSleep(false);
+#else
+    bbep.setLightSleep(true);
+#endif
+}
+#endif
+
 /**
  * @brief Function to sleep the ESP32 while saving power
  * @param u32Millis represents the sleep time in milliseconds
@@ -459,7 +483,7 @@ void display_reset(void)
     Log_info("e-Paper Clear start");
     bbep.fillScreen(BBEP_WHITE);
 #ifdef BB_EPAPER
-    bbep.setLightSleep(true);
+    display_apply_light_sleep_setting();
     if (!apiDisplayResult.response.maximum_compatibility) {
         bbep.refresh(REFRESH_FAST, true);
     } else {
@@ -815,7 +839,7 @@ unsigned char GetBWYRPixel(int r, int g, int b)
 } /* GetBWYRPixel() */
 #endif // BB_EPAPER
 
-#ifdef BOARD_SEEED_RETERMINAL_E1002
+#if defined(BOARD_SEEED_RETERMINAL_E1002) || defined(BOARD_SEEED_RETERMINAL_E1004)
 //
 // bb_epaper colors to map to Spectra6 colors
 // The RGB values are not correct for the panel, but for simple mapping
@@ -861,23 +885,25 @@ void CreateSpectra6Pal(void)
 //
 // Convert the RGB value into one of 6 Spectra6 colors
 //
+#endif // E1002 || E1004
+//
+// Convert an RGB pixel to a panel colour.
+// E1002 and E1004 map to the nearest of 6 Spectra colours.
+//
+#if defined(BOARD_SEEED_RETERMINAL_E1002) || defined(BOARD_SEEED_RETERMINAL_E1004)
 uint8_t GetSpectraPixel(int r, int g, int b)
 {
-uint8_t c;
-uint16_t rgb333;
-
-    rgb333 = (r>>5) + ((g & 0xe0) >> 2) + ((b & 0xe0) << 1);
-    c = u8SpectraPal[rgb333];
-    return c;
+    uint16_t rgb333 = (r>>5) + ((g & 0xe0) >> 2) + ((b & 0xe0) << 1);
+    return u8SpectraPal[rgb333];
 } /* GetSpectraPixel() */
-#endif // E1002
+#endif // E1002 || E1004
 /**
  * @brief Callback function for each line of PNG decoded
  * @param PNGDRAW structure containing the current line and relevant info
  * @return none
  */
 #ifdef BB_EPAPER
-#ifdef BOARD_SEEED_RETERMINAL_E1002
+#if defined(BOARD_SEEED_RETERMINAL_E1002) || defined(BOARD_SEEED_RETERMINAL_E1004)
 //
 // Draw the PNG image into the local framebuffer memory using the drawPixel() method
 // to do color translation and to properly format the memory layout
@@ -977,7 +1003,7 @@ int png_draw_6clr(PNGDRAW *pDraw)
         } // for x
     return 1; // continue decoding
 } /* png_draw_6clr() */
-#endif // E1002 (Spectra6 only)
+#endif // E1002 || E1004 (Spectra6)
 
 #ifdef BOARD_TRMNL_4CLR
 //
@@ -1485,20 +1511,20 @@ PNG *png = new PNG();
             Log_info("%s [%d]: Decoding %d-bpp png (current)\r\n", __FILE__, __LINE__, png->getBpp());
             // Prepare target memory window (entire display)
 #ifdef BB_EPAPER
-#ifdef BOARD_SEEED_RETERMINAL_E1002
-            CreateSpectra6Pal(); // create a fast color matching palette
+#if defined(BOARD_SEEED_RETERMINAL_E1002) || defined(BOARD_SEEED_RETERMINAL_E1004)
+            CreateSpectra6Pal(); // create a fast color matching palette (6-color only)
             if (bbep.allocBuffer() != BBEP_SUCCESS) {
                 Log_error("%s [%d]: bbep.AllocBuffer failed!\n\r", __FILE__, __LINE__);
                 return -1;
             }
-            Log_info("%s [%d]: decoding for 6-color EPD\r\n", __FILE__, __LINE__);
+            Log_info("%s [%d]: decoding for Spectra6 EPD\r\n", __FILE__, __LINE__);
             png->openRAM((uint8_t *)pPNG, iDataSize, png_draw_6clr);
             png->decode(NULL, 0);
             png->close();
             bbep.writePlane();
             delete(png); // free the decoder instance
             return REFRESH_FULL;
-#endif // E1002
+#endif // E1002 || E1004
 #ifdef BOARD_TRMNL_4CLR
             Log_info("%s [%d]: decoding for 4-color EPD\r\n", __FILE__, __LINE__);
             png->openRAM((uint8_t *)pPNG, iDataSize, png_draw_4clr);
@@ -1696,11 +1722,7 @@ void display_show_image(uint8_t *image_buffer, int data_size, bool bWait)
     if (bbep.capabilities() & (BBEP_4COLOR | BBEP_3COLOR | BBEP_7COLOR)) bWait = 1;
     if (!bWait) iRefreshMode = REFRESH_PARTIAL; // fast update when showing loading screen
     Log_info("%s [%d]: EPD refresh mode: %d\r\n", __FILE__, __LINE__, iRefreshMode);
-#ifdef DO_NOT_LIGHT_SLEEP
-    bbep.setLightSleep(false);
-#else
-    bbep.setLightSleep(true);
-#endif
+    display_apply_light_sleep_setting();
     bbep.refresh(iRefreshMode, bWait);
     if ((bbep.getPanelType() == EP426_800x480 || bbep.getPanelType() == EP397_800x480) && iRefreshMode == REFRESH_PARTIAL) {
         i426Workaround = 1; // need to re-initialize the controller for another update before sleeping
@@ -2280,6 +2302,7 @@ void display_show_msg(uint8_t *image_buffer, MSG message_type, const char *messa
     }
 #ifdef BB_EPAPER
     bbep.writePlane(PLANE_0);
+    display_apply_light_sleep_setting();
     bbep.refresh(REFRESH_FULL, true);
     bbep.freeBuffer();
 #else
@@ -2372,6 +2395,7 @@ void display_show_msg_qa(uint8_t *image_buffer, const float *voltage, const floa
 
     #ifdef BB_EPAPER
         bbep.writePlane(PLANE_0);
+        display_apply_light_sleep_setting();
         bbep.refresh(REFRESH_FULL, true);
         bbep.freeBuffer();
     #else
@@ -2415,6 +2439,7 @@ void display_show_msg(uint8_t *image_buffer, MSG message_type, String friendly_i
         bbep.fillScreen(BBEP_WHITE);
 #ifdef BB_EPAPER
         bbep.writePlane(PLANE_0);
+        display_apply_light_sleep_setting();
         if (!apiDisplayResult.response.maximum_compatibility) {
             bbep.refresh(REFRESH_FAST, true); // newer panel can handle the fast refresh
         } else {
@@ -2529,6 +2554,7 @@ void display_show_msg(uint8_t *image_buffer, MSG message_type, String friendly_i
     Log_info("Start drawing...");
 #ifdef BB_EPAPER
     bbep.writePlane(PLANE_0);
+    display_apply_light_sleep_setting();
     bbep.refresh(REFRESH_FULL, true);
     bbep.freeBuffer();
 #else

--- a/src/sht4x_read.cpp
+++ b/src/sht4x_read.cpp
@@ -1,0 +1,28 @@
+#include <sht4x_read.h>
+#include <config.h>
+
+#ifdef HAS_ONBOARD_SHT4X
+#include <Arduino.h>
+#include <Wire.h>
+#include <sht4x.h>
+
+bool sht4x_read(float &tempC, float &humidity)
+{
+  Wire.begin(SHT4X_SDA_PIN, SHT4X_SCL_PIN);
+
+  Wire.beginTransmission(SHT4X_I2C_ADDR);
+  Wire.write(0xFD); // measure T & RH, high precision
+  if (Wire.endTransmission() != 0)
+    return false;
+
+  delay(10); // datasheet: high-precision conversion ~8.3 ms max
+
+  uint8_t raw[6];
+  if (Wire.requestFrom((int)SHT4X_I2C_ADDR, 6) != 6)
+    return false;
+  for (int i = 0; i < 6; i++)
+    raw[i] = (uint8_t)Wire.read();
+
+  return sht4x_convert(raw, tempC, humidity);
+}
+#endif // HAS_ONBOARD_SHT4X

--- a/test/test_sht4x/sht4x.test.cpp
+++ b/test/test_sht4x/sht4x.test.cpp
@@ -48,6 +48,15 @@ void test_sht4x_convert_rejects_bad_crc(void)
   TEST_ASSERT_FALSE(sht4x_convert(raw, t, h));
 }
 
+void test_sht4x_convert_rejects_bad_humidity_crc(void)
+{
+  uint8_t raw[6];
+  make_frame(raw, 0x6667, 0x8000);
+  raw[5] ^= 0xFF; // corrupt humidity CRC
+  float t = 0.0f, h = 0.0f;
+  TEST_ASSERT_FALSE(sht4x_convert(raw, t, h));
+}
+
 void setUp(void) {}
 void tearDown(void) {}
 
@@ -58,6 +67,7 @@ void process(void)
   RUN_TEST(test_sht4x_convert_valid);
   RUN_TEST(test_sht4x_convert_humidity_clamps_low_and_high);
   RUN_TEST(test_sht4x_convert_rejects_bad_crc);
+  RUN_TEST(test_sht4x_convert_rejects_bad_humidity_crc);
   UNITY_END();
 }
 

--- a/test/test_sht4x/sht4x.test.cpp
+++ b/test/test_sht4x/sht4x.test.cpp
@@ -8,6 +8,46 @@ void test_sht4x_crc8_canonical_vector(void)
   TEST_ASSERT_EQUAL_HEX8(0x92, sht4x_crc8(data, 2));
 }
 
+// Build a valid 6-byte frame from two data words, filling CRCs.
+static void make_frame(uint8_t raw[6], uint16_t t, uint16_t h)
+{
+  raw[0] = (uint8_t)(t >> 8); raw[1] = (uint8_t)(t & 0xFF);
+  raw[2] = sht4x_crc8(&raw[0], 2);
+  raw[3] = (uint8_t)(h >> 8); raw[4] = (uint8_t)(h & 0xFF);
+  raw[5] = sht4x_crc8(&raw[3], 2);
+}
+
+void test_sht4x_convert_valid(void)
+{
+  uint8_t raw[6];
+  make_frame(raw, 0x6667, 0x8000); // ~25.0 C, ~56.5 %
+  float t = 0.0f, h = 0.0f;
+  TEST_ASSERT_TRUE(sht4x_convert(raw, t, h));
+  TEST_ASSERT_FLOAT_WITHIN(0.1f, 25.0f, t);
+  TEST_ASSERT_FLOAT_WITHIN(0.1f, 56.5f, h);
+}
+
+void test_sht4x_convert_humidity_clamps_low_and_high(void)
+{
+  uint8_t raw[6];
+  float t = 0.0f, h = 0.0f;
+  make_frame(raw, 0x6667, 0x0000); // RH formula = -6 -> clamp 0
+  TEST_ASSERT_TRUE(sht4x_convert(raw, t, h));
+  TEST_ASSERT_FLOAT_WITHIN(0.001f, 0.0f, h);
+  make_frame(raw, 0x6667, 0xFFFF); // RH formula = 119 -> clamp 100
+  TEST_ASSERT_TRUE(sht4x_convert(raw, t, h));
+  TEST_ASSERT_FLOAT_WITHIN(0.001f, 100.0f, h);
+}
+
+void test_sht4x_convert_rejects_bad_crc(void)
+{
+  uint8_t raw[6];
+  make_frame(raw, 0x6667, 0x8000);
+  raw[2] ^= 0xFF; // corrupt temperature CRC
+  float t = 0.0f, h = 0.0f;
+  TEST_ASSERT_FALSE(sht4x_convert(raw, t, h));
+}
+
 void setUp(void) {}
 void tearDown(void) {}
 
@@ -15,6 +55,9 @@ void process(void)
 {
   UNITY_BEGIN();
   RUN_TEST(test_sht4x_crc8_canonical_vector);
+  RUN_TEST(test_sht4x_convert_valid);
+  RUN_TEST(test_sht4x_convert_humidity_clamps_low_and_high);
+  RUN_TEST(test_sht4x_convert_rejects_bad_crc);
   UNITY_END();
 }
 

--- a/test/test_sht4x/sht4x.test.cpp
+++ b/test/test_sht4x/sht4x.test.cpp
@@ -1,0 +1,27 @@
+#include <unity.h>
+#include <sht4x.h>
+
+// Canonical Sensirion CRC-8 test vector: CRC of {0xBE, 0xEF} is 0x92.
+void test_sht4x_crc8_canonical_vector(void)
+{
+  const uint8_t data[2] = {0xBE, 0xEF};
+  TEST_ASSERT_EQUAL_HEX8(0x92, sht4x_crc8(data, 2));
+}
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void process(void)
+{
+  UNITY_BEGIN();
+  RUN_TEST(test_sht4x_crc8_canonical_vector);
+  UNITY_END();
+}
+
+int main(int argc, char **argv)
+{
+  (void)argc;
+  (void)argv;
+  process();
+  return 0;
+}


### PR DESCRIPTION
Builds on @limengdu's #410 (Add Seeed reTerminal E1004 support), which currently
conflicts with `main`. I rebased it onto current `main` (resolving the conflict)
and folded in a few fixes/cleanups. The E1004 is the Seeed reTerminal 13.3"
(T133A01, dual-chip Spectra6).

### On top of #410
- **Reproducible deps**: pull the EP133A-capable `bb_epaper` from a *commit-pinned*
  fork instead of a mutable branch.
- **Dependency refactor**: introduce `[deps_app_base]` (device deps minus
  `bb_epaper`) so a board can pick its own `bb_epaper` variant without duplicating
  the list — and keep `bb_epaper` out of the native test build.
- **Light-sleep helper**: extract `display_apply_light_sleep_setting()` to replace
  the repeated inline `DO_NOT_LIGHT_SLEEP` blocks, and apply it on the message/QA
  refresh paths that were missing it.
- **post-build**: invoke `esptool.py` directly via `$PYTHONEXE` + the resolved
  `tool-esptoolpy` dir instead of `pio pkg exec` (more robust in CI; affects all
  Seeed XIAO E100x merges).
- Dual-controller display init (`setCS2`), panel-power enable, wake-button RTC
  config, battery read, and dev serial pins.

### Testing
Built and flashed to a reTerminal E1004 — boots, fetches, and renders on the
13.3" Spectra6 panel.

Credit to @limengdu for the original E1004 bring-up in #410.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

### Update: onboard SHT4x sensor reporting

Also wires up the E1004's **onboard Sensirion SHT4x** (temperature + humidity)
and reports it to the backend via the existing `SENSORS` header — no server-side
changes needed. Verified on a real reTerminal E1004:

```
SENSORS: make=Sensirion;model=SHT4x;kind=temperature;value=29.77;unit=celsius;created_at=…,
         make=Sensirion;model=SHT4x;kind=humidity;value=55.5;unit=percent;created_at=…
```

- Pure, native-unit-tested CRC-8 + conversion core in `lib/trmnl/` (5 tests).
- Self-contained `Wire` reader (`0xFD`, 6 bytes, CRC-gated) on the SHT4x's I²C
  bus (`GPIO19/20`, addr `0x44`); all paths guarded by `HAS_ONBOARD_SHT4X` so
  other boards are unaffected.
- `created_at` stamped at send time so it's valid after SNTP sync.
