### PR TITLE
Fix sleep issue when playlist has one item

### DIFF
--- a/include/bl.h
+++ b/include/bl.h
@@ -30,4 +30,6 @@ void logWithAction(LogAction action, LogLevel level, const char *message, time_t
 bool submitLogString(const char *log_buffer);
 bool storeLogString(const char *log_buffer);
 
+void fixFileName(const char *src, char *dest);
+
 #endif

--- a/include/filesystem.h
+++ b/include/filesystem.h
@@ -87,4 +87,11 @@ bool filesystem_file_delete(const char *name);
  */
 bool filesystem_file_rename(const char *old_name, const char *new_name);
 
+/**
+ * @brief Function to extract the timestamp from a filename
+ * @param filename filename
+ * @return timestamp as uint32_t (0 if timestamp suffix is not present or invalid)
+ */
+uint32_t filesystem_extract_timestamp(const char *filename);
+
 void list_files();

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -383,6 +383,7 @@ static void showLastImageAndSleep()
     if (buf && file_size > 0) {
       display_show_image(buf, file_size, true);
       free(buf);
+      DisplayedImage::remember(curPath.c_str());
     }
   }
   goToSleep();
@@ -488,7 +489,11 @@ static void show_cached_image_by_offset(int offset) {
     if (path.isEmpty()) { Log_info("No cached image for gesture"); return; }
     int file_size = 0;
     buffer = display_read_file(path.c_str(), &file_size);
-    if (buffer && file_size > 0) { display_show_image(buffer, file_size, true); goToSleep(); }
+    if (buffer && file_size > 0) {
+      display_show_image(buffer, file_size, true);
+      DisplayedImage::remember(path.c_str());
+      goToSleep();
+    }
     return;
   }
 
@@ -531,6 +536,7 @@ static void show_cached_image_by_offset(int offset) {
 
   preferences.putString(PREFERENCES_BROWSE_PATH_KEY, String(images[new_idx]));
   display_show_image(buffer, file_size, true);
+  DisplayedImage::remember(images[new_idx]);
   goToSleep();
 }
 
@@ -1807,6 +1813,7 @@ static https_request_err_e downloadAndShow()
 
     display_show_image(buf, fileSize, true);
     free(buf);
+    DisplayedImage::remember(szTemp); // current image becomes the previous image
 
     preferences.putString(PREFERENCES_CURRENT_PATH_KEY, String(szTemp));
     update_playlist_order(szTemp, _prevPath.c_str());
@@ -2014,6 +2021,7 @@ static https_request_err_e downloadAndShow()
             writeImageToFile(szTemp, buffer, content_size);
             Log.info("%s [%d]: Decoding %s\r\n", __FILE__, __LINE__, (isPNG) ? "png" : "jpeg");
             display_show_image(buffer, content_size, true);
+            DisplayedImage::remember(szTemp); // current image becomes the previous image
             if (buffer_malloc) {
               Log.info("%s [%d]: Freeing the image buffer we allocated\r\n", __FILE__, __LINE__);
               free(buffer);
@@ -2093,6 +2101,11 @@ static https_request_err_e downloadAndShow()
             }
             Log.info("Free heap at before display - %d", ESP.getMaxAllocHeap());
             display_show_image(buffer, content_size, true);
