### PR TITLE
Document OG/BWRY vs X builds and add pio-trmnl-switch helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,28 +239,63 @@ There are technical and non-technical options to flashing firmware.
 
 
 ### **Via CLI**
-1. To build the binary run `pio run -e TRMNL_X_dev`
-2. To upload the binary to the device `pio run -e TRMNL_X_dev -t upload`
-3. If PlatformIO uses the wrong port use this
+
+Prefer PlatformIO from the official installer so `pio` uses `~/.platformio/penv` (not a system Python 3.14-only install).
+
+**TRMNL X** (ESP32-S3 class, pioarduino / ESP-IDF 5.x):
+
 ```bash
-pio device list # make sure JTAG device is visible
-pio run -e TRMNL_X_dev -t upload --upload-port /dev/cu.usbmodem1234
-```
-4. view serial monitor by
-```bash
+./scripts/pio-trmnl-switch x          # prepare X tool packages
+pio run -e TRMNL_X_dev
+pio run -e TRMNL_X_dev -t upload
 pio device monitor -e TRMNL_X_dev
+```
+
+**TRMNL OG** (mono / 1-bit, ESP32-C3, PlatformIO `espressif32@6.12` / ESP-IDF 4.4):
+
+```bash
+./scripts/pio-trmnl-switch og
+pio run -e trmnl
 pio device monitor -e trmnl
 ```
 
-When switching between TRMNL X and OG/BWRY, run `pio pkg install` once for the environment you are about to build (use the same `-e` value as `pio run`):
+**TRMNL BWRY** (4-color): same **PlatformIO family as OG**, different env and board define (`trmnl_4clr` / `BOARD_TRMNL_4CLR`). BWRY is not a third toolchain.
 
 ```bash
-pio pkg install -e TRMNL_X_dev   # TRMNL X
-pio pkg install -e trmnl         # TRMNL OG
-pio pkg install -e trmnl_4clr    # TRMNL BWRY
+./scripts/pio-trmnl-switch bwry       # same family as og
+pio run -e trmnl_4clr
 ```
 
-If you skip this step, the build may fail with `Error: Missing Arduino framework directory 'None'`.
+If PlatformIO picks the wrong serial port:
+
+```bash
+pio device list
+pio run -e TRMNL_X_dev -t upload --upload-port /dev/cu.usbmodem1234
+```
+
+#### Switching between X and OG/BWRY
+
+OG and BWRY share one tool stack; **X uses another**. Those stacks install into the same `~/.platformio/packages/*` names (ESP-IDF, Arduino core, esptool, cmake). Building both families without cleanup often fails with missing Arduino/IDF paths, broken `tool-cmake@src-*` stubs, or esptool “not a Python project” errors.
+
+**Always run the switch script when changing family**, then build:
+
+```bash
+./scripts/pio-trmnl-switch x     && pio run -e TRMNL_X_dev   # or TRMNL_X
+./scripts/pio-trmnl-switch og    && pio run -e trmnl         # OG mono
+./scripts/pio-trmnl-switch bwry  && pio run -e trmnl_4clr    # BWRY (og family)
+```
+
+Minimal alternative (same family only, or after a clean PlatformIO install):
+
+```bash
+pio pkg install -e TRMNL_X_dev   # X
+pio pkg install -e trmnl         # OG
+pio pkg install -e trmnl_4clr    # BWRY
+```
+
+If you skip package install after a family switch, you may see `Error: Missing Arduino framework directory 'None'`.
+
+Full environment tables, failure checklist, and CI notes: **[docs/building-og-x.md](docs/building-og-x.md)**.
 
 
 ### **Using VSCode plugin**

