### PR TITLE
Extract readBatteryVoltage() into device-specific class tree

### DIFF
--- a/include/battery.h
+++ b/include/battery.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <stdint.h>
+
+//
+// derive device-specific battery flags
+//
+#if defined(BOARD_TRMNL_X)
+#define INCLUDE_BQ27427
+#endif
+
+/// @brief Abstract battery voltage source.
+class BaseBattery {
+public:
+  virtual ~BaseBattery() = default;
+
+  /// @brief Read the battery voltage.
+  /// @return voltage in Volts, or a negative value if the reading failed
+  virtual float readVoltage() = 0;
+};
+
+/// @brief Reports a fixed 4.2 V on boards with no battery sense hardware
+///        (FAKE_BATTERY_VOLTAGE).
+class FakeBattery : public BaseBattery {
+public:
+  float readVoltage() override;
+};
+
+/// @brief Reads the battery through a 1:2 resistor divider on an ADC pin.
+class ADCBattery : public BaseBattery {
+public:
+  explicit ADCBattery(uint8_t pin);
+  float readVoltage() override;
+
+private:
+  uint8_t _pin;
+};
+
+/// @brief Seeed boards gate the battery divider behind a load switch that must
+///        be enabled before sampling the ADC (and disabled after to save power).
+class SeeedBattery : public ADCBattery {
+public:
+  SeeedBattery(uint8_t pin, uint8_t switchPin, uint8_t switchOnLevel);
+  float readVoltage() override;
+
+private:
+  uint8_t _switchPin;
+  uint8_t _switchOnLevel;
+};
+
+#ifdef INCLUDE_BQ27427
+/// @brief Reads the battery voltage from the BQ27427 fuel gauge.
+class BQ27427Battery : public BaseBattery {
+public:
+  float readVoltage() override;
+};
+#endif // INCLUDE_BQ27427
+
+/// @brief Battery instance for the running board, selected at compile time.
+BaseBattery &battery();

--- a/src/battery/adc_battery.cpp
+++ b/src/battery/adc_battery.cpp
@@ -1,0 +1,18 @@
+#include <Arduino.h>
+#include <ArduinoLog.h>
+#include <battery.h>
+
+ADCBattery::ADCBattery(uint8_t pin) : _pin(pin) {}
+
+float ADCBattery::readVoltage() {
+  Log.info("%s [%d]: Battery voltage reading...\r\n", __FILE__, __LINE__);
+
+  int32_t adc = 0;
+  analogRead(_pin); // This is needed to properly initialize the ADC BEFORE calling analogReadMilliVolts()
+  for (uint8_t i = 0; i < 8; i++) {
+    adc += analogReadMilliVolts(_pin);
+  }
+  int32_t sensorValue = (adc / 8) * 2;
+  Log.info("%s [%d]: Battery sensorValue = %d\r\n", __FILE__, __LINE__, (int)sensorValue);
+  return sensorValue / 1000.0;
+}

--- a/src/battery/battery.cpp
+++ b/src/battery/battery.cpp
@@ -1,0 +1,17 @@
+#include <DEV_Config.h> // defines FAKE_BATTERY_VOLTAGE for some boards
+#include <battery.h>
+#include <config.h>
+
+#if defined(FAKE_BATTERY_VOLTAGE)
+static FakeBattery batteryInstance;
+#elif defined(BOARD_TRMNL_X)
+static BQ27427Battery batteryInstance;
+#elif defined(PIN_VBAT_SWITCH)
+static SeeedBattery batteryInstance(PIN_BATTERY, PIN_VBAT_SWITCH, VBAT_SWITCH_LEVEL);
+#elif defined(PIN_BATTERY)
+static ADCBattery batteryInstance(PIN_BATTERY);
+#else
+static FakeBattery batteryInstance;
+#endif
+
+BaseBattery &battery() { return batteryInstance; }

