### PR TITLE
On OG, don't set PIN_INTERRUPT to INPUT

### DIFF
--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -3279,8 +3279,10 @@ void goToSleep(void)
 #if CONFIG_IDF_TARGET_ESP32
   #define BUTTON_PIN_BITMASK(GPIO) (1ULL << GPIO)  // 2 ^ GPIO_NUMBER in hex
   esp_sleep_enable_ext1_wakeup(BUTTON_PIN_BITMASK(PIN_INTERRUPT), ESP_EXT1_WAKEUP_ALL_LOW);
-#elif defined(CONFIG_IDF_TARGET_ESP32C3) || defined (CONFIG_IDF_TARGET_ESP32C5)
-  pinMode(PIN_INTERRUPT, INPUT); // needed to not immediately wake up
+#elif defined(CONFIG_IDF_TARGET_ESP32C3)
+  esp_deep_sleep_enable_gpio_wakeup(1 << PIN_INTERRUPT, ESP_GPIO_WAKEUP_GPIO_LOW);
+#elif defined(CONFIG_IDF_TARGET_ESP32C5)
+  pinMode(PIN_INTERRUPT, INPUT); // needed to not immediately wake up on gen2/C5
   esp_deep_sleep_enable_gpio_wakeup(1 << PIN_INTERRUPT, ESP_GPIO_WAKEUP_GPIO_LOW);
 #elif defined(CONFIG_IDF_TARGET_ESP32S3)
   esp_sleep_enable_ext0_wakeup((gpio_num_t)PIN_INTERRUPT, 0);


### PR DESCRIPTION
Addresses #456.

Commit 36978872ec02d6d085c60285ef0a004602ab849b added OG Gen2 support, but it also affected the OG in an unexpected way.

By setting `PIN_INTERRUPT` to the `INPUT` mode, that leaves it floating, which means wake-ups could be triggered randomly and excessively when the device is supposed to be in deep sleep.