--- a/docs/building-og-x.md
+++ b/docs/building-og-x.md
@@ -1,0 +1,237 @@
+# Building TRMNL firmware: OG, BWRY, and X
+
+This guide explains how to build the different TRMNL products from this repository, why **switching** between some of them requires an extra step, and how `scripts/pio-trmnl-switch` helps.
+
+## Does “OG” include BWRY?
+
+**Product-wise:** no. **OG** usually means the original mono / 1-bit TRMNL (ESP32-C3). **BWRY** is the four-color (black/white/red/yellow) variant, built as a **separate PlatformIO environment** (`trmnl_4clr`).
+
+**Toolchain-wise:** **yes — BWRY is in the same PlatformIO family as OG.**
+
+| Product | PlatformIO env | `BOARD_*` | PlatformIO family |
+|---------|----------------|-----------|-------------------|
+| TRMNL OG (mono) | `trmnl` (default) | `BOARD_TRMNL` | **og** |
+| TRMNL BWRY (4-color) | `trmnl_4clr` | `BOARD_TRMNL_4CLR` | **og** |
+| TRMNL X | `TRMNL_X` / `TRMNL_X_dev` | `BOARD_TRMNL_X` | **x** |
+
+BWRY shares the OG stack: PlatformIO registry `espressif32@6.12`, Arduino-as-ESP-IDF component, ESP-IDF **4.4.x**, ESP32-C3-class flow. It does **not** use the pioarduino / IDF 5.x stack that TRMNL X uses.
+
+So when documentation says “switch between **X** and **OG/BWRY**”, it means:
+
+- **One side:** X (and other **x-family** envs)
+- **Other side:** OG **or** BWRY (and other **og-family** envs)
+
+You do **not** need a special “BWRY stack switch” when moving between `trmnl` and `trmnl_4clr` — only a normal `pio pkg install -e …` if packages are missing. You **do** need a family switch when moving between BWRY and X (same as OG ↔ X).
+
+```text
+                    PlatformIO families
+  ┌─────────────────────────────────────────────────────────┐
+  │  og family (espressif32@6.12, IDF ~4.4)                 │
+  │    trmnl          ← OG mono                             │
+  │    trmnl_4clr     ← BWRY (same family as OG)            │
+  │    local, trmnl_test, many DIY / Seeed envs             │
+  └─────────────────────────────────────────────────────────┘
+                         ↕  thrash shared package names
+  ┌─────────────────────────────────────────────────────────┐
+  │  x family (pioarduino 53/55, IDF ~5.x)                  │
+  │    TRMNL_X, TRMNL_X_dev, TRMNL_X_E1003, …               │
+  │    trmnl_gen2, Sensoria, EPDIY / LilyGO / PaperS3, …    │
+  └─────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Why switching is required
+
+OG/BWRY and X both install packages under `~/.platformio/packages` with **the same directory names**, for example:
+
+| Package slot | OG / BWRY (typical) | X (typical) |
+|--------------|---------------------|-------------|
+| `framework-espidf` | ESP-IDF **4.4.x** | ESP-IDF **5.5.x** |
+| `framework-arduinoespressif32` | Arduino-ESP32 **2.0.x** line | Arduino-ESP32 **3.3.x** |
+| `tool-esptoolpy` | esptool **2.x / 4.9** packaging | esptool **5.x** |
+| `tool-cmake` / `tool-ninja` | PlatformIO registry builds | pioarduino builds |
+
+If you build OG, then X (or the reverse) without cleanup, PlatformIO may:
+
+1. Leave the **wrong** IDF/Arduino tree in the shared slot → `Missing Arduino framework directory 'None'` or obscure CMake errors  
+2. Leave **empty stubs** such as `tool-cmake@src-…` / `tool-esptoolpy@src-…` (metadata only) →  
+   - `FileNotFoundError: .../tool-cmake@src-.../bin/cmake`  
+   - `does not appear to be a Python project` (esptool)
+
+`scripts/pio-trmnl-switch` clears those shared slots, reinstalls packages for the target env, and for **x** materializes full tool trees from `~/.platformio/tools` into `packages/` when pioarduino only dropped stubs.
+
+---
+
+## Prerequisites
+
+1. **PlatformIO Core** on `PATH`, ideally from the official installer’s penv:
+
+   ```bash
+   # Good (isolated Python 3.11 tooling)
+   export PATH="$HOME/.platformio/penv/bin:$PATH"
+   pio --version
+   ```
+
+   Avoid installing PlatformIO only with **system Python 3.14** `pip`: the pioarduino builder imports host modules (`littlefs`, `fatfs`, `intelhex`) that live in penv, not in a bare 3.14 site-packages.
+
+2. Optional host modules (usually already in penv after an X install):
+
+   ```bash
+   pip install 'littlefs-python>=0.12' 'fatfs-ng>=0.1' 'intelhex>=2.3'
+   ```
+
+3. Run commands from the **repository root** (where `platformio.ini` lives).
+
+---
+
+## Quick start
+
+### TRMNL X (README default for X hardware)
+
+```bash
+./scripts/pio-trmnl-switch x          # alias → TRMNL_X_dev
+pio run -e TRMNL_X_dev
+pio run -e TRMNL_X_dev -t upload
+pio device monitor -e TRMNL_X_dev
+```
+
+Production X image (what CI / publish-dev use):
+
+```bash
+./scripts/pio-trmnl-switch TRMNL_X
+pio run -e TRMNL_X
+```
+
+### TRMNL OG (mono)
+
+```bash
+./scripts/pio-trmnl-switch og         # alias → trmnl
+pio run -e trmnl
+pio run -e trmnl -t upload
+pio device monitor -e trmnl
+```
+
+### TRMNL BWRY (4-color) — same family as OG
+
+```bash
+./scripts/pio-trmnl-switch bwry       # alias → trmnl_4clr
+pio run -e trmnl_4clr
+```
+
+Switching **OG ↔ BWRY** does not need the heavy purge if you never built X in between; the script still does a clean `pkg install` for the target env, which is safe.
+
+### After building X, build OG or BWRY again
+
+```bash
+./scripts/pio-trmnl-switch og         # or: bwry
+pio run -e trmnl                      # or: -e trmnl_4clr
+```
+
+### Arbitrary env name
+
+```bash
+./scripts/pio-trmnl-switch TRMNL_X_E1003
+./scripts/pio-trmnl-switch local
+./scripts/pio-trmnl-switch seeed_reTerminal_E1001
+```
+
+Family is inferred from the env name / `platformio.ini` (`pioarduino` → **x**, otherwise **og**).
+
+---
+
+## Environment cheat sheet
+
+### og family (`platform = espressif32@6.12` via `[env]`)
+
+| Env | Product / role |
+|-----|----------------|
+| `trmnl` | **OG mono** (default `default_envs`) |
+| `trmnl_4clr` | **BWRY** 4-color |
+| `local` | OG with USB serial / dev flags |
+| `trmnl_test` | OG on-device Unity tests |
+| `xteink_x4`, Seeed DIY kits, Waveshare, … | Community / DIY on OG stack |
+
+### x family (pioarduino URL in the env)
+
+| Env | Product / role |
+|-----|----------------|
+| `TRMNL_X` | X production flags |
+| `TRMNL_X_dev` | X developer flags (serial wait, dev firmware, …) |
+| `TRMNL_X_dev_no_qa` | X dev without QA |
+| `TRMNL_X_E1003`, `TRMNL_X_SENSORIA*`, … | Partner / Sensoria boards |
+| `TRMNL_X_EPDIY`, `TRMNL_X_LILYGO_T5PRO`, `TRMNL_X_PAPERS3` | pioarduino **53.03.13** variant |
+| `trmnl_gen2` | Gen2 (ESP32-C5), x-family tools |
+
+### Neither (host)
+
+| Env | Role |
+|-----|------|
+| `native` / `native-windows` | Unit tests on the host (no ESP flash tools thrash) |
+
+---
+
+## What the switch script does
+
+1. Resolves alias → PlatformIO env + family (**og** or **x**).  
+2. Deletes incomplete `tool-*@src-*` stubs and clears shared unversioned packages (`framework-espidf`, `tool-esptoolpy`, …).  
+3. Removes `.pio/build/<env>` for that env (stale absolute paths / cert embeds).  
+4. For **x**: clears `managed_components/` and root `dependencies.lock` so the component manager can re-fetch for the target.  
+5. Runs `pio pkg install -e <env>`.  
+6. For **x**: materializes full `tool-cmake` / `tool-esptoolpy` / `tool-ninja` / `tool-esp-rom-elfs` from `~/.platformio/tools` if `packages/` is still a stub; links IDF 5.x into `framework-espidf` when needed.  
+7. Prints ready-to-run `pio run` / upload / monitor commands.
+
+It does **not** flash a device and does **not** change `platformio.ini`.
+
+---
+
+## Minimal alternative (without the script)
+
+If you only ever build one family, the classic README flow is enough:
+
+```bash
+pio pkg install -e TRMNL_X_dev   # once per machine / after switching families
+pio run -e TRMNL_X_dev
+```
+
+```bash
+pio pkg install -e trmnl
+# or
+pio pkg install -e trmnl_4clr
+pio run -e trmnl   # or trmnl_4clr
+```
+
+If you switch families often, prefer `./scripts/pio-trmnl-switch` over bare `pkg install` so stubs and wrong IDF trees are cleared.
+
+---
+
+## Common failures
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| `Missing Arduino framework directory 'None'` | Wrong/missing Arduino package after family switch | `./scripts/pio-trmnl-switch <target>` then rebuild |
+| `No module named 'littlefs'` | `pio` running under system Python without host deps | Use `~/.platformio/penv/bin/pio`; install `littlefs-python` |
+| `tool-cmake@src-.../bin/cmake` not found | Empty pioarduino stub package | Switch script materialize step, or re-run `./scripts/pio-trmnl-switch x` |
+| `does not appear to be a Python project` (esptool) | Stub `tool-esptoolpy@src-*` | Same as above |
+| RainMaker `Warning! Could not find file "*.crt"` early in X build | `managed_components` not fetched yet | Usually non-fatal; first configure fetches components |
+| BWRY build after X fails in obscure CMake ways | Shared `framework-espidf` still IDF 5.x | `./scripts/pio-trmnl-switch bwry` (or `og`) |
+
+---
+
+## CI note
+
+GitHub Actions builds **og** and **x** in **separate jobs** with separate caches so they never thrash each other. Locally you only have one `~/.platformio`; that is why the switch script exists for developers.
+
+See `.github/workflows/build.yml`: `build-og` vs `build-x`.
+
+---
+
+## Related paths
+
+| Path | Purpose |
+|------|---------|
+| `scripts/pio-trmnl-switch` | Family switch + `pkg install` |
+| `platformio.ini` | All envs, platforms, board flags |
+| `sdkconfigs/` | Per-target ESP-IDF sdkconfig for hybrid Arduino+IDF envs |
+| `dependencies.lock.esp32c3` | Component lock for OG-class targets |
+| `dependencies.lock.esp32s3` | Component lock for many X-class targets |

--- a/scripts/pio-trmnl-switch
+++ b/scripts/pio-trmnl-switch
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# Prepare PlatformIO packages for a TRMNL firmware environment family.
+#
+# Two PlatformIO *families* share package names under ~/.platformio/packages
+# (framework-espidf, tool-esptoolpy, tool-cmake, …). Switching without cleanup
+# thrashs IDF 4.4 ↔ 5.5 and esptool 2.x ↔ 5.x, and can leave empty
+# packages/tool-*@src-* stubs (broken cmake / esptool).
+#
+# Families
+#   og  — PlatformIO registry espressif32@6.12, Arduino-as-IDF, ESP-IDF ~4.4
+#         Includes: TRMNL OG (mono), TRMNL BWRY (4-color), DIY/Seeed envs that
+#         inherit [env] platform, plus native tests (no firmware toolchain).
+#   x   — pioarduino platform-espressif32 (53.x / 55.x), ESP-IDF ~5.x
+#         Includes: TRMNL_X*, TRMNL_X_dev, gen2, Sensoria, partner boards, …
+#
+# Usage (from repository root):
+#   ./scripts/pio-trmnl-switch og                 # prep default OG env (trmnl)
+#   ./scripts/pio-trmnl-switch bwry               # prep BWRY (trmnl_4clr) — OG family
+#   ./scripts/pio-trmnl-switch x                  # prep default X env (TRMNL_X_dev)
+#   ./scripts/pio-trmnl-switch TRMNL_X            # prep production X env by name
+#   ./scripts/pio-trmnl-switch og && pio run -e trmnl
+#   ./scripts/pio-trmnl-switch bwry && pio run -e trmnl_4clr
+#   ./scripts/pio-trmnl-switch x && pio run -e TRMNL_X_dev
+#
+# See docs/building-og-x.md for the full guide.
+set -euo pipefail
+
+# Prefer PlatformIO's isolated penv when present (Python 3.11 tooling).
+if [[ -x "${HOME}/.platformio/penv/bin/pio" ]]; then
+  export PATH="${HOME}/.platformio/penv/bin:${PATH}"
+fi
+export PATH="${HOME}/.local/bin:${PATH}"
+
+PKG="${HOME}/.platformio/packages"
+TOOLS="${HOME}/.platformio/tools"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+usage() {
+  cat <<'EOF' >&2
+Usage: ./scripts/pio-trmnl-switch <target>
+
+Targets (aliases):
+  og | trmnl              OG mono  → env trmnl          (family: og)
+  bwry | trmnl_4clr       BWRY     → env trmnl_4clr     (family: og)
+  x | TRMNL_X_dev         X dev    → env TRMNL_X_dev    (family: x)
+  TRMNL_X                 X prod   → env TRMNL_X        (family: x)
+  <platformio env name>   any env in platformio.ini     (family inferred)
+
+BWRY is not a third PlatformIO stack: it uses the same og family as mono OG
+(espressif32@6.12). Only X/gen2/partner envs use the pioarduino (x) family.
+
+Docs: docs/building-og-x.md
+EOF
+  exit 2
+}
+
+TARGET="${1:-}"
+if [[ -z "${TARGET}" || "${TARGET}" == "-h" || "${TARGET}" == "--help" ]]; then
+  usage
+fi
+
+# Incomplete package dirs: metadata only, no real payload.
+is_incomplete_tool_pkg() {
+  local d="$1"
+  [[ -d "$d" ]] || return 1
+  if [[ -x "$d/bin/cmake" ]]; then return 1; fi
+  if [[ -f "$d/setup.py" || -f "$d/pyproject.toml" ]]; then return 1; fi
+  if [[ -x "$d/ninja" || -x "$d/bin/ninja" ]]; then return 1; fi
+  if compgen -G "$d/*.elf" > /dev/null; then return 1; fi
+  if [[ -f "$d/package.json" || -f "$d/tools.json" ]]; then
+    return 0
+  fi
+  return 1
+}
+
+purge_broken_tool_packages() {
+  local d
+  for d in \
+    "$PKG"/tool-esptoolpy@src-* \
+    "$PKG"/tool-cmake@src-* \
+    "$PKG"/tool-ninja@src-* \
+    "$PKG"/tool-esp-rom-elfs@src-*
+  do
+    [[ -e "$d" ]] || continue
+    if is_incomplete_tool_pkg "$d"; then
+      echo "==> Removing incomplete stub: $d"
+      rm -rf "$d"
+    fi
+  done
+
+  # Shared unversioned slots thrash between og (IDF 4.4 / esptool 2.x) and
+  # x (IDF 5.x / esptool 5.x). Clear so the next pkg install is consistent.
+  for d in \
+    "$PKG/tool-esptoolpy" \
+    "$PKG/tool-cmake" \
+    "$PKG/tool-ninja" \
+    "$PKG/tool-esp-rom-elfs" \
+    "$PKG/framework-espidf" \
+    "$PKG/framework-arduinoespressif32"
+  do
+    if [[ -L "$d" ]]; then
+      rm -f "$d"
+    elif [[ -d "$d" ]]; then
+      rm -rf "$d"
+    fi
+  done
+}
+
+# pioarduino may leave packages/ as stubs while tools/ has full trees.
+materialize_pioarduino_tools() {
+  local name src dst
+  for name in tool-esptoolpy tool-cmake tool-ninja tool-esp-rom-elfs; do
+    src="${TOOLS}/${name}"
+    dst="${PKG}/${name}"
+    [[ -d "$src" ]] || continue
+    if [[ ! -d "$dst" ]] || is_incomplete_tool_pkg "$dst"; then
+      echo "==> Materializing ${name} from tools/ into packages/"
+      rm -rf "$dst"
+      cp -a "$src" "$dst"
+    fi
+  done
+
+  if [[ ! -e "$PKG/framework-espidf" ]]; then
+    local idf
+    for idf in "$PKG"/framework-espidf@src-*; do
+      if [[ -d "$idf" ]] && [[ -f "$idf/tools/cmake/version.cmake" ]]; then
+        if grep -q 'IDF_VERSION_MAJOR 5' "$idf/tools/cmake/version.cmake" 2>/dev/null; then
+          ln -s "$(basename "$idf")" "$PKG/framework-espidf"
+          echo "==> Linked framework-espidf -> $(basename "$idf")"
+          break
+        fi
+      fi
+    done
+  fi
+}
+
+infer_family_for_env() {
+  local env_name="$1"
+  # Explicit x-class env names (pioarduino in platformio.ini)
+  case "${env_name}" in
+    TRMNL_X*|trmnl_gen2|seeed_sticky|esp32-c5-devkitc-1)
+      echo x
+      return
+      ;;
+    native|native-windows)
+      # Host unit tests — no ESP tool thrash; treat as og for pkg install only
+      echo og
+      return
+      ;;
+  esac
+  # Heuristic: if platformio.ini assigns pioarduino platform to this env
+  if grep -A 30 "^\[env:${env_name}\]" platformio.ini 2>/dev/null \
+    | grep -q 'pioarduino/platform-espressif32'; then
+    echo x
+    return
+  fi
+  echo og
+}
+
+case "${TARGET}" in
+  x|X|trmnl_x)
+    ENV_NAME="TRMNL_X_dev"
+    FAMILY="x"
+    PRODUCT="TRMNL X (dev)"
+    ;;
+  TRMNL_X)
+    ENV_NAME="TRMNL_X"
+    FAMILY="x"
+    PRODUCT="TRMNL X (production)"
+    ;;
+  og|OG|trmnl|TRMNL)
+    ENV_NAME="trmnl"
+    FAMILY="og"
+    PRODUCT="TRMNL OG (mono / 1-bit)"
+    ;;
+  bwry|BWRY|trmnl_4clr|4clr|BWR)
+    ENV_NAME="trmnl_4clr"
+    FAMILY="og"
+    PRODUCT="TRMNL BWRY (4-color) — OG PlatformIO family"
+    ;;
+  *)
+    ENV_NAME="${TARGET}"
+    FAMILY="$(infer_family_for_env "${ENV_NAME}")"
+    PRODUCT="env ${ENV_NAME}"
+    ;;
+esac
+
+if ! command -v pio >/dev/null 2>&1; then
+  echo "ERROR: pio not on PATH. Install PlatformIO Core, preferably via the" >&2
+  echo "       official installer (~/.platformio/penv), not system Python 3.14 pip." >&2
+  exit 1
+fi
+
+echo "==> Product: ${PRODUCT}"
+echo "==> PlatformIO env: ${ENV_NAME}  family: ${FAMILY}"
+echo "==> Using pio: $(command -v pio) ($(pio --version 2>/dev/null || true))"
+
+purge_broken_tool_packages
+
+if [[ -d ".pio/build/${ENV_NAME}" ]]; then
+  echo "==> Cleaning .pio/build/${ENV_NAME}"
+  rm -rf ".pio/build/${ENV_NAME}"
+fi
+
+if [[ "${FAMILY}" == "x" ]]; then
+  if [[ -d managed_components ]]; then
+    echo "==> Refreshing managed_components for x-family env"
+    rm -rf managed_components
+  fi
+  rm -f dependencies.lock
+fi
+
+echo "==> pio pkg install -e ${ENV_NAME}"
+pio pkg install -e "${ENV_NAME}"
+
+if [[ "${FAMILY}" == "x" ]]; then
+  materialize_pioarduino_tools
+  if [[ ! -x "${PKG}/tool-cmake/bin/cmake" ]]; then
+    echo "ERROR: tool-cmake/bin/cmake still missing after materialize" >&2
+    exit 1
+  fi
+  if [[ ! -f "${PKG}/tool-esptoolpy/setup.py" && ! -f "${PKG}/tool-esptoolpy/pyproject.toml" ]]; then
+    echo "ERROR: tool-esptoolpy is not a pip-installable package tree" >&2
+    exit 1
+  fi
+  echo "==> X tools OK (cmake + esptool package trees)"
+fi
+
+echo "==> Ready."
+echo "    pio run -e ${ENV_NAME}"
+echo "    pio run -e ${ENV_NAME} -t upload"
+echo "    pio device monitor -e ${ENV_NAME}"


### PR DESCRIPTION
## Summary

Documents how to build **OG**, **BWRY**, and **X** from this repo, and adds a versioned helper to switch PlatformIO package state safely between the two tool families.

### Does OG include BWRY?

| Sense | Answer |
|-------|--------|
| **Product** | **No** - OG mono (`trmnl`) vs BWRY 4-colour (`trmnl_4clr`) |
| **PlatformIO family** | **Yes** - both use `espressif32@6.12` / IDF ~4.4 (**og** family) |

BWRY is **not** X and is **not** a third stack. Switch tooling treats:

- **og family:** `trmnl`, `trmnl_4clr` (BWRY), DIY envs on registry platform  
- **x family:** `TRMNL_X*`, `trmnl_gen2`, partner boards on pioarduino  

Family switch is required for **X ↔ OG/BWRY**, not for OG ↔ BWRY alone.

### Problem

OG/BWRY and X install into the same `~/.platformio/packages/*` names with different versions (IDF 4.4 vs 5.x, esptool 2.x vs 5.x, different Arduino cores). Switching without cleanup commonly yields:

- `Error: Missing Arduino framework directory 'None'`
- empty `tool-cmake@src-*` / `tool-esptoolpy@src-*` stubs
- esptool “does not appear to be a Python project”

Bare `pio pkg install` helps but does not clear stubs or materialise pioarduino tools from `~/.platformio/tools`.

### Changes

| Path | What |
|------|------|
| `scripts/pio-trmnl-switch` | Purge shared slots + incomplete `@src-*` stubs; `pio pkg install -e <env>`; for **x**, materialize cmake/esptool/ninja and link IDF 5.x |
| `docs/building-og-x.md` | Full guide: families, BWRY vs OG, commands, env tables, failure matrix, CI note |
| `README.md` | CLI section: OG / BWRY / X flows, switch usage, link to the doc |

**Aliases:** `og` → `trmnl`, `bwry` → `trmnl_4clr`, `x` → `TRMNL_X_dev`, plus any env name with family inference.

### Usage

```bash
./scripts/pio-trmnl-switch x     && pio run -e TRMNL_X_dev
./scripts/pio-trmnl-switch og    && pio run -e trmnl
./scripts/pio-trmnl-switch bwry  && pio run -e trmnl_4clr
```

### Non-goals

- No firmware runtime / board behaviour changes  
- No CI workflow changes (covered by a separate `x-ci` PR if present)  
- Does not replace using `~/.platformio/penv` for a healthy `pio` install  

## Test plan

- [x] `./scripts/pio-trmnl-switch --help` prints aliases and BWRY note  
- [ ] From repo root after X work: `./scripts/pio-trmnl-switch og && pio run -e trmnl`  
- [ ] `./scripts/pio-trmnl-switch bwry && pio run -e trmnl_4clr`  
- [ ] `./scripts/pio-trmnl-switch x && pio run -e TRMNL_X_dev`  
- [ ] README links resolve to `docs/building-og-x.md`  
- [ ] PR diff contains only README + docs + script (no accidental `platformio.ini` / sdkconfig rewrites)

## Related

- Local PlatformIO host issues (penv vs system Python, tool stubs) described in the doc  
- CI isolates og/x jobs so Actions does not need this script; **developers** sharing one `~/.platformio` do