### PR TITLE
Display firmware commit

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -121,6 +121,7 @@ board_build.flash_mode = dio    ; Common flash mode for ESP32dev
 
 [env:waveshare-esp32-driver]
 extends = env:esp32dev
+extra_scripts = pre:scripts/extra/git_version.py
 build_flags =
 	${env:esp32_base.build_flags}
 	-D BOARD_WAVESHARE_ESP32_DRIVER
@@ -222,6 +223,7 @@ build_flags =
 [env:seeed_xiao_esp32c3]
 extends = env:esp32_base
 board = seeed_xiao_esp32c3
+extra_scripts = pre:scripts/extra/git_version.py
 build_flags = 
 	${env:esp32_base.build_flags}
 	-D BOARD_SEEED_XIAO_ESP32C3
@@ -231,7 +233,9 @@ debug_tool = esp-builtin
 [env:seeed_xiao_esp32s3]
 extends = env:esp32_base
 board = seeed_xiao_esp32s3
-extra_scripts = post:scripts/extra/post_build_seeed.py
+extra_scripts =
+	pre:scripts/extra/git_version.py
+	post:scripts/extra/post_build_seeed.py
 build_flags =
 	${env:esp32_base.build_flags}
 	-D BOARD_SEEED_XIAO_ESP32S3
@@ -247,7 +251,9 @@ board_build.flash_mode = qio
 board_build.partitions = trmnl_x_partitions.csv
 board_build.filesystem = littlefs
 upload_speed = 460800
-extra_scripts = post:scripts/extra/post_build_x.py
+extra_scripts =
+	pre:scripts/extra/git_version.py
+	post:scripts/extra/post_build_x.py
 build_flags =
     -D BOARD_TRMNL_X_EPDIY
 	-D BOARD_X_CLASS
@@ -282,7 +288,9 @@ board_build.flash_mode = qio
 board_build.partitions = trmnl_x_partitions.csv
 board_build.filesystem = littlefs
 upload_speed = 460800
-extra_scripts = post:scripts/extra/post_build_x.py
+extra_scripts = 
+	pre:scripts/extra/git_version.py
+	post:scripts/extra/post_build_x.py
 build_flags =
     -D BOARD_TRMNL_X_LILYGO
 	-D BOARD_X_CLASS
@@ -317,7 +325,9 @@ board_build.flash_mode = qio
 board_build.partitions = trmnl_x_partitions.csv
 board_build.filesystem = littlefs
 upload_speed = 460800
-extra_scripts = post:scripts/extra/post_build_x.py
+extra_scripts = 
+	pre:scripts/extra/git_version.py
+	post:scripts/extra/post_build_x.py
 build_flags =
     -D BOARD_TRMNL_X_PAPERS3
 	-D BOARD_X_CLASS
@@ -352,7 +362,9 @@ board_build.flash_mode = qio
 board_build.partitions = trmnl_x_partitions.csv
 board_build.filesystem = littlefs
 upload_speed = 460800
-extra_scripts = post:scripts/extra/post_build_x.py
+extra_scripts = 
+	pre:scripts/extra/git_version.py
+	post:scripts/extra/post_build_x.py
 build_flags =
     -D BOARD_TRMNL_X_SENSORIAS3
 	-D BOARD_X_CLASS
@@ -387,7 +399,9 @@ board_build.flash_mode = qio
 board_build.partitions = trmnl_x_partitions.csv
 board_build.filesystem = littlefs
 upload_speed = 460800
-extra_scripts = post:scripts/extra/post_build_x.py
+extra_scripts =
+	pre:scripts/extra/git_version.py
+	post:scripts/extra/post_build_x.py
 build_flags =
     -D BOARD_TRMNL_X_SENSORIAC5
 	-D BOARD_X_CLASS
@@ -460,7 +474,9 @@ board_build.flash_mode = qio
 board_build.partitions = trmnl_x_partitions.csv
 board_build.filesystem = littlefs
 upload_speed = 460800
-extra_scripts = post:scripts/extra/post_build_seeed.py
+extra_scripts =
+	pre:scripts/extra/git_version.py
+	post:scripts/extra/post_build_seeed.py
 ; override the default build flags, removing the USB_MODE and CDC_ON_BOOT flags
 board_build.extra_flags =
 	-D ARDUINO_XIAO_ESP32S3
