### PR TITLE
Add single and triple button feedback beeps

### DIFF
--- a/src/button.cpp
+++ b/src/button.cpp
@@ -16,6 +16,11 @@ static unsigned long wait_for_button_release(unsigned long start_time) {
     }
     delay(10);
   }
+  if (millis() - start_time >= BUTTON_SOFT_RESET_TIME) {
+    buzzer().beepPattern(3, 100, 100);
+  } else if (!hold_buzzer_fired) {
+    buzzer().beep(100);
+  }
   return millis() - start_time;
 }
 


### PR DESCRIPTION
## Summary

- beep once when a button press is released before the long-hold threshold
- retain the existing two-beep feedback at the WiFi reset threshold
- beep three times when the soft-reset threshold is reached
- use the refactored `BaseBuzzer` interface introduced after #402

## Test plan

- `pio run -e seeed_reTerminal_E1001`