### PR TITLE
Add single and triple button feedback beeps

### DIFF
--- a/src/button.cpp
+++ b/src/button.cpp
@@ -16,6 +16,9 @@ static unsigned long wait_for_button_release(unsigned long start_time) {
     }
     delay(10);
   }
+  if (millis() - start_time >= BUTTON_SOFT_RESET_TIME) {
+    buzzer().beepPattern(3, 100, 100);
+  }
   return millis() - start_time;
 }
 
@@ -55,7 +58,7 @@ static ButtonPressResult wait_for_second_press(unsigned long start_time) {
   return ShortPress;
 }
 
-ButtonPressResult read_button_presses() {
+static ButtonPressResult classify_button_presses() {
   auto time_start = millis();
   Log_info("Button time=%lu: start", time_start);
   pinMode(PIN_INTERRUPT, INPUT);
@@ -85,6 +88,14 @@ ButtonPressResult read_button_presses() {
   }
 
   return NoAction;
+}
+
+ButtonPressResult read_button_presses() {
+  auto result = classify_button_presses();
+  if (result == ShortPress || result == DoubleClick) {
+    buzzer().beep(100);
+  }
+  return result;
 }
 
 const char *ButtonPressResultNames[] = {"LongPress", "DoubleClick", "ShortPress", "SoftReset"};


### PR DESCRIPTION
## Summary

- beep once for short presses, double clicks, and medium holds after the action is classified
- acknowledge quick GPIO-wakeup presses even when the button is already released before parsing starts
- retain the existing two-beep feedback at the WiFi reset threshold
- beep three times when the soft-reset threshold is reached
- use the refactored `BaseBuzzer` interface introduced after #402

## Test plan

- `pio run -e seeed_reTerminal_E1001`
- `PLATFORMIO_CORE_DIR="$HOME/.platformio-x" pio run -e TRMNL_X_E1003`