+            {
+              char szTemp[36];
+              fixFileName(apiDisplayResult.response.filename.c_str(), szTemp);
+              DisplayedImage::remember(szTemp);
+            }
             
             if (buffer_malloc) {
               Log.info("%s [%d]: Freeing the image buffer we allocated\r\n", __FILE__, __LINE__);

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -49,6 +49,7 @@
 #include <wifi-helpers.h>
 #include <sys/time.h>
 #include "messages.h"
+#include "displayed_image.h"
 #ifdef SENSOR_SDA
 #include <bb_scd41.h>
 #include <bb_temperature.h>
@@ -95,7 +96,6 @@ RTC_DATA_ATTR int iPrevWakeTime = 0; // total wake time of the last cycle (for s
 RTC_DATA_ATTR bool bUsedCachedImage = false; // if the last image displayed was read from cache (for statistics collection)
 RTC_DATA_ATTR uint8_t need_to_refresh_display = 1;
 RTC_DATA_ATTR bool otg_state = false;  // Track OTG state across deep sleep
-RTC_DATA_ATTR char szPrevFile[36] = {0};
 bool touchbar_tap_mode = true;  // false = "slide", true = "tap" (default)
 Preferences preferences;
 PreferencesPersistence preferencesPersistence(preferences);
@@ -1092,7 +1092,7 @@ void bl_init(void)
 #endif // BOARD_TRMNL_X
     // Force the display to show the current playlist image after the loading screen
     // (even if it hasn't changed)
-    szPrevFile[0] = 0;
+    DisplayedImage::clear();
 
     need_to_refresh_display = 1;
     preferences.putBool(PREFERENCES_DEVICE_REGISTERED_KEY, false);
@@ -1667,10 +1667,10 @@ ApiDisplayInputs loadApiDisplayInputs(Preferences &preferences)
 void load_prev_image(void)
 {
   uint8_t *buffer;
-  size_t content_size = 0; //filesystem_read_and_allocate(szPrevFile, &buffer);
+  size_t content_size = 0;
   if (content_size > 0) {
     // Decode it into the previous buffer
-    Log.info("%s [%d]: Decoding previous image (%s) into FastEPD previous buffer\r\n", __FILE__, __LINE__, szPrevFile);
+    Log.info("%s [%d]: Decoding previous image (%s) into FastEPD previous buffer\r\n", __FILE__, __LINE__, DisplayedImage::get());
     png_to_epd(buffer, content_size, true);
   }
 } /* load_prev_image() */
@@ -1731,18 +1731,18 @@ static https_request_err_e downloadAndShow()
   if (!status && result == HTTPS_SUCCESS) { // this means we already have this image stored in SPIFFS
       char szTemp[36];
 #if defined( BOARD_X_CLASS ) && !defined(BOARD_SEEED_RETERMINAL_E1003)
-      if (szPrevFile[0]) {
+      if (DisplayedImage::exists()) {
         load_prev_image(); // decode the older image into the previous buffer of FastEPD
       }
 #endif // BOARD_X_CLASS
       fixFileName(apiDisplayResult.response.filename.c_str(), szTemp);
-      if (strcmp(szTemp, szPrevFile) == 0) {
+      if (DisplayedImage::matches(szTemp)) {
         // We just displayed the same image, don't refresh the display
         Log.info("%s [%d]: The image hasn't changed since the last wakeup, don't refresh the display.\r\n", __FILE__, __LINE__);
         buffer = nullptr;
         return result;
       }
-      strcpy(szPrevFile, szTemp); // save the filename to compare on the next wakeup
+      DisplayedImage::remember(szTemp);
       Log.info("%s [%d]: Reading %s from SPIFFS\r\n", __FILE__, __LINE__, szTemp);
       size_t content_size = filesystem_read_and_allocate(szTemp, &buffer);
       if (!buffer || content_size == 0) {
@@ -1754,7 +1754,7 @@ static https_request_err_e downloadAndShow()
       display_show_image(buffer, content_size, true);
       free(buffer);
       buffer = nullptr;
-      strcpy(szPrevFile, szTemp); // current image becomes the previous image
+      DisplayedImage::remember(szTemp); // current image becomes the previous image
       // Rotate NVS path keys: last ← current ← szTemp
       String _curPath = preferences.getString(PREFERENCES_CURRENT_PATH_KEY, "");
       String _lastPath = preferences.getString(PREFERENCES_LAST_PATH_KEY, "");

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -124,7 +124,6 @@ static uint8_t *storedLogoOrDefault(int iType);
 static bool checkCurrentFileName(String &newName);
 static DeviceStatusStamp getDeviceStatusStamp();
 void log_nvs_usage();
-void fixFileName(const char *src, char *dest);
 void config_gpio_for_lp();
 int png_to_epd(const uint8_t *pPNG, int iDataSize, bool bPrevious);
 

--- a/src/displayed_image.cpp
+++ b/src/displayed_image.cpp
@@ -1,0 +1,36 @@
+#include "displayed_image.h"
+#include "esp_attr.h"
+#include <string.h>
+
+namespace DisplayedImage
+{
+    // SPIFFS path of the image currently on the display
+    RTC_DATA_ATTR static char szPrevFile[36] = {0};
+
+    // filename must already be a 32-byte fixed SPIFFS path (see Storage::fix_file_name)
+    void remember(const char *filename)
+    {
+        strncpy(szPrevFile, filename, sizeof(szPrevFile) - 1);
+        szPrevFile[sizeof(szPrevFile) - 1] = '\0';
+    }
+
+    void clear()
+    {
+        memset(szPrevFile, 0, sizeof(szPrevFile));
+    }
+
+    bool exists()
+    {
+        return szPrevFile[0] != '\0';
+    }
+
+    bool matches(const char *filename)
+    {
+        return strcmp(szPrevFile, filename) == 0;
+    }
+
+    char *get()
+    {
+        return szPrevFile;
+    }
+}

--- a/src/displayed_image.h
+++ b/src/displayed_image.h
@@ -1,0 +1,12 @@
+#pragma once
+
+// Tracks which image is physically on the display, surviving deep sleep,
+// so the next wakeup can skip repainting when the server re-serves it.
+namespace DisplayedImage
+{
+    void remember(const char *filename);
+    void clear();
+    bool exists();
+    bool matches(const char *filename);
+    char *get();
+}

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -123,13 +123,13 @@ bool filesystem_read_from_file(const char *name, uint8_t *out_buffer, size_t siz
  */
 void filesystem_purge_old_file(const char *name)
 {
-uint32_t u32;
-time_t tt;
+uint32_t timestamp;
+time_t now;
 File rootDir; 
 char *s, szTemp[32];
 bool bDel;
 
-    time(&tt); // get the current epoch time
+    time(&now); // get the current epoch time
     rootDir = FS.open("/");
     while (File file = rootDir.openNextFile()) {
         Log_info("Checking file \"%s\" for deletion", file.name());
@@ -141,18 +141,18 @@ bool bDel;
         }
 
         s = (char *)file.name();
-        // The last 10 characters of the name are the epoch timestamp
-        u32 = (uint32_t) atoi(&s[strlen(s)-10]);
+
+        timestamp = filesystem_extract_timestamp(s);
         bDel = false;
 
         strcpy(szTemp, "/"); // needed on this file operation
         strcat(szTemp, file.name());
 
-        Log_info("Comparing name %s with %s, timestamp %u, current time %u", name, file.name(), u32, (uint32_t)tt);
-        if (memcmp(name, szTemp, 14) == 0) { // older version of the same file
+        Log_info("Comparing name %s with %s, timestamp %u, current time %u", name, file.name(), timestamp, (uint32_t)now);
+        if (strncmp(name, szTemp, 14) == 0) { // older version of the same file
             Log_info("Deleting older version of plugin image %s - %s", name, file.name());
             bDel = true;
-        } else if ((uint32_t)tt - u32 > 60*60*24) { // More than 24h old
+        } else if ((uint32_t)now > timestamp + 60*60*24) { // More than 24h old, or no timestamp
             Log_info("Deleting image older than 24h - %s", file.name());
             bDel = true;
         }
@@ -314,4 +314,29 @@ void list_files()
         Log_info("  %d  %s", file.size(), file.name());
     }
     rootDir.close();
+}
+
+uint32_t filesystem_extract_timestamp(const char *filename)
+{
+    if (strlen(filename) < 10)
+    {
+        return 0;
+    }
+
+    const char *szTimestamp = &filename[strlen(filename)-10];
+    bool is_numeric = true;
+
+    for (int i = 0; i < 10 && is_numeric; i++) 
+    {
+        is_numeric = (szTimestamp[i] >= '0' && szTimestamp[i] <= '9');
+    }
+
+    if (is_numeric)
+    {
+        return (uint32_t) atoi(szTimestamp);
+    }
+    else
+    {
+        return 0;
+    }
 }


### PR DESCRIPTION
Fixes #469 

## The problems

1. we were not setting `szPrevFile` in all situations where an image was displayed
2. we weren't accounting for filenames that don't have a timestamp, like "sleep.png"

## The solution

1. refactor: extract "previous image" logic into new `DisplayedImage` namespace
2. fix: add `DisplayedImage::remember()` calls where they were missing
3. fix: improve filename timestamp parsing