### PR TITLE
display SSID on WiFi Connect screen

### DIFF
--- a/lib/wificaptive/src/WifiCaptive.cpp
+++ b/lib/wificaptive/src/WifiCaptive.cpp
@@ -22,6 +22,15 @@ void WifiCaptive::setUpDNSServer(DNSServer &dnsServer, const IPAddress &localIP)
     dnsServer.start(53, "*", localIP);
 }
 
+String WifiCaptive::getAPSSID()
+{
+    uint64_t mac = ESP.getEfuseMac();
+    char macSuffix[7];
+    snprintf(macSuffix, sizeof(macSuffix), "%02X%02X%02X",
+        (uint8_t)(mac >> 24), (uint8_t)(mac >> 32), (uint8_t)(mac >> 40));
+    return String(WIFI_SSID) + "-" + String(macSuffix);
+}
+
 bool WifiCaptive::startPortal()
 {
     _dnsServer = new DNSServer();
@@ -42,11 +51,7 @@ bool WifiCaptive::startPortal()
     WiFi.softAPConfig(localIP, gatewayIP, subnetMask);
     delay(50);
 
-    uint64_t mac = ESP.getEfuseMac();
-    char macSuffix[7];
-    snprintf(macSuffix, sizeof(macSuffix), "%02X%02X%02X",
-        (uint8_t)(mac >> 24), (uint8_t)(mac >> 32), (uint8_t)(mac >> 40));
-    String SSID = String(WIFI_SSID) + "-" + String(macSuffix);
+    String SSID = getAPSSID();
 
     // Start the soft access point with the given ssid, password, channel, max number of clients
     WiFi.softAP(SSID.c_str(), WIFI_PASSWORD, WIFI_CHANNEL, 0, MAX_CLIENTS);

--- a/lib/wificaptive/src/WifiCaptive.h
+++ b/lib/wificaptive/src/WifiCaptive.h
@@ -95,6 +95,10 @@ public:
     /// @return True if successfully connected to provided SSID, false otherwise.
     bool startPortal();
 
+    /// @brief Returns the SSID broadcast by the setup access point (e.g. "TRMNL-4D4CF0").
+    ///        Derived from the eFuse MAC, so it is stable and available before startPortal().
+    String getAPSSID();
+
     /// @brief Checks if any ssid is saved
     /// @return True if any ssis is saved, false otherwise
     bool isSaved();

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -1256,7 +1256,7 @@ void bl_init(void)
 
     Log_info("FW version %s", FW_VERSION_STRING);
 
-    showMessageWithLogo(WIFI_CONNECT, "", false, FW_VERSION_STRING, "");
+    showMessageWithLogo(WIFI_CONNECT, "", false, FW_VERSION_STRING, WifiCaptivePortal.getAPSSID());
 #ifdef BOARD_TRMNL_X
     // set TAP mode as default
     iqs323_task_i2c_lock();
@@ -1284,7 +1284,7 @@ void bl_init(void)
           // Only reached on cancel — confirmed path calls ESP.restart()
           s_power_off_cooldown_until = millis() + 2000;
           iqs323_task_i2c_unlock();
-          showMessageWithLogo(WIFI_CONNECT, "", false, FW_VERSION_STRING, "");
+          showMessageWithLogo(WIFI_CONNECT, "", false, FW_VERSION_STRING, WifiCaptivePortal.getAPSSID());
           return;
         }
       } else {

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -2492,10 +2492,9 @@ void display_show_msg(uint8_t *image_buffer, MSG message_type, String friendly_i
         string1 += fw_version;
         bbep.setCursor(40, 48); // place in upper left corner
         bbep.println(string1);
-        // message carries the AP SSID (see WifiCaptive::getAPSSID()); empty for callers that don't pass one
         String string2 = "Connect your phone or computer to ";
         string2 += (message.length() > 0) ? "'" + message + "'" : String("the TRMNL");
-        string2 += " WiFi";
+        string2 += " Wi-Fi";
         bbep.getStringBox(string2, &rect);
 #ifdef __BB_EPAPER__
         bbep.setCursor((bbep.width() - rect.w) / 2, 386);

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -2491,7 +2491,10 @@ void display_show_msg(uint8_t *image_buffer, MSG message_type, String friendly_i
         string1 += fw_version;
         bbep.setCursor(40, 48); // place in upper left corner
         bbep.println(string1);
-        const char string2[] = "Connect your phone or computer to the TRMNL WiFi";
+        // message carries the AP SSID (see WifiCaptive::getAPSSID()); empty for callers that don't pass one
+        String string2 = "Connect your phone or computer to ";
+        string2 += (message.length() > 0) ? "'" + message + "'" : String("the TRMNL");
+        string2 += " WiFi";
         bbep.getStringBox(string2, &rect);
 #ifdef __BB_EPAPER__
         bbep.setCursor((bbep.width() - rect.w) / 2, 386);


### PR DESCRIPTION
- when setting up multiple devices it's not clear which TRMNL is which
- this makes it more clear which wifi network is actually in question

we made this using Claude with @niklasbabel so it's only a proof of concept

<img width="3213" height="3831" alt="IMG_2157" src="https://github.com/user-attachments/assets/ca9dde24-69e0-4424-a46d-53296bfcd807" />