### PR TITLE
Fix battery reading on reTerminal E1003 (wrong ADC pin + switch not driven)

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -163,7 +163,7 @@ enum WIFI_CONNECT_RETRY_TIME // Time to sleep before trying to connect to the Wi
 #define DEVICE_MODEL "reterminal_e1003"
 #endif
 
-#if defined(BOARD_XIAO_EPAPER_DISPLAY) || defined(BOARD_SEEED_RETERMINAL_E1001) || defined(BOARD_SEEED_RETERMINAL_E1002)
+#if defined(BOARD_XIAO_EPAPER_DISPLAY) || defined(BOARD_SEEED_RETERMINAL_E1001) || defined(BOARD_SEEED_RETERMINAL_E1002) || defined(BOARD_SEEED_RETERMINAL_E1003)
 #define PIN_BATTERY 1
 #elif defined(BOARD_XTEINK_X4)
 #define PIN_BATTERY 0

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -3481,7 +3481,7 @@ static float readBatteryVoltage(void)
     return -1.0;
   }
 #else
-  #if defined(BOARD_XIAO_EPAPER_DISPLAY) || defined(BOARD_SEEED_RETERMINAL_E1001) || defined(BOARD_SEEED_RETERMINAL_E1002)
+  #if defined(BOARD_XIAO_EPAPER_DISPLAY) || defined(BOARD_SEEED_RETERMINAL_E1001) || defined(BOARD_SEEED_RETERMINAL_E1002) || defined(BOARD_SEEED_RETERMINAL_E1003)
     pinMode(PIN_VBAT_SWITCH, OUTPUT);
     digitalWrite(PIN_VBAT_SWITCH, VBAT_SWITCH_LEVEL);
     delay(10); // Wait for the switch to stabilize
@@ -3495,7 +3495,7 @@ static float readBatteryVoltage(void)
     for (uint8_t i = 0; i < 8; i++) {
       adc += analogReadMilliVolts(PIN_BATTERY);
     }
-  #if defined(BOARD_XIAO_EPAPER_DISPLAY) || defined(BOARD_SEEED_RETERMINAL_E1001) || defined(BOARD_XIAO_EPAPER_DISPLAY_3CLR)
+  #if defined(BOARD_XIAO_EPAPER_DISPLAY) || defined(BOARD_SEEED_RETERMINAL_E1001) || defined(BOARD_XIAO_EPAPER_DISPLAY_3CLR) || defined(BOARD_SEEED_RETERMINAL_E1003)
     digitalWrite(PIN_VBAT_SWITCH, (VBAT_SWITCH_LEVEL == HIGH ? LOW : HIGH));
   #endif
     sensorValue = (adc / 8) * 2;


### PR DESCRIPTION
The reTerminal **E1003** is left out of both halves of the battery path in `readBatteryVoltage()`, so it never reports a real battery level:

1. **Wrong ADC pin.** In `include/config.h`, `PIN_BATTERY` is only set to `1` (GPIO1) for `BOARD_XIAO_EPAPER_DISPLAY / E1001 / E1002`; the E1003 falls through to the `#else` → **`PIN_BATTERY 3` (GPIO3)**. GPIO3 is a rail that saturates the 12 dB ADC (~3.1 V), so the `* 2` divider math reports a pegged **~6.2 V → 100%**. The E1003 cell is on **GPIO1**, same as the other reTerminals.
2. **Load switch never enabled.** The E1003 is also excluded from the `PIN_VBAT_SWITCH` enable/disable conditions in `readBatteryVoltage()`, so its `PIN_VBAT_SWITCH` (GPIO40, already defined in `config.h`) is never driven — the sense divider stays disconnected.

### Fix
Add `BOARD_SEEED_RETERMINAL_E1003` to the `PIN_BATTERY = 1` group and to both switch conditions. Three lines.

### Verified on hardware
On a reTerminal E1003, sweeping ADC1 with GPIO40 driven high:
- **GPIO1: ~1830 mV → ×2 = ~3660 mV** (a valid 1S cell) ✅
- GPIO3: pegged at the ADC ceiling (~3108 mV → the bogus ~6216 mV) ❌

(Found while bringing the E1003 up in a separate ESP-IDF firmware; the same off-by-one pin selection was the culprit there.)