### PR TITLE
Refactor setup process

### DIFF
--- a/dependencies.lock.esp32s3
+++ b/dependencies.lock.esp32s3
@@ -242,7 +242,7 @@ dependencies:
       type: service
     version: 1.2.0
   espressif/esp_secure_cert_mgr:
-    component_hash: 40a986c1f45d91eb6d339ca51dcab90c4ecce2a6622c268edaaa05887852d464
+    component_hash: 0b83e150f48d6839f0a0a8753850be55a51cc298cfca7658f21d355d5f41dd67
     dependencies:
     - name: idf
       require: private
@@ -250,7 +250,7 @@ dependencies:
     source:
       registry_url: https://components.espressif.com
       type: service
-    version: 2.9.2
+    version: 2.9.3
   espressif/jsmn:
     component_hash: d80350c41bbaa827c98a25b6072df00884e72f54885996fab4a4f0aebce6b6c3
     dependencies:

--- a/include/filesystem.h
+++ b/include/filesystem.h
@@ -66,6 +66,15 @@ bool filesystem_read_from_file(const char *name, uint8_t *out_buffer, size_t siz
 size_t filesystem_write_to_file(const char *name, uint8_t *in_buffer, size_t size);
 
 /**
+ * @brief Function to write an image buffer to a file, logging an error on short writes
+ * @param name filename
+ * @param in_buffer pointer to input buffer
+ * @param size size of the input buffer
+ * @return none
+ */
+void writeImageToFile(const char *name, uint8_t *in_buffer, size_t size);
+
+/**
  * @brief Function to check if file exists
  * @param name filename
  * @return result - true if exists; false - if not exists

--- a/include/services/device_setup.h
+++ b/include/services/device_setup.h
@@ -1,0 +1,93 @@
+#pragma once
+
+#include <api-client/setup.h>
+#include <display.h>
+#include <persistence_interface.h>
+#include <stdint.h>
+
+//
+// derive device-specific setup flags
+//
+#if defined(BOARD_TRMNL_X)
+#define INCLUDE_DEVICE_SETUP_X
+#endif
+
+/// @brief Outcome of the device setup flow.
+enum class DeviceSetupOutcome {
+  Success,            // credentials stored and setup image downloaded
+  ConnectionError,    // could not reach the server
+  ParsingError,       // malformed /api/setup response
+  RequestError,       // /api/setup request failed
+  MacNotRegistered,   // server does not know this device
+  ApiStatusError,     // /api/setup returned an unexpected status code
+  ImageDownloadError, // setup image download failed
+  ImageInvalidError,  // setup image had an unexpected size or format
+};
+
+/// @brief Everything the caller needs to finish the setup flow: which screen
+///        to draw, the /api/setup payload fields, and whether to sleep.
+struct DeviceSetupResult {
+  DeviceSetupOutcome outcome = DeviceSetupOutcome::RequestError;
+  String imageUrl;               // setup image URL from /api/setup
+  String message;                // user-facing message from /api/setup
+  String friendlyId;             // for the FRIENDLY_ID screen
+  ApiSetupResponse apiResponse;  // for the MAC_NOT_REGISTERED screen (404)
+  MSG errorScreen = NONE;        // error screen to show, NONE for no screen
+  bool showSetupScreen = false;  // draw the FRIENDLY_ID screen
+  bool shouldGoToSleep = false;  // 404 path: put the device to sleep
+};
+
+/// @brief Registers the device with the server: fetches credentials (API key,
+///        friendly ID) from /api/setup, then downloads the setup image.
+///        Display and sleep side effects are returned to the caller via
+///        DeviceSetupResult rather than performed here.
+class DeviceSetup {
+public:
+  explicit DeviceSetup(Persistence &persistence) : _persistence(persistence) {}
+  virtual ~DeviceSetup() = default;
+
+  /// @brief Run the full setup flow.
+  DeviceSetupResult perform();
+
+protected:
+  /// @brief Call the /api/setup endpoint.
+  virtual ApiSetupResult callSetupApi(ApiSetupInputs &inputs);
+
+  /// @brief Download the setup image, filling _result's outcome and
+  ///        FRIENDLY_ID screen fields.
+  virtual void downloadSetupImage();
+
+  /// @brief Handle a downloaded setup image with an unexpected size or format.
+  virtual void handleInvalidImage(uint32_t bytesRead);
+
+  Persistence &_persistence;
+  DeviceSetupResult _result;
+
+private:
+  void performApiSetup();
+};
+
+#ifdef INCLUDE_DEVICE_SETUP_X
+class Modem;
+
+/// @brief TRMNL X setup flow: routes API and image traffic through the 5 GHz
+///        modem when connected to a 5 GHz network.
+class DeviceSetupX : public DeviceSetup {
+public:
+  /// @brief `modem` is a reference to the owner's pointer because the modem is
+  ///        initialized during bl_init, after static construction.
+  DeviceSetupX(Persistence &persistence, Modem *&modem) : DeviceSetup(persistence), _modem(modem) {}
+
+protected:
+  ApiSetupResult callSetupApi(ApiSetupInputs &inputs) override;
+  void downloadSetupImage() override;
+  void handleInvalidImage(uint32_t bytesRead) override;
+
+private:
+  bool is5Ghz();
+  Modem *&_modem;
+};
+#endif // INCLUDE_DEVICE_SETUP_X
+
+/// @brief Device setup service for the running board, selected at compile time.
+DeviceSetup &deviceSetup();

--- a/lib/trmnl/include/http_client.h
+++ b/lib/trmnl/include/http_client.h
@@ -1,5 +1,4 @@
-#ifndef HTTP_UTILS_H
-#define HTTP_UTILS_H
+#pragma once
 
 #include <Arduino.h>
 #include <HTTPClient.h>
@@ -16,6 +15,8 @@ enum HttpError {
   HTTPCLIENT_WIFICLIENT_ERROR = 101, // Failed to create client
   HTTPCLIENT_HTTPCLIENT_ERROR = 102  // Failed to connect
 };
+
+uint32_t downloadStream(WiFiClient *stream, int content_size, uint8_t *buffer);
 
 /**
  * @brief Higher-order function that sets up WiFiClient and HTTPClient, then runs a callback
@@ -76,5 +77,3 @@ ReturnType withHttp(const String &url, Callback callback, bool resumable = false
  * request_headers.h; this is the HTTPClient adapter for it.
  */
 void applyHeaders(HTTPClient &https, const HttpHeaderList &headers);
-
-#endif // HTTP_UTILS_H

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -50,6 +50,7 @@
 #include <wifi-helpers.h>
 #include <sys/time.h>
 #include <misc/buzzer.h>
+#include <services/device_setup.h>
 #include "messages.h"
 #include "displayed_image.h"
 #ifdef SENSOR_SDA
@@ -104,9 +105,6 @@ RefreshInterval refreshInterval(preferencesPersistence);
 
 static https_request_err_e downloadAndShow(); // download and show the image
 static https_request_err_e handleApiDisplayResponse(ApiDisplayResponse &apiResponse);
-static void getDeviceCredentials();                  // receiveing API key and Friendly ID
-static bool performApiSetup();     // perform API setup call and return success
-static void downloadSetupImage();                    // download and display setup image
 static void resetDeviceCredentials(void);            // reset device credentials API key, Friendly ID, Wi-Fi SSID and password
 void goToSleep(void);                         // sleep preparing
 static void goToSleepButtonOnly(void);               // sleep until button press, no timer
@@ -759,6 +757,7 @@ battery_count_t battery_count = BATTERY_NONE;
 bool battery_charging = false;
 // ############################ Gas gauge #############################
 #endif
+
 /**
  * @brief Function to initialize and read from I2C sensors (if present)
  * @param none
@@ -1402,15 +1401,43 @@ void bl_init(void)
 
   Log.info("%s [%d]: Time since last sleep: %d\r\n", __FILE__, __LINE__, time_since_sleep);
 
-  if (!preferences.isKey(PREFERENCES_API_KEY) || !preferences.isKey(PREFERENCES_FRIENDLY_ID))
+  if (preferences.isKey(PREFERENCES_API_KEY) && preferences.isKey(PREFERENCES_FRIENDLY_ID))
   {
-    Log.info("%s [%d]: API key or friendly ID not saved\r\n", __FILE__, __LINE__);
-    // lets get the api key and friendly ID
-    getDeviceCredentials();
+    Log.info("%s [%d]: API key and friendly ID saved\r\n", __FILE__, __LINE__);
   }
   else
   {
-    Log.info("%s [%d]: API key and friendly ID saved\r\n", __FILE__, __LINE__);
+    Log.info("%s [%d]: API key or friendly ID not saved\r\n", __FILE__, __LINE__);
+
+    // attempt to get the API key and friendly ID
+    DeviceSetupResult setup = deviceSetup().perform();
+
+    // copy results into globals
+    setup.imageUrl.toCharArray(filename, sizeof(filename));
+    setup.message.toCharArray(message_buffer, sizeof(message_buffer));
+
+    // perform post-setup actions
+    if (setup.showSetupScreen)
+    {
+      display_show_msg(storedLogoOrDefault(0), FRIENDLY_ID, setup.friendlyId, true, "", setup.message);
+      need_to_refresh_display = 0;
+    }
+    else if (setup.errorScreen != NONE)
+    {
+      showMessageWithLogo(setup.errorScreen);
+    }
+
+    if (setup.outcome == DeviceSetupOutcome::MacNotRegistered)
+    {
+      showMessageWithLogo(MAC_NOT_REGISTERED, setup.apiResponse);
+      refreshInterval.applyDefault();
+    }
+
+    if (setup.shouldGoToSleep)
+    {
+      display_sleep();
+      goToSleep();
+    }
   }
 
   submitStoredLogs();
@@ -2721,334 +2748,6 @@ https_request_err_e handleApiDisplayResponse(ApiDisplayResponse &apiResponse)
 }
 
 /**
- * @brief Performs API setup call to get credentials and image URL
- * @return true if should continue to image download, false otherwise
- */
-static bool performApiSetup()
-{
-  // Set up the API inputs
-  ApiSetupInputs inputs;
-  inputs.baseUrl = preferences.getString(PREFERENCES_API_URL, API_BASE_URL);
-  inputs.macAddress = device_mac_address();
-  inputs.firmwareVersion = FW_VERSION_STRING;
-  inputs.model = String(DEVICE_MODEL);
-
-  Log.info("%s [%d]: [HTTPS] begin /api/setup ...\r\n", __FILE__, __LINE__);
-  Log.info("%s [%d]: RSSI: %d\r\n", __FILE__, __LINE__, WiFi.RSSI());
-  Log.info("%s [%d]: Device MAC address: %s\r\n", __FILE__, __LINE__, inputs.macAddress.c_str());
-
-  ApiSetupResult result;
-  // Call the API client
-#ifdef BOARD_TRMNL_X
-  if (g_modem && WifiCaptivePortal.getLastCredentials().is5GHz)
-  {
-    Log_info("API setup via modem (5 GHz path)");
-    String reqHeaders = formatHeaders(buildSetupHeaders(inputs));
-    auto httpRes = g_modem->httpGet(inputs.baseUrl + "/api/setup", "", 0, reqHeaders);
-    if (!httpRes.ok)
-    {
-      Log_error_submit("[MODEM] /api/setup request failed (%u bytes received)", httpRes.bytesReceived);
-      result = {HTTPS_RESPONSE_CODE_INVALID, {}, "Modem httpGet failed"};
-    }
-    else
-    {
-      auto apiResp = parseResponse_apiSetup(httpRes.body);
-      if (apiResp.outcome == ApiSetupOutcome::DeserializationError)
-        result = {HTTPS_JSON_PARSING_ERR, {}, "JSON deserialization error"};
-      else
-        result = {HTTPS_NO_ERR, apiResp, ""};
-    }
-  }
-  else
-#endif // BOARD_TRMNL_X
-  {
-    result = fetchApiSetup(inputs);
-  }
-  // Handle connection errors
-  if (result.error == HTTPS_UNABLE_TO_CONNECT)
-  {
-    showMessageWithLogo(WIFI_INTERNAL_ERROR);
-    Log_error_submit("[HTTPS] %s", result.error_detail.c_str());
-    return false;
-  }
-
-  // Handle JSON parsing errors
-  if (result.error == HTTPS_JSON_PARSING_ERR)
-  {
-    Log.error("%s [%d]: JSON deserialization error.\r\n", __FILE__, __LINE__);
-    return false;
-  }
-
-  // Handle HTTP request errors
-  if (result.error != HTTPS_NO_ERR)
-  {
-    if (WiFi.RSSI() > WIFI_CONNECTION_RSSI)
-    {
-      showMessageWithLogo(API_SETUP_FAILED);
-    }
-    else
-    {
-      showMessageWithLogo(WIFI_WEAK);
-    }
-    Log_error_submit("[HTTPS] Request failed: %s", result.error_detail.c_str());
-    return false;
-  }
-
-  // Process the successful response
-  auto &apiResponse = result.response;
-  uint16_t url_status = apiResponse.status;
-
-  Log.info("%s [%d]: GET... code: %d\r\n", __FILE__, __LINE__, url_status);
-
-  if (url_status == 200)
-  {
-    status = true;
-    Log.info("%s [%d]: status OK.\r\n", __FILE__, __LINE__);
-
-    String api_key = apiResponse.api_key;
-    Log.info("%s [%d]: API key - %s\r\n", __FILE__, __LINE__, api_key.c_str());
-    size_t res = preferences.putString(PREFERENCES_API_KEY, api_key);
-    Log.info("%s [%d]: api key saved in the preferences - %d\r\n", __FILE__, __LINE__, res);
-
-    String friendly_id = apiResponse.friendly_id;
-    Log.info("%s [%d]: friendly ID - %s\r\n", __FILE__, __LINE__, friendly_id.c_str());
-    res = preferences.putString(PREFERENCES_FRIENDLY_ID, friendly_id);
-    Log.info("%s [%d]: friendly ID saved in the preferences - %d\r\n", __FILE__, __LINE__, res);
-
-    String image_url = apiResponse.image_url;
-    Log.info("%s [%d]: image_url - %s\r\n", __FILE__, __LINE__, image_url.c_str());
-    image_url.toCharArray(filename, image_url.length() + 1);
-
-    String message_str = apiResponse.message;
-    Log.info("%s [%d]: message - %s\r\n", __FILE__, __LINE__, message_str.c_str());
-    message_str.toCharArray(message_buffer, message_str.length() + 1);
-
-    Log.info("%s [%d]: status - %d\r\n", __FILE__, __LINE__, status);
-    return true;
-  }
-  else if (url_status == 404)
-  {
-    Log_info("MAC Address is not registered on server");
-
-    showMessageWithLogo(MAC_NOT_REGISTERED, apiResponse);
-
-    refreshInterval.applyDefault();
-
-    display_sleep();
-    goToSleep();
-    return false;
-  }
-  else
-  {
-    Log.info("%s [%d]: status FAIL.\r\n", __FILE__, __LINE__);
-    status = false;
-    return false;
-  }
-}
-
-/**
- * @brief Downloads and displays the setup image from the API response
- * @return none
- */
-static void downloadSetupImage()
-{
-  status = false;
-  Log.info("%s [%d]: filename - %s\r\n", __FILE__, __LINE__, filename);
-
-  #ifdef BOARD_TRMNL_X
-  if (WifiCaptivePortal.getLastCredentials().is5GHz && g_modem)
-  {
-    Log_info("Downloading setup image via modem (5 GHz path)");
-    auto httpRes = g_modem->httpGet(String(filename), "/logo.bmp");
-    if (!httpRes.ok || httpRes.bytesReceived != DISPLAY_BMP_IMAGE_SIZE)
-    {
-      Log_error_submit("Modem logo download failed: ok=%d bytes=%u expected=%u",
-                       httpRes.ok, httpRes.bytesReceived, DISPLAY_BMP_IMAGE_SIZE);
-      filesystem_file_delete("/logo.bmp");
-    }
-    String friendly_id = preferences.getString(PREFERENCES_FRIENDLY_ID, PREFERENCES_FRIENDLY_ID_DEFAULT);
-    display_show_msg(storedLogoOrDefault(0), FRIENDLY_ID, friendly_id, true, "", String(message_buffer));
-    need_to_refresh_display = 0;
-    return;
-  }
-#endif // BOARD_TRMNL_X
-
-  withHttp(filename, [&](HTTPClient *https, HttpError error) -> bool
-           {
-    if (error != HttpError::HTTPCLIENT_SUCCESS)
-    {
-      if (WiFi.RSSI() > WIFI_CONNECTION_RSSI)
-      {
-        showMessageWithLogo(API_IMAGE_DOWNLOAD_ERROR);
-      }
-      else
-      {
-        showMessageWithLogo(WIFI_WEAK);
-      }
-      Log_error_submit("[HTTPS] Unable to connect");
-      return false;
-    }
-
-    https->setTimeout(15000);
-    https->setConnectTimeout(15000);
-
-    Log.info("%s [%d]: [HTTPS] Request to %s\r\n", __FILE__, __LINE__, filename);
-    Log.info("%s [%d]: [HTTPS] GET..\r\n", __FILE__, __LINE__);
-
-    int httpCode = https->GET();
-
-    if(httpCode == HTTP_CODE_PERMANENT_REDIRECT ||httpCode == HTTP_CODE_TEMPORARY_REDIRECT){
-              https->end();
-              https->begin(https->getLocation());
-              Log_info("Redirected to: %s", https->getLocation().c_str());
-              https->setTimeout(15000);
-              https->setConnectTimeout(15000);
-              httpCode = https->GET();
-            }
-
-    // httpCode will be negative on error
-    if (httpCode <= 0)
-    {
-      if (WiFi.RSSI() > WIFI_CONNECTION_RSSI)
-      {
-        showMessageWithLogo(API_IMAGE_DOWNLOAD_ERROR);
-      }
-      else
-      {
-        showMessageWithLogo(WIFI_WEAK);
-      }
-      Log_error_submit("[HTTPS] GET... failed, error: %s", https->errorToString(httpCode).c_str());
-      return false;
-    }
-
-    // HTTP header has been send and Server response header has been handled
-    Log.info("%s [%d]: [HTTPS] GET... code: %d\r\n", __FILE__, __LINE__, httpCode);
-    
-    // file found at server
-    if (httpCode != HTTP_CODE_OK && httpCode != HTTP_CODE_MOVED_PERMANENTLY)
-    {
-      if (WiFi.RSSI() > WIFI_CONNECTION_RSSI)
-      {
-        showMessageWithLogo(API_IMAGE_DOWNLOAD_ERROR);
-      }
-      else
-      {
-        showMessageWithLogo(WIFI_WEAK);
-      }
-      Log_error_submit("[HTTPS] GET... failed, error: %s", https->errorToString(httpCode).c_str());
-      return false;
-    }
-
-    Log.info("%s [%d]: Content size: %d\r\n", __FILE__, __LINE__, https->getSize());
-
-    WiFiClient *stream = https->getStreamPtr();
-
-    uint32_t counter = 0;
-#ifdef BOARD_TRMNL_X
-    int contentSize = https->getSize();
-    buffer = (uint8_t *)malloc(contentSize > 0 ? contentSize : 1);
-    if (buffer == nullptr)
-    {
-      Log_error_submit("Failed to allocate buffer for setup image (%d bytes)", contentSize);
-      return false;
-    }
-    if (stream->available() && contentSize > 0)
-    {
-      counter = downloadStream(stream, contentSize, buffer);
-    }
-#else
-    // Read and save image data to buffer (BMP or PNG)
-    int contentSize = https->getSize();
-    buffer = (uint8_t *)malloc(contentSize > 0 ? contentSize : 1);
-    if (buffer == nullptr)
-    {
-      Log_error_submit("Failed to allocate buffer for setup image (%d bytes)", contentSize);
-      return false;
-    }
-    if (stream->available() && contentSize > 0)
-    {
-      counter = downloadStream(stream, contentSize, buffer);
-    }
-#endif
-
-    if (counter == DISPLAY_BMP_IMAGE_SIZE)
-    {
-      Log.info("%s [%d]: Received successfully\r\n", __FILE__, __LINE__);
-
-      writeImageToFile("/logo.bmp", buffer, DEFAULT_IMAGE_SIZE);
-
-      // show the image
-      String friendly_id = preferences.getString(PREFERENCES_FRIENDLY_ID, PREFERENCES_FRIENDLY_ID_DEFAULT);
-      display_show_msg(storedLogoOrDefault(0), FRIENDLY_ID, friendly_id, true, "", String(message_buffer));
-      need_to_refresh_display = 0;
-    }
-#ifdef BOARD_TRMNL_X 
-    else if (counter >= 4 && buffer[0] == 0x89 && buffer[1] == 'P' && buffer[2] == 'N' && buffer[3] == 'G')
-    {       
-      Log.info("%s [%d]: Received PNG setup logo (%d bytes)\r\n", __FILE__, __LINE__, counter);
-      writeImageToFile("/logo.png", buffer, counter);
-      free(buffer);
-      buffer = nullptr;
-
-      // show the image
-      String friendly_id = preferences.getString(PREFERENCES_FRIENDLY_ID, PREFERENCES_FRIENDLY_ID_DEFAULT);
-      display_show_msg(storedLogoOrDefault(0), FRIENDLY_ID, friendly_id, true, "", String(message_buffer));
-      need_to_refresh_display = 0;
-    }
-    else
-    {
-      free(buffer);
-      buffer = nullptr;
-      Log_error_submit("Setup image: unexpected format or size. Read: %d bytes (expected BMP %d)", counter, DISPLAY_BMP_IMAGE_SIZE);
-    }
-#else
-    else if (counter >= 4 && buffer[0] == 0x89 && buffer[1] == 'P' && buffer[2] == 'N' && buffer[3] == 'G')
-    {
-      Log.info("%s [%d]: Received PNG setup logo (%d bytes)\r\n", __FILE__, __LINE__, counter);
-      writeImageToFile("/logo.png", buffer, counter);
-      free(buffer);
-      buffer = nullptr;
-
-      String friendly_id = preferences.getString(PREFERENCES_FRIENDLY_ID, PREFERENCES_FRIENDLY_ID_DEFAULT);
-      display_show_msg(storedLogoOrDefault(0), FRIENDLY_ID, friendly_id, true, "", String(message_buffer));
-      need_to_refresh_display = 0;
-    }
-    else
-    {
-      if (buffer) {
-        free(buffer);
-        buffer = nullptr;
-      }
-      if (WiFi.RSSI() > WIFI_CONNECTION_RSSI)
-      {
-        showMessageWithLogo(API_SIZE_ERROR);
-      }
-      else
-      {
-        showMessageWithLogo(WIFI_WEAK);
-      }
-      Log_error_submit("Receiving failed. Read: %" PRIu32, counter);
-    }
-#endif // !BOARD_TRMNL_X    
-    return true; });
-}
-
-/**
- * @brief Function to getting the friendly id and API key
- * @return none
- */
-static void getDeviceCredentials()
-{
-  bool shouldDownloadImage = performApiSetup();
-
-  Log.info("%s [%d]: status - %d\r\n", __FILE__, __LINE__, status);
-  if (shouldDownloadImage)
-  {
-    downloadSetupImage();
-  }
-}
-
-/**
  * @brief Function to reset the friendly id, API key, WiFi SSID and password
  * @param url Server URL address
  * @return none
@@ -3409,19 +3108,6 @@ static void submitStoredLogs(void)
   if (submitLogToApiResult == true)
   {
     storedLogs.clear_stored_logs();
-  }
-}
-
-static void writeImageToFile(const char *name, uint8_t *in_buffer, size_t size)
-{
-  size_t res = filesystem_write_to_file(name, in_buffer, size);
-  if (res != size)
-  {
-    Log_error_submit("File writing ERROR. Result - %d", res);
-  }
-  else
-  {
-    Log.info("%s [%d]: file %s writing success - %d bytes\r\n", __FILE__, __LINE__, name, res);
   }
 }
 

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -113,7 +113,6 @@ static void goToSleepButtonOnly(void);               // sleep until button press
 static bool setClock(void);                          // clock synchronization
 static void submitStoredLogs(void);
 static void writeSpecialFunction(SPECIAL_FUNCTION function);
-static void writeImageToFile(const char *name, uint8_t *in_buffer, size_t size);
 void showMessageWithLogo(MSG message_type);
 static void showMessageWithLogo(MSG message_type, String friendly_id, bool id, const char *fw_version, String message);
 static void showMessageWithLogo(MSG message_type, const ApiSetupResponse &apiResponse);

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -103,7 +103,6 @@ StoredLogs storedLogs(LOG_MAX_NOTES_NUMBER / 2, LOG_MAX_NOTES_NUMBER / 2, PREFER
 RefreshInterval refreshInterval(preferencesPersistence);
 
 static https_request_err_e downloadAndShow(); // download and show the image
-static uint32_t downloadStream(WiFiClient *stream, int content_size, uint8_t *buffer);
 static https_request_err_e handleApiDisplayResponse(ApiDisplayResponse &apiResponse);
 static void getDeviceCredentials();                  // receiveing API key and Friendly ID
 static bool performApiSetup();     // perform API setup call and return success
@@ -2163,35 +2162,6 @@ static https_request_err_e downloadAndShow()
   Log_info("Returned result - %s", szHTTPErrors[result]);
 
   return result;
-}
-
-uint32_t downloadStream(WiFiClient *stream, int content_size, uint8_t *buffer)
-{
-  int iteration_counter = 0;
-  int counter2 = content_size;
-  unsigned long download_start = millis();
-  unsigned long last_data_time = millis();
-  int counter = 0;
-
-  while (counter < content_size && millis() - download_start < 30000)
-  {
-    if (stream->available())
-    {
-      Log.info("%s [%d]: Downloading... Available bytes: %d\r\n", __FILE__, __LINE__, stream->available());
-      int bytes_to_read = min(stream->available(), counter2 - counter);
-      counter += stream->readBytes(buffer + counter, bytes_to_read);
-      iteration_counter++;
-      last_data_time = millis();
-    }
-    else if (!stream->connected() || millis() - last_data_time > 5000)
-    {
-      break;
-    }
-    delay(10);
-  }
-
-  Log_info("Download end: %d/%d bytes in %lu ms (%d iterations)", counter, content_size, millis() - download_start, iteration_counter);
-  return counter;
 }
 
 https_request_err_e handleApiDisplayResponse(ApiDisplayResponse &apiResponse)

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -289,3 +289,12 @@ uint32_t filesystem_extract_timestamp(const char *filename) {
     return 0;
   }
 }
+
+void writeImageToFile(const char *name, uint8_t *in_buffer, size_t size) {
+  size_t res = filesystem_write_to_file(name, in_buffer, size);
+  if (res != size) {
+    Log_error_submit("File writing ERROR. Result - %d", res);
+  } else {
+    Log_info("file %s writing success - %d bytes", name, res);
+  }
+}

--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -1,7 +1,33 @@
+#include <ArduinoLog.h>
 #include <http_client.h>
 
 // See lib/trmnl/include/api-client/request_headers.h for how headers are built
 void applyHeaders(HTTPClient &https, const HttpHeaderList &headers) {
   for (const auto &header : headers)
     https.addHeader(header.first, header.second);
+}
+
+uint32_t downloadStream(WiFiClient *stream, int content_size, uint8_t *buffer) {
+  int iteration_counter = 0;
+  int counter2 = content_size;
+  unsigned long download_start = millis();
+  unsigned long last_data_time = millis();
+  int counter = 0;
+
+  while (counter < content_size && millis() - download_start < 30000) {
+    if (stream->available()) {
+      Log.info("%s [%d]: Downloading... Available bytes: %d\r\n", __FILE__, __LINE__, stream->available());
+      int bytes_to_read = min(stream->available(), counter2 - counter);
+      counter += stream->readBytes(buffer + counter, bytes_to_read);
+      iteration_counter++;
+      last_data_time = millis();
+    } else if (!stream->connected() || millis() - last_data_time > 5000) {
+      break;
+    }
+    delay(10);
+  }
+
+  Log_info("Download end: %d/%d bytes in %lu ms (%d iterations)", counter, content_size, millis() - download_start,
+           iteration_counter);
+  return counter;
 }

--- a/src/services/device_setup.cpp
+++ b/src/services/device_setup.cpp
@@ -1,0 +1,214 @@
+#include <Arduino.h>
+#include <ArduinoLog.h>
+#include <HTTPClient.h>
+#include <WiFi.h>
+#include <api-client/setup.h>
+#include <config.h>
+#include <device_id.h>
+#include <filesystem.h>
+#include <http_client.h>
+#include <inttypes.h>
+#include <preferences_persistence.h>
+#include <services/device_setup.h>
+#include <trmnl_log.h>
+#include <types.h>
+
+DeviceSetupResult DeviceSetup::perform() {
+  _result = DeviceSetupResult();
+  performApiSetup();
+  if (_result.outcome == DeviceSetupOutcome::Success) {
+    downloadSetupImage();
+  }
+  return _result;
+}
+
+ApiSetupResult DeviceSetup::callSetupApi(ApiSetupInputs &inputs) { return fetchApiSetup(inputs); }
+
+void DeviceSetup::handleInvalidImage(uint32_t bytesRead) {
+  _result.errorScreen = (WiFi.RSSI() > WIFI_CONNECTION_RSSI) ? API_SIZE_ERROR : WIFI_WEAK;
+  _result.outcome = DeviceSetupOutcome::ImageInvalidError;
+  Log_error_submit("Receiving failed. Read: %" PRIu32, bytesRead);
+}
+
+/**
+ * @brief Performs API setup call to get credentials and image URL, filling
+ *        _result; Success means the image download should proceed
+ */
+void DeviceSetup::performApiSetup() {
+  // Set up the API inputs
+  ApiSetupInputs inputs;
+  inputs.baseUrl = _persistence.readString(PREFERENCES_API_URL, API_BASE_URL);
+  inputs.macAddress = device_mac_address();
+  inputs.firmwareVersion = FW_VERSION_STRING;
+  inputs.model = String(DEVICE_MODEL);
+
+  Log.info("%s [%d]: [HTTPS] begin /api/setup ...\r\n", __FILE__, __LINE__);
+  Log.info("%s [%d]: RSSI: %d\r\n", __FILE__, __LINE__, WiFi.RSSI());
+  Log.info("%s [%d]: Device MAC address: %s\r\n", __FILE__, __LINE__, inputs.macAddress.c_str());
+
+  // Call the API client
+  ApiSetupResult apiResult = callSetupApi(inputs);
+
+  // Handle connection errors
+  if (apiResult.error == HTTPS_UNABLE_TO_CONNECT) {
+    _result.errorScreen = WIFI_INTERNAL_ERROR;
+    _result.outcome = DeviceSetupOutcome::ConnectionError;
+    Log_error_submit("[HTTPS] %s", apiResult.error_detail.c_str());
+    return;
+  }
+
+  // Handle JSON parsing errors
+  if (apiResult.error == HTTPS_JSON_PARSING_ERR) {
+    _result.outcome = DeviceSetupOutcome::ParsingError;
+    Log.error("%s [%d]: JSON deserialization error.\r\n", __FILE__, __LINE__);
+    return;
+  }
+
+  // Handle HTTP request errors
+  if (apiResult.error != HTTPS_NO_ERR) {
+    _result.errorScreen = (WiFi.RSSI() > WIFI_CONNECTION_RSSI) ? API_SETUP_FAILED : WIFI_WEAK;
+    _result.outcome = DeviceSetupOutcome::RequestError;
+    Log_error_submit("[HTTPS] Request failed: %s", apiResult.error_detail.c_str());
+    return;
+  }
+
+  // Process the successful response
+  auto &apiResponse = apiResult.response;
+  uint16_t url_status = apiResponse.status;
+
+  Log.info("%s [%d]: GET... code: %d\r\n", __FILE__, __LINE__, url_status);
+
+  if (url_status == 200) {
+    Log.info("%s [%d]: status OK.\r\n", __FILE__, __LINE__);
+
+    String api_key = apiResponse.api_key;
+    Log.info("%s [%d]: API key - %s\r\n", __FILE__, __LINE__, api_key.c_str());
+    _persistence.writeString(PREFERENCES_API_KEY, api_key.c_str());
+    Log.info("%s [%d]: api key saved in the preferences\r\n", __FILE__, __LINE__);
+
+    String friendly_id = apiResponse.friendly_id;
+    Log.info("%s [%d]: friendly ID - %s\r\n", __FILE__, __LINE__, friendly_id.c_str());
+    _persistence.writeString(PREFERENCES_FRIENDLY_ID, friendly_id.c_str());
+    Log.info("%s [%d]: friendly ID saved in the preferences\r\n", __FILE__, __LINE__);
+
+    _result.imageUrl = apiResponse.image_url;
+    Log.info("%s [%d]: image_url - %s\r\n", __FILE__, __LINE__, _result.imageUrl.c_str());
+
+    _result.message = apiResponse.message;
+    Log.info("%s [%d]: message - %s\r\n", __FILE__, __LINE__, _result.message.c_str());
+
+    _result.outcome = DeviceSetupOutcome::Success;
+  } else if (url_status == 404) {
+    Log_info("MAC Address is not registered on server");
+
+    _result.apiResponse = apiResponse;
+    _result.shouldGoToSleep = true;
+    _result.outcome = DeviceSetupOutcome::MacNotRegistered;
+  } else {
+    Log.info("%s [%d]: status FAIL.\r\n", __FILE__, __LINE__);
+    _result.outcome = DeviceSetupOutcome::ApiStatusError;
+  }
+}
+
+/**
+ * @brief Downloads the setup image from the API response, filling _result's
+ *        outcome and FRIENDLY_ID screen fields
+ */
+void DeviceSetup::downloadSetupImage() {
+  Log.info("%s [%d]: filename - %s\r\n", __FILE__, __LINE__, _result.imageUrl.c_str());
+
+  _result.outcome = DeviceSetupOutcome::ImageDownloadError;
+
+  withHttp(_result.imageUrl, [&](HTTPClient *https, HttpError error) -> bool {
+    if (error != HttpError::HTTPCLIENT_SUCCESS) {
+      _result.errorScreen = (WiFi.RSSI() > WIFI_CONNECTION_RSSI) ? API_IMAGE_DOWNLOAD_ERROR : WIFI_WEAK;
+      Log_error_submit("[HTTPS] Unable to connect");
+      return false;
+    }
+
+    https->setTimeout(15000);
+    https->setConnectTimeout(15000);
+
+    Log.info("%s [%d]: [HTTPS] Request to %s\r\n", __FILE__, __LINE__, _result.imageUrl.c_str());
+    Log.info("%s [%d]: [HTTPS] GET..\r\n", __FILE__, __LINE__);
+
+    int httpCode = https->GET();
+
+    if (httpCode == HTTP_CODE_PERMANENT_REDIRECT || httpCode == HTTP_CODE_TEMPORARY_REDIRECT) {
+      https->end();
+      https->begin(https->getLocation());
+      Log_info("Redirected to: %s", https->getLocation().c_str());
+      https->setTimeout(15000);
+      https->setConnectTimeout(15000);
+      httpCode = https->GET();
+    }
+
+    // httpCode will be negative on error
+    if (httpCode <= 0) {
+      _result.errorScreen = (WiFi.RSSI() > WIFI_CONNECTION_RSSI) ? API_IMAGE_DOWNLOAD_ERROR : WIFI_WEAK;
+      Log_error_submit("[HTTPS] GET... failed, error: %s", https->errorToString(httpCode).c_str());
+      return false;
+    }
+
+    // HTTP header has been send and Server response header has been handled
+    Log.info("%s [%d]: [HTTPS] GET... code: %d\r\n", __FILE__, __LINE__, httpCode);
+
+    // file found at server
+    if (httpCode != HTTP_CODE_OK && httpCode != HTTP_CODE_MOVED_PERMANENTLY) {
+      _result.errorScreen = (WiFi.RSSI() > WIFI_CONNECTION_RSSI) ? API_IMAGE_DOWNLOAD_ERROR : WIFI_WEAK;
+      Log_error_submit("[HTTPS] GET... failed, error: %s", https->errorToString(httpCode).c_str());
+      return false;
+    }
+
+    Log.info("%s [%d]: Content size: %d\r\n", __FILE__, __LINE__, https->getSize());
+
+    WiFiClient *stream = https->getStreamPtr();
+
+    // Read and save image data to buffer (BMP or PNG)
+    uint32_t counter = 0;
+    int contentSize = https->getSize();
+    uint8_t *imageBuffer = (uint8_t *)malloc(contentSize > 0 ? contentSize : 1);
+    if (imageBuffer == nullptr) {
+      Log_error_submit("Failed to allocate buffer for setup image (%d bytes)", contentSize);
+      return false;
+    }
+    if (stream->available() && contentSize > 0) {
+      counter = downloadStream(stream, contentSize, imageBuffer);
+    }
+
+    if (counter == DISPLAY_BMP_IMAGE_SIZE) {
+      Log.info("%s [%d]: Received successfully\r\n", __FILE__, __LINE__);
+
+      writeImageToFile("/logo.bmp", imageBuffer, DEFAULT_IMAGE_SIZE);
+      free(imageBuffer);
+
+      _result.friendlyId = _persistence.readString(PREFERENCES_FRIENDLY_ID, PREFERENCES_FRIENDLY_ID_DEFAULT);
+      _result.showSetupScreen = true;
+      _result.outcome = DeviceSetupOutcome::Success;
+    } else if (counter >= 4 && imageBuffer[0] == 0x89 && imageBuffer[1] == 'P' && imageBuffer[2] == 'N' &&
+               imageBuffer[3] == 'G') {
+      Log.info("%s [%d]: Received PNG setup logo (%d bytes)\r\n", __FILE__, __LINE__, counter);
+      writeImageToFile("/logo.png", imageBuffer, counter);
+      free(imageBuffer);
+
+      _result.friendlyId = _persistence.readString(PREFERENCES_FRIENDLY_ID, PREFERENCES_FRIENDLY_ID_DEFAULT);
+      _result.showSetupScreen = true;
+      _result.outcome = DeviceSetupOutcome::Success;
+    } else {
+      free(imageBuffer);
+      handleInvalidImage(counter);
+    }
+    return true;
+  });
+}
+
+extern PreferencesPersistence preferencesPersistence; // global owned by bl.cpp
+
+#ifdef INCLUDE_DEVICE_SETUP_X
+extern Modem *g_modem; // global owned by bl.cpp
+static DeviceSetupX deviceSetupService(preferencesPersistence, g_modem);
+#else
+static DeviceSetup deviceSetupService(preferencesPersistence);
+#endif
+
+DeviceSetup &deviceSetup() { return deviceSetupService; }

--- a/src/services/device_setup_x.cpp
+++ b/src/services/device_setup_x.cpp
@@ -1,0 +1,65 @@
+#include <services/device_setup.h>
+
+#ifdef INCLUDE_DEVICE_SETUP_X
+
+#include <Arduino.h>
+#include <WifiCaptive.h>
+#include <api-client/request_headers.h>
+#include <api_response_parsing.h>
+#include <config.h>
+#include <filesystem.h>
+#include <trmnl_log.h>
+#include <types.h>
+
+#include "modem.h"
+
+bool DeviceSetupX::is5Ghz() { return WifiCaptivePortal.getLastCredentials().is5GHz && _modem; }
+
+ApiSetupResult DeviceSetupX::callSetupApi(ApiSetupInputs &inputs) {
+  if (!is5Ghz()) {
+    return DeviceSetup::callSetupApi(inputs);
+  }
+
+  Log_info("API setup via modem (5 GHz path)");
+  String reqHeaders = formatHeaders(buildSetupHeaders(inputs));
+  auto httpRes = _modem->httpGet(inputs.baseUrl + "/api/setup", "", 0, reqHeaders);
+  if (!httpRes.ok) {
+    Log_error_submit("[MODEM] /api/setup request failed (%u bytes received)", httpRes.bytesReceived);
+    return {HTTPS_RESPONSE_CODE_INVALID, {}, "Modem httpGet failed"};
+  }
+
+  auto apiResp = parseResponse_apiSetup(httpRes.body);
+  if (apiResp.outcome == ApiSetupOutcome::DeserializationError) {
+    return {HTTPS_JSON_PARSING_ERR, {}, "JSON deserialization error"};
+  }
+  return {HTTPS_NO_ERR, apiResp, ""};
+}
+
+void DeviceSetupX::downloadSetupImage() {
+  if (!is5Ghz()) {
+    DeviceSetup::downloadSetupImage();
+    return;
+  }
+
+  Log_info("Downloading setup image via modem (5 GHz path)");
+  _result.outcome = DeviceSetupOutcome::Success;
+  auto httpRes = _modem->httpGet(_result.imageUrl, "/logo.bmp");
+  if (!httpRes.ok || httpRes.bytesReceived != DISPLAY_BMP_IMAGE_SIZE) {
+    Log_error_submit("Modem logo download failed: ok=%d bytes=%u expected=%u", httpRes.ok, httpRes.bytesReceived,
+                     DISPLAY_BMP_IMAGE_SIZE);
+    filesystem_file_delete("/logo.bmp");
+    _result.outcome = DeviceSetupOutcome::ImageDownloadError;
+  }
+  // Show the FRIENDLY_ID screen even when the download failed, matching the
+  // original modem-path behavior.
+  _result.friendlyId = _persistence.readString(PREFERENCES_FRIENDLY_ID, PREFERENCES_FRIENDLY_ID_DEFAULT);
+  _result.showSetupScreen = true;
+}
+
+void DeviceSetupX::handleInvalidImage(uint32_t bytesRead) {
+  _result.outcome = DeviceSetupOutcome::ImageInvalidError;
+  Log_error_submit("Setup image: unexpected format or size. Read: %d bytes (expected BMP %d)", bytesRead,
+                   DISPLAY_BMP_IMAGE_SIZE);
+}
+
+#endif // INCLUDE_DEVICE_SETUP_X


### PR DESCRIPTION
This PR reduces `bl.cpp` by 10% (~340 LOC).

- move functions `downloadStream()` and `writeImageToFile()` out of `bl.cpp`
- add `DeviceSetup` and `DeviceSetupX` service classes to encapsulate the setup flow (`downloadSetupImage()`, `performApiSetup()`, and `getDeviceCredentials()`)
    - new `src/services` directory - will move `FirmwareUpdate` there in a future PR

## todo
- [x] test on OG
- [x] test on X (5 GHz)