### PR TITLE
reTerminal E1001/E1002: wake on the extra front buttons (next screen)

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -163,6 +163,17 @@ enum WIFI_CONNECT_RETRY_TIME // Time to sleep before trying to connect to the Wi
 #define DEVICE_MODEL "reterminal_e1003"
 #endif
 
+// Optional extra "next" navigation buttons in addition to the PIN_INTERRUPT
+// wake button. The reTerminal E1001/E1002 expose two more front buttons next to
+// the green button: Left (GPIO4) and Right (GPIO5), both active-low. Pressing
+// either wakes the device and triggers a normal refresh, which advances to the
+// next playlist item ("next" screen).
+#if defined(BOARD_SEEED_RETERMINAL_E1001) || defined(BOARD_SEEED_RETERMINAL_E1002)
+#define HAS_NEXT_BUTTONS 1
+#define PIN_BUTTON_NEXT_LEFT 4  // white button, silkscreen "Left"
+#define PIN_BUTTON_NEXT_RIGHT 5 // white button, silkscreen "Right"
+#endif
+
 #if defined(BOARD_XIAO_EPAPER_DISPLAY) || defined(BOARD_SEEED_RETERMINAL_E1001) || defined(BOARD_SEEED_RETERMINAL_E1002)
 #define PIN_BATTERY 1
 #elif defined(BOARD_XTEINK_X4)

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -37,6 +37,9 @@
 #include <api-client/display.h>
 #include <api-client/request_headers.h>
 #include "driver/gpio.h"
+#ifdef HAS_NEXT_BUTTONS
+#include "driver/rtc_io.h"
+#endif
 #include "esp_ota_ops.h"
 #include "esp_sntp.h"
 #include "esp_flash.h"
@@ -850,6 +853,23 @@ void bl_init(void)
                       wakeup_reason == ESP_SLEEP_WAKEUP_EXT1);
   Log.info("%s [%d]: Wake reason: %d\r\n", __FILE__, __LINE__, (int)wakeup_reason);
 
+#ifdef HAS_NEXT_BUTTONS
+  // Detect whether one of the extra "next" buttons (not PIN_INTERRUPT) woke us.
+  // Those boards use ext1 (any-low) wakeup over all button GPIOs, so the source
+  // pin is reported in the ext1 wakeup status bitmask.
+  bool next_button_wakeup = false;
+  if (wakeup_reason == ESP_SLEEP_WAKEUP_EXT1)
+  {
+    uint64_t ext1_status = esp_sleep_get_ext1_wakeup_status();
+    if (ext1_status & ((1ULL << PIN_BUTTON_NEXT_LEFT) | (1ULL << PIN_BUTTON_NEXT_RIGHT)))
+    {
+      next_button_wakeup = true;
+      Log_info("Next button wakeup (ext1 status=0x%llx) -> will refresh to next screen",
+               (unsigned long long)ext1_status);
+    }
+  }
+#endif
+
   Log_info("preferences start");
   bool res = preferences.begin("data", false);
   if (res)
@@ -874,6 +894,18 @@ void bl_init(void)
   if (gpio_wakeup)
   {
     Log_info("GPIO wakeup detected (%d)", wakeup_reason);
+#ifdef HAS_NEXT_BUTTONS
+    if (next_button_wakeup)
+    {
+      // A "next" button was pressed: skip the green-button press classification
+      // (and its double-click wait) and fall through to the normal refresh,
+      // which fetches the next playlist item.
+      wait_for_serial();
+      Log_info("GPIO wakeup (%d) -> next button, refreshing to next screen", wakeup_reason);
+    }
+    else
+#endif
+    {
     auto button = read_button_presses();
     wait_for_serial();
     Log_info("GPIO wakeup (%d) -> button was read (%s)", wakeup_reason, ButtonPressResultNames[button]);
@@ -893,6 +925,7 @@ void bl_init(void)
       resetDeviceCredentials();
     }
     Log_info("button handling end");
+    }
   }
   else
   {
@@ -3226,6 +3259,26 @@ static bool checkAndPerformFirmwareUpdate(void)
   return ota_ok;
 }
 
