### PR TITLE
Fixed null WiFi status label for unlisted values

### DIFF
--- a/lib/wificaptive/src/wifi-helpers.cpp
+++ b/lib/wificaptive/src/wifi-helpers.cpp
@@ -24,7 +24,9 @@ const char *wifiStatusStr(wl_status_t wifi_status) {
   for (const WifiStatusNode &entry : wifiStatusMap) {
     if (wifi_status == entry.value) return entry.name;
   }
-  return nullptr;
+  // Callers strncpy this into a fixed-size log field, so it must never be null.
+  // The 3.x core adds status values this table does not list.
+  return "unknown";
 }
 
 void applyWifiHostname(const String &hostname) {


### PR DESCRIPTION
wifiStatusStr returned a null pointer for any wl_status_t missing from its lookup table. Callers pass the result straight to strncpy, which cannot take null. The 3.x Arduino core used by the X builds has WL_STOPPED, which the table does not list.

- returns "unknown" instead of null for unlisted values

Verified with pio run -e trmnl.