@@ -500,6 +516,7 @@ board_build.flash_mode = qio
 board_build.partitions = trmnl_x_partitions.csv
 board_build.filesystem = littlefs
 upload_speed = 460800
+extra_scripts = pre:scripts/extra/git_version.py
 build_flags =
 	-I .
     -D BOARD_TRMNL_X
@@ -527,6 +544,7 @@ lib_deps =
 lib_ignore = bb_epaper
 
 [env:TRMNL_X_dev_no_qa]
+extra_scripts = pre:scripts/extra/git_version.py
 board = esp32s3_n16r8
 board_build.esp-idf.sdkconfig_path = sdkconfigs/sdkconfig.${this.__env__}
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.37/platform-espressif32.zip
@@ -567,7 +585,9 @@ lib_ignore = bb_epaper
 extends = env:esp32_base
 board = seeed_xiao_esp32s3
 framework = arduino
-extra_scripts = post:scripts/extra/post_build_seeed.py
+extra_scripts =
+	pre:scripts/extra/git_version.py
+	post:scripts/extra/post_build_seeed.py
 build_flags =
 	${env:esp32_base.build_flags}
 	-D BOARD_XIAO_EPAPER_DISPLAY
@@ -579,7 +599,9 @@ build_flags =
 extends = env:esp32_base
 board = seeed_xiao_esp32s3
 framework = arduino
-extra_scripts = post:scripts/extra/post_build_seeed.py
+extra_scripts =
+	pre:scripts/extra/git_version.py
+	post:scripts/extra/post_build_seeed.py
 build_flags =
 	${env:esp32_base.build_flags}
     -D BOARD_XIAO_EPAPER_DISPLAY
@@ -589,7 +611,9 @@ build_flags =
 extends = env:esp32_base
 board = seeed_xiao_esp32s3
 framework = arduino
-extra_scripts = post:scripts/extra/post_build_seeed.py
+extra_scripts =
+	pre:scripts/extra/git_version.py
+	post:scripts/extra/post_build_seeed.py
 build_flags =
 	${env:esp32_base.build_flags}
     -D BOARD_XIAO_EPAPER_DISPLAY_3CLR
@@ -599,7 +623,9 @@ build_flags =
 extends = env:esp32_base
 board = seeed_xiao_esp32s3
 framework = arduino
-extra_scripts = post:scripts/extra/post_build_seeed.py
+extra_scripts =
+	pre:scripts/extra/git_version.py
+	post:scripts/extra/post_build_seeed.py
 ; override the default build flags, removing the USB_MODE and CDC_ON_BOOT flags
 board_build.extra_flags =
 	-D ARDUINO_XIAO_ESP32S3
@@ -617,6 +643,7 @@ build_flags =
 extends = env:esp32_base
 board = seeed_xiao_esp32s3
 framework = arduino
+extra_scripts = pre:scripts/extra/git_version.py
 ; override the default build flags, removing the USB_MODE and CDC_ON_BOOT flags
 board_build.extra_flags =
         -D ARDUINO_XIAO_ESP32S3
@@ -637,7 +664,9 @@ build_flags =
 extends = env:esp32_base
 board = seeed_xiao_esp32s3
 framework = arduino
-extra_scripts = post:scripts/extra/post_build_seeed.py
+extra_scripts =
+	pre:scripts/extra/git_version.py
+	post:scripts/extra/post_build_seeed.py
 ; override the default build flags, removing the USB_MODE and CDC_ON_BOOT flags
 board_build.extra_flags =
 	-D ARDUINO_XIAO_ESP32S3
@@ -696,6 +725,7 @@ lib_ignore =
 
 [env:esp32-c5-devkitc-1]
 board = esp32-c5-devkitc-1
+extra_scripts = pre:scripts/extra/git_version.py
 
 monitor_speed = 115200
 board_build.f_cpu = 240000000L

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -48,6 +48,7 @@
 #include "loading.h"
 #include <wifi-helpers.h>
 #include <sys/time.h>
+#include "messages.h"
 #ifdef SENSOR_SDA
 #include <bb_scd41.h>
 #include <bb_temperature.h>
@@ -1160,7 +1161,7 @@ void bl_init(void)
 #endif // BOARD_TRMNL_X
   vBatt = readBatteryVoltage(); // Read the battery voltage BEFORE WiFi is turned on
 