+#ifdef HAS_NEXT_BUTTONS
+// Configure deep-sleep wakeup on any of the button GPIOs (PIN_INTERRUPT plus the
+// extra "next" buttons). ext1 with ANY_LOW lets several active-low buttons wake
+// the device; the source pin is later read via esp_sleep_get_ext1_wakeup_status().
+static void configure_button_wakeup_ext1(void)
+{
+  const uint64_t mask = (1ULL << PIN_INTERRUPT) |
+                        (1ULL << PIN_BUTTON_NEXT_LEFT) |
+                        (1ULL << PIN_BUTTON_NEXT_RIGHT);
+  // Ensure the active-low buttons read high while idle during deep sleep.
+  rtc_gpio_pullup_en((gpio_num_t)PIN_INTERRUPT);
+  rtc_gpio_pulldown_dis((gpio_num_t)PIN_INTERRUPT);
+  rtc_gpio_pullup_en((gpio_num_t)PIN_BUTTON_NEXT_LEFT);
+  rtc_gpio_pulldown_dis((gpio_num_t)PIN_BUTTON_NEXT_LEFT);
+  rtc_gpio_pullup_en((gpio_num_t)PIN_BUTTON_NEXT_RIGHT);
+  rtc_gpio_pulldown_dis((gpio_num_t)PIN_BUTTON_NEXT_RIGHT);
+  esp_sleep_enable_ext1_wakeup(mask, ESP_EXT1_WAKEUP_ANY_LOW);
+}
+#endif
+
 /**
  * @brief Function to sleep preparing and go to sleep
  * @param none
@@ -3286,7 +3339,11 @@ void goToSleep(void)
   pinMode(PIN_INTERRUPT, INPUT); // needed to not immediately wake up
   esp_deep_sleep_enable_gpio_wakeup(1 << PIN_INTERRUPT, ESP_GPIO_WAKEUP_GPIO_LOW);
 #elif defined(CONFIG_IDF_TARGET_ESP32S3)
+#ifdef HAS_NEXT_BUTTONS
+  configure_button_wakeup_ext1();
+#else
   esp_sleep_enable_ext0_wakeup((gpio_num_t)PIN_INTERRUPT, 0);
+#endif
 #else
 #error "Unsupported ESP32 target for GPIO wakeup configuration"
 #endif
@@ -3312,7 +3369,11 @@ static void goToSleepButtonOnly(void)
 #elif defined( CONFIG_IDF_TARGET_ESP32C3 ) || defined ( CONFIG_IDF_TARGET_ESP32C5 )
   esp_deep_sleep_enable_gpio_wakeup(1 << PIN_INTERRUPT, ESP_GPIO_WAKEUP_GPIO_LOW);
 #elif CONFIG_IDF_TARGET_ESP32S3
+#ifdef HAS_NEXT_BUTTONS
+  configure_button_wakeup_ext1();
+#else
   esp_sleep_enable_ext0_wakeup((gpio_num_t)PIN_INTERRUPT, 0);
+#endif
 #else
 #error "Unsupported ESP32 target for GPIO wakeup configuration"
 #endif


### PR DESCRIPTION
## What

The Seeed reTerminal E1001/E1002 have three front buttons, but the firmware only used the green button (`GPIO3`) as a deep-sleep wake source. The two white buttons — Left (`GPIO4`) and Right (`GPIO5`) — were unused.

This wires both white buttons to act as a **"next screen"** control: pressing either wakes the device and runs a normal refresh, which advances to the next playlist item. The green button keeps its existing behavior (refresh / double-click special function / long-press WiFi reset).

## How

- On these boards the ESP32-S3 deep-sleep wake source is switched from single-pin `ext0` to **`ext1` with `ESP_EXT1_WAKEUP_ANY_LOW`** over `GPIO3 | GPIO4 | GPIO5` (with RTC pull-ups), so any of the three buttons can wake the device.
- On wake, the source pin is read back via `esp_sleep_get_ext1_wakeup_status()`. A white-button wake skips the green-button press classification (and its double-click wait) and falls straight through to the normal display refresh.
- All of this is gated behind a new `HAS_NEXT_BUTTONS` macro defined only for `BOARD_SEEED_RETERMINAL_E1001` / `_E1002`, so every other board is byte-for-byte unchanged.

Button GPIO mapping confirmed against Seeed's Zephyr board definition (`gpio-keys`: refresh=3, left=4, right=5, all active-low).

## Testing

- Verified on reTerminal E1001 hardware: pressing either white button wakes the device and advances the displayed screen.
- Builds cleanly for `seeed_reTerminal_E1001` and `seeed_reTerminal_E1002`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)