--- a/src/battery/bq27427_battery.cpp
+++ b/src/battery/bq27427_battery.cpp
@@ -1,0 +1,20 @@
+#include <battery.h>
+
+#ifdef INCLUDE_BQ27427
+
+#include <ArduinoLog.h>
+
+#include "BQ27427.h"
+
+float BQ27427Battery::readVoltage() {
+  if (lipo._initialized) {
+    float voltage = lipo.voltage() / 1000.0; // Convert mV to V
+    Log.info("%s [%d]: Battery voltage reading from BQ27427: %.3f V\r\n", __FILE__, __LINE__, voltage);
+    return voltage;
+  } else {
+    Log.error("%s [%d]: BQ27427 not initialized. Cannot read battery voltage.\r\n", __FILE__, __LINE__);
+    return -1.0;
+  }
+}
+
+#endif // INCLUDE_BQ27427

--- a/src/battery/fake_battery.cpp
+++ b/src/battery/fake_battery.cpp
@@ -1,0 +1,7 @@
+#include <ArduinoLog.h>
+#include <battery.h>
+
+float FakeBattery::readVoltage() {
+  Log.warning("%s [%d]: FAKE_BATTERY_VOLTAGE is defined. Returning 4.2V.\r\n", __FILE__, __LINE__);
+  return 4.2f;
+}

--- a/src/battery/seeed_battery.cpp
+++ b/src/battery/seeed_battery.cpp
@@ -1,0 +1,16 @@
+#include <Arduino.h>
+#include <battery.h>
+
+SeeedBattery::SeeedBattery(uint8_t pin, uint8_t switchPin, uint8_t switchOnLevel)
+    : ADCBattery(pin), _switchPin(switchPin), _switchOnLevel(switchOnLevel) {}
+
+float SeeedBattery::readVoltage() {
+  pinMode(_switchPin, OUTPUT);
+  digitalWrite(_switchPin, _switchOnLevel);
+  delay(10); // Wait for the switch to stabilize
+
+  float voltage = ADCBattery::readVoltage();
+
+  digitalWrite(_switchPin, _switchOnLevel == HIGH ? LOW : HIGH);
+  return voltage;
+}

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -4,6 +4,7 @@
 #include <bl.h>
 #include <wifi_network.h>
 #include <power.h>
+#include <battery.h>
 #include <device_id.h>
 #include <trmnl_log.h>
 #include <types.h>
@@ -110,7 +111,6 @@ static void resetDeviceCredentials(void);            // reset device credentials
 void goToSleep(void);                         // sleep preparing
 static void goToSleepButtonOnly(void);               // sleep until button press, no timer
 static bool setClock(void);                          // clock synchronization
-static float readBatteryVoltage(void);               // battery voltage reading
 static void submitStoredLogs(void);
 static void writeSpecialFunction(SPECIAL_FUNCTION function);
 static void writeImageToFile(const char *name, uint8_t *in_buffer, size_t size);
@@ -1216,7 +1216,7 @@ void bl_init(void)
     Log_info("No battery detected - skipping BQ27427 initialization");
   }
 #endif // BOARD_TRMNL_X
-  vBatt = readBatteryVoltage(); // Read the battery voltage BEFORE WiFi is turned on
+  vBatt = battery().readVoltage(); // Read the battery voltage BEFORE WiFi is turned on
 
   Log_info("Firmware version %s", Messages::firmware_version().c_str());
   Log_info("Arduino version %d.%d.%d", ESP_ARDUINO_VERSION_MAJOR, ESP_ARDUINO_VERSION_MINOR, ESP_ARDUINO_VERSION_PATCH);
@@ -1627,7 +1627,7 @@ ApiDisplayInputs loadApiDisplayInputs(Preferences &preferences)
   WiFiStatus wifi = getWiFiStatus();
   inputs.rssi = wifi.rssi;
   inputs.wifiBand = wifi.band;
-  inputs.batteryVoltage = vBatt; //readBatteryVoltage();
+  inputs.batteryVoltage = vBatt;
   inputs.firmwareVersion = String(FW_VERSION_STRING);
   inputs.firmwareCommit = String(FW_COMMIT);
   inputs.displayWidth = display_width();