-  Log_info("Firmware version %s", FW_VERSION_STRING);
+  Log_info("Firmware version %s", Messages::firmware_version().c_str());
   Log_info("Arduino version %d.%d.%d", ESP_ARDUINO_VERSION_MAJOR, ESP_ARDUINO_VERSION_MINOR, ESP_ARDUINO_VERSION_PATCH);
   Log_info("ESP-IDF version %d.%d.%d", ESP_IDF_VERSION_MAJOR, ESP_IDF_VERSION_MINOR, ESP_IDF_VERSION_PATCH);
   list_files();
@@ -1168,7 +1169,7 @@ void bl_init(void)
 
   // DEBUG - test message display
   // showMessageWithLogo(MSG_FORMAT_ERROR);
-  // display_show_msg(storedLogoOrDefault(1), WIFI_CONNECT, "ABCDEF", true, FW_VERSION_STRING, "Hello World!");
+  // display_show_msg(storedLogoOrDefault(1), WIFI_CONNECT, "ABCDEF", true, Messages::firmware_version().c_str(), "Hello World!");
   // wifiErrorDeepSleep();
 #ifdef BOARD_TRMNL_X
   if (bModemNeeded) {
@@ -1254,9 +1255,9 @@ void bl_init(void)
     // WiFi credentials are not saved - start captive portal
     Log.info("%s [%d]: WiFi NOT saved\r\n", __FILE__, __LINE__);
 
-    Log_info("FW version %s", FW_VERSION_STRING);
+    Log_info("FW version %s", Messages::firmware_version().c_str());
 
-    showMessageWithLogo(WIFI_CONNECT, "", false, FW_VERSION_STRING, "");
+    showMessageWithLogo(WIFI_CONNECT, "", false, Messages::firmware_version().c_str(), "");
 #ifdef BOARD_TRMNL_X
     // set TAP mode as default
     iqs323_task_i2c_lock();
@@ -1284,7 +1285,7 @@ void bl_init(void)
           // Only reached on cancel — confirmed path calls ESP.restart()
           s_power_off_cooldown_until = millis() + 2000;
           iqs323_task_i2c_unlock();
-          showMessageWithLogo(WIFI_CONNECT, "", false, FW_VERSION_STRING, "");
+          showMessageWithLogo(WIFI_CONNECT, "", false, Messages::firmware_version().c_str(), "");
           return;
         }
       } else {

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -7,6 +7,7 @@
 #include <preferences_persistence.h>
 #include "DEV_Config.h"
 #include "battery_small.h"
+#include "messages.h"
 #define MAX_BIT_DEPTH 8
 #ifndef BOARD_X_CLASS
 #define BB_EPAPER
@@ -1923,7 +1924,7 @@ void display_show_msg(uint8_t *image_buffer, MSG message_type, const char *messa
     case WIFI_FAILED:
     {
         String string0 = "TRMNL firmware ";
-        string0 += FW_VERSION_STRING;
+        string0 += Messages::firmware_version();
 #ifdef __BB_EPAPER__
         bbep.setCursor(40, 48); // place in upper left corner
 #else

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -1,0 +1,17 @@
+#include "config.h"
+#include "messages.h"
+
+namespace Messages
+{
+    String firmware_version()
+    {
+        if (FW_COMMIT[0] != '\0')
+        {
+            return String(FW_VERSION_STRING) + " (" + String(FW_COMMIT) + ")";
+        }
+        else
+        {
+            return FW_VERSION_STRING;
+        }
+    }
+}

--- a/src/messages.h
+++ b/src/messages.h
@@ -1,0 +1,7 @@
+#pragma once
+#include <Arduino.h>
+
+namespace Messages
+{
+    String firmware_version();
+}


### PR DESCRIPTION
To avoid confusion about exactly which firmware release is running on the device (especially in the dev and staging channels), we need to display the Git commit hash of the build.

- add `pre:scripts/extra/git_version.py` to all remaining environments
- add `Messages` namespace for human-facing strings, and `Messages::firmware_version()`
- display firmware commit on screen

<img width="4032" height="3024" alt="IMG_1502" src="https://github.com/user-attachments/assets/75371761-df29-40b2-93e7-2642ba8a951c" />
