### PR TITLE
Add TRMNL_X CI matrix with isolated OG/X PlatformIO build jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,15 @@
+# CI for trmnl-firmware
+#
+# Two independent build families (do not mix in one job — different PlatformIO
+# platforms thrash shared packages: espressif32@6.12 / IDF 4.4 vs pioarduino
+# 55.03.37 / IDF 5.5):
+#
+#   build-og  — TRMNL OG + native tests + clang-tidy (multi-OS)
+#   build-x   — TRMNL X production path (Ubuntu, always on PR/push)
+#   build-x-extended — additional X-class envs (main/tags/manual only)
+#
+# Publish workflows wait for both OG and the required X gate.
+
 name: build
 
 on:
@@ -5,10 +17,27 @@ on:
     branches: ["main"]
     tags: ["**"]
   pull_request:
+  # Weekly full X-class board matrix (optional partner/DIY envs)
+  schedule:
+    - cron: "17 6 * * 1" # Mondays 06:17 UTC
   workflow_dispatch:
+    inputs:
+      full_x_matrix:
+        description: "Also build the extended TRMNL X board matrix"
+        type: boolean
+        default: false
+
+# Cancel superseded runs on the same PR/branch
+concurrency:
+  group: build-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  build-test:
+  # ---------------------------------------------------------------------------
+  # OG family: PlatformIO espressif32@6.12, Arduino-as-IDF, ESP32-C3
+  # ---------------------------------------------------------------------------
+  build-og:
+    name: OG (${{ matrix.os }})
     strategy:
       fail-fast: false
       max-parallel: 3
@@ -16,7 +45,6 @@ jobs:
         os: [ubuntu-latest, macos-15, windows-latest]
 
     runs-on: ${{ matrix.os }}
-
     timeout-minutes: 30
 
     steps:
@@ -28,19 +56,23 @@ jobs:
             ~/.cache/pip
             ~/.platformio
             ~/.buildcache
-          key: ${{ runner.os }}-pio-${{ hashFiles('platformio.ini') }}
+          # Isolated from X cache — OG and X must not share a cold restore of
+          # each other's framework-espidf / tool-esptoolpy slots.
+          key: ${{ runner.os }}-pio-og-${{ hashFiles('platformio.ini', 'dependencies.lock.esp32c3') }}
           restore-keys: |
+            ${{ runner.os }}-pio-og-
             ${{ runner.os }}-pio-
 
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1
         with:
-          key: ${{ runner.os }}-ccache-${{ hashFiles('platformio.ini') }}
-          job-summary: "" # disabled
+          key: ${{ runner.os }}-ccache-og-${{ hashFiles('platformio.ini') }}
+          job-summary: ""
 
+      # 3.12: well-tested with PlatformIO; avoids bleeding-edge 3.14 host issues.
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.12"
 
       - uses: maxim-lobanov/setup-xcode@v1
         if: matrix.os == 'macos-15'
@@ -48,17 +80,15 @@ jobs:
           xcode-version: latest-stable
 
       - name: Install PlatformIO Core
-        run: pip install --upgrade platformio
+        run: pip install --upgrade "platformio==6.1.19"
 
       - name: Configure ccache for PlatformIO (Unix)
         if: runner.os != 'Windows'
-        run: |
-          echo "PLATFORMIO_BUILD_CACHE_DIR=$HOME/.buildcache" >> $GITHUB_ENV
-          
+        run: echo "PLATFORMIO_BUILD_CACHE_DIR=$HOME/.buildcache" >> "$GITHUB_ENV"
+
       - name: Configure ccache for PlatformIO (Windows)
         if: runner.os == 'Windows'
-        run: |
-          echo "PLATFORMIO_BUILD_CACHE_DIR=$env:USERPROFILE\.buildcache" >> $env:GITHUB_ENV
+        run: echo "PLATFORMIO_BUILD_CACHE_DIR=$env:USERPROFILE\.buildcache" >> $env:GITHUB_ENV
 
       - name: Display PlatformIO Information
         run: |
@@ -66,25 +96,254 @@ jobs:
           g++ --version
           gcc --version
 