@@ -3347,53 +3347,6 @@ static bool setClock()
 }
 
 /**
- * @brief Function to read the battery voltage
- * @param none
- * @return float voltage in Volts
- */
-static float readBatteryVoltage(void)
-{
-#ifdef FAKE_BATTERY_VOLTAGE
-  Log.warning("%s [%d]: FAKE_BATTERY_VOLTAGE is defined. Returning 4.2V.\r\n", __FILE__, __LINE__);
-  return 4.2f;
-#elif defined(BOARD_TRMNL_X)
-  if (lipo._initialized)
-  {
-    float voltage = lipo.voltage() / 1000.0; // Convert mV to V
-    Log.info("%s [%d]: Battery voltage reading from BQ27427: %.3f V\r\n", __FILE__, __LINE__, voltage);
-    return voltage;
-  }
-  else
-  {
-    Log.error("%s [%d]: BQ27427 not initialized. Cannot read battery voltage.\r\n", __FILE__, __LINE__);
-    return -1.0;
-  }
-#else
-  #if defined(BOARD_XIAO_EPAPER_DISPLAY) || defined(BOARD_SEEED_RETERMINAL_E1001) || defined(BOARD_SEEED_RETERMINAL_E1002) || defined(BOARD_SEEED_RETERMINAL_E1003)
-    pinMode(PIN_VBAT_SWITCH, OUTPUT);
-    digitalWrite(PIN_VBAT_SWITCH, VBAT_SWITCH_LEVEL);
-    delay(10); // Wait for the switch to stabilize
-  #endif
-    Log.info("%s [%d]: Battery voltage reading...\r\n", __FILE__, __LINE__);
-    int32_t adc;
-    int32_t sensorValue;
-
-    adc = 0;
-    analogRead(PIN_BATTERY); // This is needed to properly initialize the ADC BEFORE calling analogReadMilliVolts()
-    for (uint8_t i = 0; i < 8; i++) {
-      adc += analogReadMilliVolts(PIN_BATTERY);
-    }
-  #if defined(BOARD_XIAO_EPAPER_DISPLAY) || defined(BOARD_SEEED_RETERMINAL_E1001) || defined(BOARD_XIAO_EPAPER_DISPLAY_3CLR) || defined(BOARD_SEEED_RETERMINAL_E1003)
-    digitalWrite(PIN_VBAT_SWITCH, (VBAT_SWITCH_LEVEL == HIGH ? LOW : HIGH));
-  #endif
-    sensorValue = (adc / 8) * 2;
-    Log.info("%s [%d]: Battery sensorValue = %d\r\n", __FILE__, __LINE__, (int)sensorValue);
-    float voltage = sensorValue / 1000.0;
-    return voltage;
-#endif // FAKE_BATTERY_VOLTAGE
-}
-
-/**
  * @brief Function to submit a log string to the API
  * @param log_buffer pointer to the buffer that contains log note
  * @return bool true if successful, false if failed
@@ -3678,7 +3631,7 @@ DeviceStatusStamp getDeviceStatusStamp()
   deviceStatus.time_since_last_sleep = time_since_sleep;
   snprintf(deviceStatus.current_fw_version, sizeof(deviceStatus.current_fw_version), "%s", FW_VERSION_STRING);
   parseSpecialFunctionToStr(deviceStatus.special_function, sizeof(deviceStatus.special_function), special_function);
-  deviceStatus.battery_voltage = vBatt; //readBatteryVoltage()
+  deviceStatus.battery_voltage = vBatt;
   parseWakeupReasonToStr(deviceStatus.wakeup_reason, sizeof(deviceStatus.wakeup_reason), esp_sleep_get_wakeup_cause());
   deviceStatus.free_heap_size = ESP.getFreeHeap();
   deviceStatus.max_alloc_size = ESP.getMaxAllocHeap();


### PR DESCRIPTION
Related to #377 but does not impact it.

---

Now that the backlog of PR's is slowing down (knock on wood), I wanted to share an idea of how we can start improving the structure of our code using basic OOP principles.

This PR takes the function `readBatteryVoltage()` and extracts it into a basic class hierarchy: a virtual `BaseBattery` class with no functionality, and then device-specific subclasses for each type of battery gauge, including the mock 4.2 V "fake" battery.

Now this example is pretty verbose, but it shows the *kind* of structure that we should aim for. And despite being longer, it's easier to read and understand exactly the path each device takes. In the future, now we have a singular place to move battery logic, like initializing and managing the gauge.

Notice the simple series of `#ifdef`s in [battery.cpp](https://github.com/usetrmnl/trmnl-firmware/pull/521/changes#diff-1790ea18e1dbb380c209dbc4753011571295d3d3492ede491cfad64ee5e9858e) whose only job is to instantiate the specific battery implementation, and everything contained within is runtime logic.