### PR TITLE
Add Seeed device environments to prepare_release.sh

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -249,8 +249,10 @@ build_flags =
 [env:seeed_xiao_esp32c3]
 extends = env:esp32_base
 board = seeed_xiao_esp32c3
-extra_scripts = pre:scripts/extra/git_version.py
-build_flags = 
+extra_scripts =
+	pre:scripts/extra/git_version.py
+	post:scripts/extra/post_build_og.py
+build_flags =
 	${env:esp32_base.build_flags}
 	-D BOARD_SEEED_XIAO_ESP32C3
 	-D PNG_MAX_BUFFERED_PIXELS=6432

--- a/scripts/prepare_release.sh
+++ b/scripts/prepare_release.sh
@@ -2,16 +2,47 @@
 
 set -e
 
+TRMNL_ENVS=(
+    trmnl
+    trmnl_4clr
+    TRMNL_X
+)
+
+BYOD_ENVS=(
+    seeed_xiao_esp32c3
+    xteink_x4
+    TRMNL_7inch5_OG_DIY_Kit
+    seeed_reTerminal_E1001
+    seeed_reTerminal_E1002
+    TRMNL_X_E1003
+)
+
+CONFIG="include/config.h"
 FORCE=0
+ENV_INPUT=()
+ENVS=()
+
 for arg in "$@"; do
     case "$arg" in
         --force|-f) FORCE=1 ;;
-        *) echo "Unknown option: $arg"; echo "Usage: $0 [--force]"; exit 1 ;;
+        --help) echo "Usage: $0 [--force] [trmnl] [byod] [env1] [env2] [...]"; exit 0 ;;
+        *) ENV_INPUT+=("$arg") ;;
     esac
 done
 
-ENVS=(trmnl trmnl_4clr TRMNL_X)
-CONFIG="include/config.h"
+# expand "trmnl" and "byod" to multiple environments
+for i in "${!ENV_INPUT[@]}"; do
+    case "${ENV_INPUT[$i]}" in
+        trmnl) ENVS+=("${TRMNL_ENVS[@]}") ;;
+        byod) ENVS+=("${BYOD_ENVS[@]}") ;;
+        *) ENVS+=("${ENV_INPUT[$i]}") ;;
+    esac
+done
+
+# default to TRMNL_ENVS if blank
+if [ ${#ENVS[@]} -eq 0 ]; then
+    ENVS=("${TRMNL_ENVS[@]}")
+fi
 
 if [ ! -f "$CONFIG" ]; then
     echo "Error: $CONFIG not found. Run from the firmware repo root."


### PR DESCRIPTION
Usage examples:

```sh
./scripts/prepare_release.sh # -> TRMNL devices only
./scripts/prepare_release.sh trmnl # -> TRMNL devices only
./scripts/prepare_release.sh byod # -> BYOD devices only
./scripts/prepare_release.sh trmnl byod # -> TRMNL and BYOD devices
./scripts/prepare_release.sh my_special_env # -> single env
```