### PR TITLE
Use double quotes around Wi-Fi SSID message

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -2552,7 +2552,7 @@ void display_show_msg(uint8_t *image_buffer, MSG message_type, String friendly_i
         bbep.setCursor(40, 48); // place in upper left corner
         bbep.println(string1);
         String string2 = "Connect your phone or computer to ";
-        string2 += (message.length() > 0) ? "'" + message + "'" : String("the TRMNL");
+        string2 += (message.length() > 0) ? "\"" + message + "\"" : String("the TRMNL");
         string2 += " Wi-Fi";
         bbep.getStringBox(string2, &rect);
 #ifdef __BB_EPAPER__


### PR DESCRIPTION
Follow-up to #467 

The single quote character `'` is skipped by bb_epaper because it is exactly 1 pixel wide, so it's treated as a space and skipped. Quick fix is to use `"` instead.