### PR TITLE
Add image request headers on 5 GHz

### DIFF
--- a/lib/trmnl/include/api-client/request_headers.h
+++ b/lib/trmnl/include/api-client/request_headers.h
@@ -19,6 +19,10 @@ HttpHeaderList buildDisplayHeaders(const ApiDisplayInputs &inputs);
 HttpHeaderList buildSetupHeaders(const ApiSetupInputs &inputs);
 HttpHeaderList buildLogHeaders(const ApiLogInputs &inputs);
 
+// Auth headers for fetching the image, sent only when the image is hosted on
+// the same server as the API (see callers in bl.cpp).
+HttpHeaderList buildImageHeaders(const ApiDisplayInputs &inputs);
+
 // Format a header list as a newline-separated "Name: value" string with no
 // trailing newline, as expected by Modem::httpGet() (TRMNL X 5 GHz path).
 String formatHeaders(const HttpHeaderList &headers);

--- a/lib/trmnl/src/api-client/request_headers.cpp
+++ b/lib/trmnl/src/api-client/request_headers.cpp
@@ -54,6 +54,14 @@ HttpHeaderList buildSetupHeaders(const ApiSetupInputs &inputs)
   return headers;
 }
 
+HttpHeaderList buildImageHeaders(const ApiDisplayInputs &inputs)
+{
+  HttpHeaderList headers;
+  headers.push_back({"ID", inputs.macAddress});
+  headers.push_back({"Access-Token", inputs.apiKey});
+  return headers;
+}
+
 HttpHeaderList buildLogHeaders(const ApiLogInputs &inputs)
 {
   HttpHeaderList headers;

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -1728,7 +1728,12 @@ static https_request_err_e downloadAndShow()
     if (!_prevPath.isEmpty() && (_prevPath != String(szTemp) || _prevLastPath.isEmpty()))
       preferences.putString(PREFERENCES_LAST_PATH_KEY, _prevPath);
 
-    auto httpRes = g_modem->httpGet(String(filename), szTemp, 0);
+    // Include ID and Access Token if the image is hosted on the same server as the API
+    String imgHeaders;
+    if (strncmp(filename, apiDisplayInputs.baseUrl.c_str(), apiDisplayInputs.baseUrl.length()) == 0)
+      imgHeaders = formatHeaders(buildImageHeaders(apiDisplayInputs));
+
+    auto httpRes = g_modem->httpGet(String(filename), szTemp, 0, imgHeaders);
     if (!httpRes.ok)
     {
       Log_error_submit("Modem httpGet failed: %u bytes received", httpRes.bytesReceived);
@@ -1779,10 +1784,7 @@ static https_request_err_e downloadAndShow()
 
         // Include ID and Access Token if the image is hosted on the same server as the API
         if (strncmp(filename, apiDisplayInputs.baseUrl.c_str(), apiDisplayInputs.baseUrl.length()) == 0)
-        {
-          https.addHeader("ID", apiDisplayInputs.macAddress);
-          https.addHeader("Access-Token", apiDisplayInputs.apiKey);
-        }
+          applyHeaders(https, buildImageHeaders(apiDisplayInputs));
 
         if (status && !reset_firmware)
         {

--- a/test/test_request_headers/request_headers.test.cpp
+++ b/test/test_request_headers/request_headers.test.cpp
@@ -174,6 +174,23 @@ void test_display_headers_wifi_band_omitted_when_empty(void)
   TEST_ASSERT_FALSE(has(headers, "WiFi-Band"));
 }
 
+// --- buildImageHeaders -----------------------------------------------------
+
+// The image request carries only auth headers (ID + Access-Token), shared by
+// the Wi-Fi and modem (5 GHz) image-download paths.
+void test_image_headers_names_order_and_values(void)
+{
+  auto inputs = makeDisplayInputs();
+  auto headers = buildImageHeaders(inputs);
+
+  TEST_ASSERT_EQUAL_UINT32(2, headers.size());
+  TEST_ASSERT_EQUAL_STRING("ID", headers[0].first.c_str());
+  TEST_ASSERT_EQUAL_STRING("Access-Token", headers[1].first.c_str());
+
+  TEST_ASSERT_EQUAL_STRING("AA:BB:CC:DD:EE:FF", valueOf(headers, "ID").c_str());
+  TEST_ASSERT_EQUAL_STRING("test-token", valueOf(headers, "Access-Token").c_str());
+}
+
 // --- formatHeaders ---------------------------------------------------------
 
 void test_format_headers_newline_separated_no_trailing_newline(void)
@@ -225,6 +242,7 @@ void process()
   RUN_TEST(test_display_headers_wifi_band_2_4);
   RUN_TEST(test_display_headers_wifi_band_5);
   RUN_TEST(test_display_headers_wifi_band_omitted_when_empty);
+  RUN_TEST(test_image_headers_names_order_and_values);
   RUN_TEST(test_format_headers_newline_separated_no_trailing_newline);
   RUN_TEST(test_format_headers_empty_list_is_empty_string);
   RUN_TEST(test_format_setup_headers_round_trip);


### PR DESCRIPTION
Fixes #459.

This PR DRYs up the request headers for images, which is something we missed in #384. 

The net result is that `ID` and `Access-Token` are now included in TRMNL X image requests on 5 GHz networks, for parity with 2.4 GHz requests.