### PR TITLE
Enable real battery reading on the TRMNL 7.5" OG DIY kit (drop the fake)

### DIFF
--- a/src/DEV_Config.h
+++ b/src/DEV_Config.h
@@ -130,8 +130,11 @@
    #define EPD_RST_PIN  38
    #define EPD_DC_PIN   10
    #define EPD_BUSY_PIN 4
-   // DEBUG - remove the fake battery line after testing
+   // Real battery reading works via PIN_VBAT_SWITCH=6 + PIN_BATTERY=1 (config.h);
+   // opt into the constant 4.2V fake only when explicitly requested.
+   #ifdef USE_FAKE_BATTERY_VOLTAGE
    #define FAKE_BATTERY_VOLTAGE
+   #endif
 #elif defined(BOARD_TRMNL_X)
 //   #define FAKE_BATTERY_VOLTAGE
 

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -3481,7 +3481,7 @@ static float readBatteryVoltage(void)
     return -1.0;
   }
 #else
-  #if defined(BOARD_XIAO_EPAPER_DISPLAY) || defined(BOARD_SEEED_RETERMINAL_E1001) || defined(BOARD_SEEED_RETERMINAL_E1002)
+  #if defined(BOARD_XIAO_EPAPER_DISPLAY) || defined(BOARD_XIAO_EPAPER_DISPLAY_3CLR) || defined(BOARD_SEEED_RETERMINAL_E1001) || defined(BOARD_SEEED_RETERMINAL_E1002)
     pinMode(PIN_VBAT_SWITCH, OUTPUT);
     digitalWrite(PIN_VBAT_SWITCH, VBAT_SWITCH_LEVEL);
     delay(10); // Wait for the switch to stabilize


### PR DESCRIPTION
The **TRMNL 7.5" OG DIY kit** (`BOARD_XIAO_EPAPER_DISPLAY`) unconditionally `#define`s `FAKE_BATTERY_VOLTAGE` in `DEV_Config.h` — with a `// DEBUG - remove the fake battery line after testing` comment — so `readBatteryVoltage()` always returns a constant **4.2 V** instead of reading the cell.

Everything needed for the real read is already in the tree: `config.h` defines `PIN_VBAT_SWITCH 6`, `PIN_BATTERY 1` and the `/2` divider, and `readBatteryVoltage()` already drives the switch for this board. It just never runs because of the fake.

### Changes
- **Gate the fake behind the existing `USE_FAKE_BATTERY_VOLTAGE` flag** (which one env already sets) instead of defining it unconditionally. Envs that want the fake keep opting in; the shipping kit reads real voltage.
- **Add `BOARD_XIAO_EPAPER_DISPLAY_3CLR` to the switch-*enable* condition** in `readBatteryVoltage()` — it was already in the *disable* condition, so without this the 3-colour variant would toggle the load switch off but never on, leaving the divider disconnected.

### Verified on hardware
On the mono 7.5" kit, sweeping ADC1 with `PIN_VBAT_SWITCH` (GPIO6) driven high:
- **GPIO1: ~2064 mV → ×2 = ~4128 mV** (a full 1S cell) ✅
- With the switch **off**: GPIO1 reads **0 mV** — the exact symptom the fake was masking.

The 3CLR variant shares the identical `BOARD_XIAO_EPAPER_DISPLAY*` battery config (switch 6 / battery 1).

_Note: touches the same `readBatteryVoltage()` `#if` line as #464 (E1003 fix); trivial to resolve whichever lands second._