-      - name: build (trmnl)
-        run: pio run -j ${{ runner.os == 'Windows' && '1' || '4' }} -v
+      - name: Install packages (trmnl)
+        run: pio pkg install -e trmnl
 
-      #- name: build (TRMNL_X)
-      #  run: pio run -e TRMNL_X -j ${{ runner.os == 'Windows' && '1' || '4' }} -v
+      - name: Build OG (trmnl)
+        run: pio run -e trmnl -j ${{ runner.os == 'Windows' && '1' || '4' }}
 
-      - name: test
+      - name: Native unit tests
         if: matrix.os != 'windows-latest'
         run: pio test -e native -v
 
-      - name: test (windows)
+      - name: Native unit tests (Windows)
         if: matrix.os == 'windows-latest'
         run: pio test -e native-windows -v
 
-      - name: static analysis
-        run: pio check --skip-packages --fail-on-defect high
+      - name: Static analysis
+        # clang-tidy path is heaviest on Windows; run where toolchains are reliable.
+        if: matrix.os == 'ubuntu-latest'
+        run: pio check -e trmnl --skip-packages --fail-on-defect high
+
+  # ---------------------------------------------------------------------------
+  # X gate: production TRMNL_X (+ dev env). Always required for PR / main / tags.
+  # Ubuntu-only: full multi-OS X matrix is cost-heavy; tools are Linux-first in CI.
+  # ---------------------------------------------------------------------------
+  build-x:
+    name: X (${{ matrix.env }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        # TRMNL_X     — shipping / publish-dev path (BOARD_TRMNL_X, release flags)
+        # TRMNL_X_dev — contributor default from README (DEV_FIRMWARE, serial, etc.)
+        env: [TRMNL_X, TRMNL_X_dev]
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio
+            ~/.buildcache
+          key: ${{ runner.os }}-pio-x55-${{ matrix.env }}-${{ hashFiles('platformio.ini', 'src/idf_component.yml', 'dependencies.lock.esp32s3') }}
+          restore-keys: |
+            ${{ runner.os }}-pio-x55-${{ matrix.env }}-
+            ${{ runner.os }}-pio-x55-
+            ${{ runner.os }}-pio-x-
+
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: ${{ runner.os }}-ccache-x55-${{ matrix.env }}-${{ hashFiles('platformio.ini') }}
+          job-summary: ""
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install PlatformIO + host modules for pioarduino
+        # littlefs / fatfs / intelhex: required by pioarduino builder/main.py and esptool.
+        run: |
+          pip install --upgrade \
+            "platformio==6.1.19" \
+            "littlefs-python>=0.12" \
+            "fatfs-ng>=0.1" \
+            "intelhex>=2.3"
+
+      - name: Configure ccache for PlatformIO
+        run: echo "PLATFORMIO_BUILD_CACHE_DIR=$HOME/.buildcache" >> "$GITHUB_ENV"
+
+      - name: Display PlatformIO Information
+        run: pio system info
+
+      - name: Install packages (${{ matrix.env }})
+        run: pio pkg install -e ${{ matrix.env }}
+
+      # pioarduino sometimes leaves packages/tool-* as metadata stubs while the
+      # real trees live under ~/.platformio/tools/. Materialize before the build
+      # so cmake/esptool resolution cannot hit empty @src-* stubs.
+      - name: Materialize pioarduino tool packages
+        run: |
+          set -euo pipefail
+          PKG="${HOME}/.platformio/packages"
+          TOOLS="${HOME}/.platformio/tools"
+          materialize() {
+            local name="$1"
+            local src="${TOOLS}/${name}"
+            local dst="${PKG}/${name}"
+            if [[ -d "$src" ]]; then
+              if [[ ! -d "$dst" ]] \
+                || { [[ "$name" == "tool-cmake" ]] && [[ ! -x "${dst}/bin/cmake" ]]; } \
+                || { [[ "$name" == "tool-esptoolpy" ]] && [[ ! -f "${dst}/setup.py" && ! -f "${dst}/pyproject.toml" ]]; } \
+                || { [[ "$name" == "tool-ninja" ]] && [[ ! -x "${dst}/ninja" && ! -x "${dst}/bin/ninja" ]]; }; then
+                echo "Materializing ${name} from tools/ -> packages/"
+                rm -rf "$dst"
+                cp -a "$src" "$dst"
+              fi
+            fi
+          }
+          # Drop incomplete versioned stubs that break resolution
+          find "$PKG" -maxdepth 1 -type d \( \
+            -name 'tool-esptoolpy@src-*' -o \
+            -name 'tool-cmake@src-*' -o \
+            -name 'tool-ninja@src-*' \
+          \) -exec rm -rf {} + 2>/dev/null || true
+          materialize tool-esptoolpy
+          materialize tool-cmake
+          materialize tool-ninja
+          materialize tool-esp-rom-elfs
+          test -x "${PKG}/tool-cmake/bin/cmake"
+          test -f "${PKG}/tool-esptoolpy/setup.py" -o -f "${PKG}/tool-esptoolpy/pyproject.toml"
+          echo "pioarduino tools OK"
+
+      - name: Build ${{ matrix.env }}
+        run: pio run -e ${{ matrix.env }} -j 4
+
+      - name: Upload firmware artifacts
+        if: success()
+        uses: actions/upload-artifact@v7
+        with:
+          name: firmware-x-${{ matrix.env }}
+          path: |
+            .pio/build/${{ matrix.env }}/firmware.bin
+            .pio/build/${{ matrix.env }}/merged_firmware.bin
+          if-no-files-found: warn
+          retention-days: 14
+
+  # ---------------------------------------------------------------------------
+  # Extended X-class matrix: partner / DIY / gen2 boards.
+  # Not a merge gate — runs on tags, weekly schedule, or manual full_x_matrix.
+  # ---------------------------------------------------------------------------
+  build-x-extended:
+    name: X ext (${{ matrix.env }})
+    if: (github.event_name == 'workflow_dispatch' && inputs.full_x_matrix) || github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    timeout-minutes: 50
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        include:
+          # Same platform zip as TRMNL_X (55.03.37) — different boards/flags
+          - { env: TRMNL_X_E1003, platform_family: "55" }
+          - { env: TRMNL_X_SENSORIAS3, platform_family: "55" }
+          - { env: TRMNL_X_SENSORIAC5, platform_family: "55" }
+          - { env: trmnl_gen2, platform_family: "55" }
+          # Older pioarduino 53.03.13 DIY / partner boards
+          - { env: TRMNL_X_EPDIY, platform_family: "53" }
+          - { env: TRMNL_X_LILYGO_T5PRO, platform_family: "53" }
+          - { env: TRMNL_X_PAPERS3, platform_family: "53" }
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio
+            ~/.buildcache
+          key: ${{ runner.os }}-pio-x${{ matrix.platform_family }}-${{ matrix.env }}-${{ hashFiles('platformio.ini', 'src/idf_component.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-pio-x${{ matrix.platform_family }}-${{ matrix.env }}-
+            ${{ runner.os }}-pio-x${{ matrix.platform_family }}-
+
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: ${{ runner.os }}-ccache-x${{ matrix.platform_family }}-${{ matrix.env }}
+          job-summary: ""
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install PlatformIO + host modules for pioarduino
+        run: |
+          pip install --upgrade \
+            "platformio==6.1.19" \
+            "littlefs-python>=0.12" \
+            "fatfs-ng>=0.1" \
+            "intelhex>=2.3"
+
+      - name: Configure ccache for PlatformIO
+        run: echo "PLATFORMIO_BUILD_CACHE_DIR=$HOME/.buildcache" >> "$GITHUB_ENV"
+
+      - name: Install packages (${{ matrix.env }})
+        run: pio pkg install -e ${{ matrix.env }}
+
+      - name: Materialize pioarduino tool packages
+        run: |
+          set -euo pipefail
+          PKG="${HOME}/.platformio/packages"
+          TOOLS="${HOME}/.platformio/tools"
+          materialize() {
+            local name="$1"
+            local src="${TOOLS}/${name}"
+            local dst="${PKG}/${name}"
+            if [[ -d "$src" ]]; then
+              if [[ ! -d "$dst" ]] \
+                || { [[ "$name" == "tool-cmake" ]] && [[ ! -x "${dst}/bin/cmake" ]]; } \
+                || { [[ "$name" == "tool-esptoolpy" ]] && [[ ! -f "${dst}/setup.py" && ! -f "${dst}/pyproject.toml" ]]; } \
+                || { [[ "$name" == "tool-ninja" ]] && [[ ! -x "${dst}/ninja" && ! -x "${dst}/bin/ninja" ]]; }; then
+                echo "Materializing ${name}"
+                rm -rf "$dst"
+                cp -a "$src" "$dst"
+              fi
+            fi
+          }
+          find "$PKG" -maxdepth 1 -type d \( \
+            -name 'tool-esptoolpy@src-*' -o \
+            -name 'tool-cmake@src-*' -o \
+            -name 'tool-ninja@src-*' \
+          \) -exec rm -rf {} + 2>/dev/null || true
+          materialize tool-esptoolpy
+          materialize tool-cmake
+          materialize tool-ninja
+          materialize tool-esp-rom-elfs
+
+      - name: Build ${{ matrix.env }}
+        run: pio run -e ${{ matrix.env }} -j 4
+
+  # Aggregate gate so publish only needs one `needs` entry for required checks.
+  ci-success:
+    name: CI success
+    if: always()
+    needs: [build-og, build-x]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check required jobs
+        run: |
+          echo "build-og: ${{ needs.build-og.result }}"
+          echo "build-x:  ${{ needs.build-x.result }}"
+          if [[ "${{ needs.build-og.result }}" != "success" ]]; then
+            echo "OG build failed"
+            exit 1
+          fi
+          if [[ "${{ needs.build-x.result }}" != "success" ]]; then
+            echo "X build failed"
+            exit 1
+          fi
+          echo "Required CI jobs passed"
+          # Extended matrix is informative; failures do not block merge/publish.
+          # (GitHub still shows build-x-extended status on main.)
 
   publish-engineering-build:
-    needs: build-test
+    needs: [ci-success]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     uses: ./.github/workflows/publish-firmware.yml
     with:
@@ -92,7 +351,7 @@ jobs:
       filename_suffix_type: git_short_hash
 
   publish-tagged-build:
-    needs: build-test
+    needs: [ci-success]
     if: startsWith(github.ref, 'refs/tags/')
     uses: ./.github/workflows/publish-firmware.yml
     with:
@@ -100,7 +359,7 @@ jobs:
       filename_suffix_type: git_tag
 
   publish-dev-builds:
-    needs: build-test
+    needs: [ci-success]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     uses: ./.github/workflows/publish-dev-firmware.yml
     secrets: inherit

--- a/.github/workflows/publish-dev-firmware.yml
+++ b/.github/workflows/publish-dev-firmware.yml
@@ -26,15 +26,51 @@ jobs:
         with:
           path: |
             ~/.cache/pip
-            ~/.platformio/.cache
-          key: ${{ runner.os }}-pio
+            ~/.platformio
+          # Per-env caches avoid OG (espressif32@6.12) thrashing X (pioarduino 55.x).
+          key: ${{ runner.os }}-pio-dev-${{ matrix.env }}-${{ hashFiles('platformio.ini', 'src/idf_component.yml', 'dependencies.lock.esp32s3', 'dependencies.lock.esp32c3') }}
+          restore-keys: |
+            ${{ runner.os }}-pio-dev-${{ matrix.env }}-
+            ${{ runner.os }}-pio-dev-
 
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.x"
+          python-version: "3.12"
 
-      - name: Install PlatformIO Core
-        run: pip install --upgrade platformio esptool
+      - name: Install PlatformIO Core and host deps
+        # littlefs/fatfs/intelhex required for pioarduino (TRMNL_X) builder scripts.
+        run: |
+          pip install --upgrade \
+            "platformio==6.1.19" \
+            esptool \
+            "littlefs-python>=0.12" \
+            "fatfs-ng>=0.1" \
+            "intelhex>=2.3"
+
+      - name: Install packages (${{ matrix.env }})
+        run: pio pkg install -e ${{ matrix.env }}
+
+      - name: Materialize pioarduino tools (X envs)
+        if: matrix.env == 'TRMNL_X'
+        run: |
+          set -euo pipefail
+          PKG="${HOME}/.platformio/packages"
+          TOOLS="${HOME}/.platformio/tools"
+          for name in tool-esptoolpy tool-cmake tool-ninja tool-esp-rom-elfs; do
+            src="${TOOLS}/${name}"
+            dst="${PKG}/${name}"
+            [[ -d "$src" ]] || continue
+            if [[ ! -d "$dst" ]] \
+              || { [[ "$name" == "tool-cmake" ]] && [[ ! -x "${dst}/bin/cmake" ]]; } \
+              || { [[ "$name" == "tool-esptoolpy" ]] && [[ ! -f "${dst}/setup.py" && ! -f "${dst}/pyproject.toml" ]]; }; then
+              echo "Materializing ${name}"
+              rm -rf "$dst"
+              cp -a "$src" "$dst"
+            fi
+          done
+          find "$PKG" -maxdepth 1 -type d \( \
+            -name 'tool-esptoolpy@src-*' -o -name 'tool-cmake@src-*' -o -name 'tool-ninja@src-*' \
+          \) -exec rm -rf {} + 2>/dev/null || true
 
       - name: Build dev firmware (${{ matrix.env }})
         env:

--- a/.github/workflows/publish-firmware.yml
+++ b/.github/workflows/publish-firmware.yml
@@ -29,10 +29,13 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.x"
+          python-version: "3.12"
 
       - name: Install PlatformIO Core
-        run: pip install --upgrade platformio
+        run: pip install --upgrade "platformio==6.1.19"
+
+      - name: Install packages (trmnl)
+        run: pio pkg install -e trmnl
 
       - name: Build release firmware
         env:


### PR DESCRIPTION
Makes **TRMNL_X a first-class CI gate** and stops OG and X from sharing a single PlatformIO install/cache (which corrupts tool packages across `espressif32@6.12` vs pioarduino `55.03.37`).

### Problem

| Before | After |
|--------|--------|
| `pio run` defaulted to **OG only** (`trmnl`) | **OG** and **X** build in separate jobs |
| `TRMNL_X` step was **commented out** | **`TRMNL_X` + `TRMNL_X_dev` always run** on PR/push |
| Shared `~/.platformio` cache across stacks | **Isolated cache keys** (`pio-og-*` vs `pio-x55-*` / `pio-x53-*`) |
| X only validated at **publish-dev on main** | X must pass before publish via **`ci-success`** |
| Host missing `littlefs` / `intelhex` for pioarduino | Explicit host deps + **tool materialize** step |

### Job graph

```text
PR / push / tag
├── build-og (ubuntu, macos-15, windows)
│     trmnl · native tests · clang-tidy (ubuntu)
├── build-x (ubuntu × {TRMNL_X, TRMNL_X_dev})   ← merge gate
├── build-x-extended (optional, non-blocking)
│     tags · weekly cron · workflow_dispatch full_x_matrix
└── ci-success  needs: [build-og, build-x]
      └── publish-* (main/tags only, unchanged intent)
```

### Required X matrix (always)

| Env | Role |
|-----|------|
| `TRMNL_X` | Production / `publish-dev` path |
| `TRMNL_X_dev` | README contributor path (`DEV_FIRMWARE`, serial wait, etc.) |

### Extended X matrix (not required for merge)

| Env | Platform family |
|-----|-----------------|
| `TRMNL_X_E1003`, `TRMNL_X_SENSORIAS3`, `TRMNL_X_SENSORIAC5`, `trmnl_gen2` | pioarduino **55.03.37** |
| `TRMNL_X_EPDIY`, `TRMNL_X_LILYGO_T5PRO`, `TRMNL_X_PAPERS3` | pioarduino **53.03.13** |

Triggers: **tags**, **weekly** (`17 6 * * 1` UTC), or **Actions → build → Run workflow** with `full_x_matrix: true`.

### Hardening (X + publish-dev)

- Python **3.12**, `platformio==6.1.19`
- `littlefs-python`, `fatfs-ng`, `intelhex`
- Materialize full `tool-cmake` / `tool-esptoolpy` / `tool-ninja` from `~/.platformio/tools` into `packages/` and drop empty `@src-*` stubs
- Upload `firmware.bin` + `merged_firmware.bin` for X gate jobs (14-day artifacts)

### Files

- `.github/workflows/build.yml` - rewrite
- `.github/workflows/publish-dev-firmware.yml` - Python/deps/cache/materialize for X
- `.github/workflows/publish-firmware.yml` - Python 3.12 + `pio pkg install` for OG release

---

## ⚠️ Branch protection & required checks (action required)

The old required job name was effectively **`build-test`** (single matrix job). That job **no longer exists**.

If GitHub branch protection (or rulesets) still requires **`build-test`**, PRs will show a **stuck/missing required check** even when CI is green.

### Recommended (simplest)

In the default branch protection / ruleset, **remove** required check:

- ~~`build-test`~~

**Add** required check:

- **`CI success`**

`CI success` only passes when both **`build-og`** and **`build-x`** succeed. Extended X failures do **not** fail this gate.

### Alternative (granular)

Require these check names (as shown in the PR checks UI):

| Check name pattern | Purpose |
|--------------------|---------|
| `OG (ubuntu-latest)` | OG Linux build + tests + clang-tidy |
| `OG (macos-15)` | optional if you want multi-OS required |
| `OG (windows-latest)` | optional |
| `X (TRMNL_X)` | production X |
| `X (TRMNL_X_dev)` | dev X |

Prefer requiring **Ubuntu OG + both X jobs**, and leave macOS/Windows OG as non-required if you want faster merge gates.

### Do **not** require

- `X ext (*)` / `build-x-extended` - informational only  
- Old name **`build-test`** - removed  

### How to update (UI)

1. Repo → **Settings** → **Branches** (or **Rules** → rulesets)  
2. Rule for `main` (and any release branches)  
3. **Status checks that are required**  
4. Remove `build-test`  
5. Add `CI success` (after this PR has run once so the check name exists)  
6. Save  

### How to update (`gh`, if you use classic branch protection)

```bash
# Inspect current required contexts
gh api repos/{owner}/{repo}/branches/main/protection/required_status_checks

# Example: set required checks to the new aggregate gate
# (adjust owner/repo; may need admin scope)
gh api -X PATCH repos/{owner}/{repo}/branches/main/protection/required_status_checks \
  -f strict=true \
  -f 'contexts[]=CI success'
```

> Note: classic branch protection APIs differ from rulesets. Use the UI if the repo uses **rulesets**.

### After merge checklist

- [ ] Open a test PR and confirm checks appear as `OG (…)`, `X (TRMNL_X)`, `X (TRMNL_X_dev)`, `CI success`
- [ ] Confirm **`build-test` is gone** from the checks list
- [ ] Update branch protection / ruleset required checks
- [ ] Confirm `publish-dev` still runs on `main` push after `CI success`
- [ ] Optional: **Actions → build → Run workflow** with `full_x_matrix: true` to smoke the extended matrix

---

## Test plan

- [x] Workflow YAML loads (jobs: `build-og`, `build-x`, `build-x-extended`, `ci-success`, publish hooks)
- [ ] PR run: OG multi-OS + X matrix green; `CI success` green
- [ ] Confirm publish jobs did **not** run on the PR
- [ ] On `main` after merge: `publish-dev` builds `trmnl` / `TRMNL_X` / `trmnl_4clr`
- [ ] Manual `full_x_matrix` or wait for weekly cron for extended boards
- [ ] Branch protection no longer references `build-test`

## Risk / cost

- **PR wall time**: +2 Ubuntu X builds (mitigated by ccache + per-env PIO caches)
- **Minutes**: higher than OG-only CI; extended matrix limited to weekly/tags/manual to control cost
- **First X run** may be slow (cold toolchain download); subsequent runs should cache