### PR TITLE
Extract sensor logic into classes

### DIFF
--- a/include/globals.h
+++ b/include/globals.h
@@ -12,11 +12,6 @@
 #include <special_function.h>
 #include <stored_logs.h>
 
-#ifdef SENSOR_SDA
-#include <bb_scd41.h>
-#include <bb_temperature.h>
-#endif
-
 #ifdef BOARD_TRMNL_X
 #include "IQS323.h"
 class Modem;
@@ -61,15 +56,6 @@ extern bool otg_message;
 extern int iUpdateCount;   // RTC: partial updates since the last full refresh
 extern bool bCanDoPartial; // RTC
 extern uint32_t iTempProfile;
-
-#ifdef SENSOR_SDA
-// --- Environmental sensors ---
-extern SCD41 scd41;
-extern BBTemp bbt;
-extern bool bCO2;
-extern int iSensorType;
-extern int lastCO2, lastSCDTemp, lastTemp, lastSCDHumid, lastHumid, lastPressure, lastType, lastTime;
-#endif // SENSOR_SDA
 
 #ifdef BOARD_TRMNL_X
 // --- TRMNL X hardware ---

--- a/include/misc/sensor.h
+++ b/include/misc/sensor.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <DEV_Config.h>
+#include <config.h>
+
+#ifdef SENSOR_SDA
+#define INCLUDE_ENV_SENSOR
+#endif
+
+#ifdef INCLUDE_ENV_SENSOR
+#include <bb_scd41.h>
+#include <bb_temperature.h>
+#endif
+
+/// @brief Environmental sample captured during this wake cycle. Temperatures
+///        are in tenths of a degree Celsius.
+struct SensorReadings {
+  int co2 = 0;           // ppm; 0 = no SCD41 sample
+  int scdTemperature = 0;
+  int scdHumidity = 0;   // percent
+  int sensorType = -1;   // bb_temperature device type; -1 = no sample
+  int temperature = 0;
+  int humidity = 0;      // percent
+  int pressure = 0;      // hectopascal
+  int sampledAt = 0;     // UTC epoch when the sample was captured
+};
+
+/// @brief Sensor interface. The base class silently does nothing and reports
+///        empty readings, for boards with no environmental sensor bus.
+class BaseSensor {
+public:
+  virtual ~BaseSensor() = default;
+
+  virtual void init() {}
+  virtual SensorReadings readings() { return SensorReadings(); }
+
+  /// @brief Builds the SENSORS HTTP header value from the last sample.
+  ///        Returns false when no sample is available; on success the caller
+  ///        owns *szTemp and must free() it.
+  virtual bool buildSensorsHeader(char **szTemp) {
+    (void)szTemp;
+    return false;
+  }
+};
+
+#ifdef INCLUDE_ENV_SENSOR
+/// @brief Samples an SCD41 CO2 sensor and/or a bb_temperature-supported
+///        sensor over I2C once per wake cycle.
+class EnvironmentSensor : public BaseSensor {
+public:
+  EnvironmentSensor(int sdaPin, int sclPin) : _sdaPin(sdaPin), _sclPin(sclPin) {}
+  void init() override;
+  SensorReadings readings() override { return _readings; }
+  bool buildSensorsHeader(char **szTemp) override;
+
+private:
+  int _sdaPin;
+  int _sclPin;
+  SCD41 _scd41;
+  BBTemp _bbt;
+  SensorReadings _readings;
+};
+#endif // INCLUDE_ENV_SENSOR
+
+/// @brief Sensor instance for the running board, selected at compile time.
+BaseSensor &sensor();

--- a/src/api-client/display.cpp
+++ b/src/api-client/display.cpp
@@ -8,60 +8,19 @@
 #include <globals.h>
 #include <http_client.h>
 #include <inttypes.h>
+#include <misc/sensor.h>
 #include <trmnl_log.h>
-#ifdef SENSOR_SDA
-const char *szDevices[] = {"None",    "AHT20",  "BMP180",  "BME280", "BMP388", "SHT3X",
-                           "HDC1080", "HTS221", "MCP9808", "BME68x", "SHTC3"};
-const char *szMakers[] = {"None", "ASAIR",   "Bosch",     "Bosch", "Bosch",    "Sensirion",
-                          "TI",   "STMicro", "MicroChip", "Bosch", "Sensirion"};
-#endif // SENSOR_SDA
 
 void addHeaders(HTTPClient &https, ApiDisplayInputs &inputs) {
   HttpHeaderList headers = buildDisplayHeaders(inputs);
 
-#ifdef SENSOR_SDA
-  char *szTemp, szPart[128];
-  szTemp = (char *)malloc(1024); // make sure we have enough space, but don't use the stack because it's small
-  szTemp[0] = 0;
-  if (lastCO2 != 0) { // valid data from SCD4x for CO2, Temperature and Humidity
-    // create the multi-value string to pass as a HTTP header
-    sprintf(szTemp,
-            "make=Sensirion;model=SCD41;kind=carbon_dioxide;value=%d;unit=parts_per_million;created_at=%d,make="
-            "Sensirion;model=SCD41;kind=temperature;value=%f;unit=celsius;created_at=%d,make=Sensirion;model=SCD41;"
-            "kind=humidity;value=%d;unit=percent;created_at=%d",
-            lastCO2, lastTime, (float)lastSCDTemp / 10.0f, lastTime, lastSCDHumid, lastTime);
-    Log_info("%s [%d] Adding SCD41 data to api request: CO2: %d, Temp: %d.%dC, Humidity: %d%%", __FILE__, __LINE__,
-             lastCO2, lastSCDTemp / 10, lastSCDTemp % 10, lastSCDHumid);
-  }
-  if (lastType >= 0 && lastTemp != 0) { // we have data from another bb_temperature supported sensor too; add it
-    if (lastCO2 != 0) {
-      strcat(szTemp, ","); // separate from CO2 data
-    } else {
-      szTemp[0] = 0;
-    }
-    Log_info("%s [%d] Adding bb_temperature data to api request: pressure: %d, Temp: %d.%dC, Humidity: %d%%", __FILE__,
-             __LINE__, lastPressure, lastTemp / 10, lastTemp % 10, lastHumid);
-    sprintf(szPart, "make=%s;model=%s;kind=temperature;value=%f;unit=celsius;created_at=%d", szMakers[lastType],
-            szDevices[lastType], (float)lastTemp / 10.0f, lastTime);
-    strcat(szTemp, szPart);
-    if (lastHumid > 0) { // add humidity
-      sprintf(szPart, ",make=%s;model=%s;kind=humidity;value=%d;unit=percent;created_at=%d", szMakers[lastType],
-              szDevices[lastType], lastHumid, lastTime);
-      strcat(szTemp, szPart);
-    }
-    if (lastPressure > 0) {
-      sprintf(szPart, ",make=%s;model=%s;kind=pressure;value=%d;unit=hectopascal;created_at=%d", szMakers[lastType],
-              szDevices[lastType], lastPressure, lastTime);
-      strcat(szTemp, szPart);
-    }
-  }
-  if (lastCO2 != 0 || lastType >= 0) {
+  char *szTemp;
+  if (sensor().buildSensorsHeader(&szTemp)) {
     headers.push_back({"SENSORS", szTemp});
+    free(szTemp);
   } else {
     Log_info("%s [%d] Sensor data not available", __FILE__, __LINE__);
   }
-  free(szTemp);
-#endif // SENSOR_SDA
 
   applyHeaders(https, headers);
   logHeaders(headers);

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -50,6 +50,7 @@
 #include <sys/time.h>
 #include <misc/buzzer.h>
 #include <misc/clock.h>
+#include <misc/sensor.h>
 #include <services/device_setup.h>
 #include "messages.h"
 #include "displayed_image.h"
@@ -714,70 +715,6 @@ void process_iqs323_data(void)
 #endif
 
 /**
- * @brief Function to initialize and read from I2C sensors (if present)
- * @param none
- * @return none
- */
-void sensor_init(void)
-{
-#ifdef SENSOR_SDA
-  // check if there is a SCD41 or supported temperature sensor attached
-  if (scd41.init(SENSOR_SDA, SENSOR_SCL) == SCD41_SUCCESS) {
-    bCO2 = true;
-    Log.info("%s [%d]: SCD41 sensor found!\r\n", __FILE__, __LINE__);
-//    scd41.start(SCD41_MODE_PERIODIC);
-    scd41.wakeup();
-    // The SCD41 needs to be re-initialized after big Vcc variations from the last wakeup
-    // put it in a 'confused' state. If we don't re-initialize it, it won't generate more samples
-    scd41.sendCMD(SCD41_CMD_REINIT);
-    vTaskDelay(3); // allow time to reinitialize
-    scd41.triggerSample(); // trigger a 'one-shot' sample that takes about 5 seconds to complete
-  }
-  if (bbt.init(SENSOR_SDA, SENSOR_SCL) == BBT_SUCCESS) {
-    iSensorType = bbt.type();
-    Log.info("%s [%d]: supported sensor found! (%d)\r\n", __FILE__, __LINE__, iSensorType);
-    bbt.start(); // start the sensor
-  }
-  if (!bCO2 && iSensorType < 0) {
-    Log.info("%s [%d]: No sensor found on I2C bus %d/%d\r\n", __FILE__, __LINE__, SENSOR_SDA, SENSOR_SCL);
-  }
-  // wait for the sensor(s) to generate a sample
-  if (bCO2 || iSensorType >= 0) {
-    Log.info("%s [%d]: Light sleep for 5 seconds to allow sensor to generate a sample\r\n", __FILE__, __LINE__);
-    esp_sleep_enable_timer_wakeup(5000 * 1000L); // the SCD4x needs 5 seconds to get a sample
-    esp_light_sleep_start(); // use light sleep to save power
-  }
-  if (bCO2) {
-    if (scd41.getSample() == SCD41_SUCCESS) {
-        time((time_t *)&lastTime); // get the UTC epoch time that the same was captured
-        lastCO2 = scd41.co2();
-        lastSCDTemp = scd41.temperature();
-        lastSCDHumid = scd41.humidity();
-        Log.info("%s [%d]: Got SCD41 sample: CO2 = %dppm\r\n", __FILE__, __LINE__, lastCO2);
-    } else {
-        Log.info("%s [%d]: SCD41 sample failed\r\n", __FILE__, __LINE__);
-        lastCO2 = 0;
-    }
-    scd41.shutdown(); // conserve power since we completed getting a sample ready for the next TRMNL wakeup
-  }
-  if (iSensorType >= 0) {
-      BBT_SAMPLE bbts;
-      if (bbt.getSample(&bbts) == BBT_SUCCESS) {
-        time((time_t *)&lastTime); // get the UTC epoch time that the same was captured
-        lastTemp = bbts.temperature;
-        lastHumid = bbts.humidity;
-        lastPressure = bbts.pressure;
-        lastType = iSensorType;
-        Log.info("%s [%d]: Got bb_temperature sample: Temp = %d.%dC\r\n", __FILE__, __LINE__, lastTemp/10, lastTemp % 10);
-      } else {
-        lastType = -1;
-        Log.info("%s [%d]: bb_temperature sample failed\r\n", __FILE__, __LINE__);
-      }
-      bbt.stop(); // turn off the sensor to conserve power
-  }
-#endif // SENSOR_SDA
-} /* sensor_init() */
-/**
  * @brief Function to init business logic module
  * @param none
  * @return none
@@ -820,7 +757,7 @@ void bl_init(void)
 #endif // X
   pins_init();
   buzzer().init();
-  sensor_init();
+  sensor().init();
 #ifdef BOARD_TRMNL_X
   // Debug: Print all wakeup_stub_iqs_status structure fields
   Log_info("wakeup_stub_iqs_status.status: 0x%02X 0x%02X", wakeup_stub_iqs_status.status[0], wakeup_stub_iqs_status.status[1]);

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -38,16 +38,6 @@ RTC_DATA_ATTR int iUpdateCount = 0;
 RTC_DATA_ATTR bool bCanDoPartial = false;
 uint32_t iTempProfile;
 
-#ifdef SENSOR_SDA
-// --- Environmental sensors ---
-SCD41 scd41;
-BBTemp bbt;
-bool bCO2 = false;
-int iSensorType = -1;
-int lastCO2 = 0, lastSCDTemp = 0, lastTemp = 0, lastSCDHumid = 0, lastHumid = 0, lastPressure = 0, lastType = -1,
-    lastTime = 0;
-#endif // SENSOR_SDA
-
 #ifdef BOARD_TRMNL_X
 // --- TRMNL X hardware ---
 // Set once during bl_init, used by download helpers and getWiFiStatus()

--- a/src/misc/sensor/environment_sensor.cpp
+++ b/src/misc/sensor/environment_sensor.cpp
@@ -1,0 +1,118 @@
+#include <misc/sensor.h>
+
+#ifdef INCLUDE_ENV_SENSOR
+
+#include <Arduino.h>
+#include <esp_sleep.h>
+#include <time.h>
+#include <trmnl_log.h>
+
+// bb_temperature device names, indexed by SensorReadings::sensorType
+static const char *szDevices[] = {"None",    "AHT20",  "BMP180",  "BME280", "BMP388", "SHT3X",
+                                  "HDC1080", "HTS221", "MCP9808", "BME68x", "SHTC3"};
+static const char *szMakers[] = {"None", "ASAIR",   "Bosch",     "Bosch", "Bosch",    "Sensirion",
+                                 "TI",   "STMicro", "MicroChip", "Bosch", "Sensirion"};
+
+void EnvironmentSensor::init() {
+  bool co2Found = false;
+  int sensorType = -1;
+
+  // check if there is a SCD41 or supported temperature sensor attached
+  if (_scd41.init(_sdaPin, _sclPin) == SCD41_SUCCESS) {
+    co2Found = true;
+    Log_info("SCD41 sensor found!");
+    _scd41.wakeup();
+    // The SCD41 needs to be re-initialized after big Vcc variations from the last wakeup
+    // put it in a 'confused' state. If we don't re-initialize it, it won't generate more samples
+    _scd41.sendCMD(SCD41_CMD_REINIT);
+    vTaskDelay(3);          // allow time to reinitialize
+    _scd41.triggerSample(); // trigger a 'one-shot' sample that takes about 5 seconds to complete
+  }
+  if (_bbt.init(_sdaPin, _sclPin) == BBT_SUCCESS) {
+    sensorType = _bbt.type();
+    Log_info("supported sensor found! (%d)", sensorType);
+    _bbt.start(); // start the sensor
+  }
+  if (!co2Found && sensorType < 0) {
+    Log_info("No sensor found on I2C bus %d/%d", _sdaPin, _sclPin);
+    return;
+  }
+
+  // wait for the sensor(s) to generate a sample
+  Log_info("Light sleep for 5 seconds to allow sensor to generate a sample");
+  esp_sleep_enable_timer_wakeup(5000 * 1000L); // the SCD4x needs 5 seconds to get a sample
+  esp_light_sleep_start();                     // use light sleep to save power
+
+  if (co2Found) {
+    if (_scd41.getSample() == SCD41_SUCCESS) {
+      _readings.sampledAt = (int)time(nullptr);
+      _readings.co2 = _scd41.co2();
+      _readings.scdTemperature = _scd41.temperature();
+      _readings.scdHumidity = _scd41.humidity();
+      Log_info("Got SCD41 sample: CO2 = %dppm", _readings.co2);
+    } else {
+      Log_info("SCD41 sample failed");
+    }
+    _scd41.shutdown(); // conserve power since we completed getting a sample ready for the next TRMNL wakeup
+  }
+  if (sensorType >= 0) {
+    BBT_SAMPLE bbts;
+    if (_bbt.getSample(&bbts) == BBT_SUCCESS) {
+      _readings.sampledAt = (int)time(nullptr);
+      _readings.temperature = bbts.temperature;
+      _readings.humidity = bbts.humidity;
+      _readings.pressure = bbts.pressure;
+      _readings.sensorType = sensorType;
+      Log_info("Got bb_temperature sample: Temp = %d.%dC", _readings.temperature / 10, _readings.temperature % 10);
+    } else {
+      Log_info("bb_temperature sample failed");
+    }
+    _bbt.stop(); // turn off the sensor to conserve power
+  }
+}
+
+bool EnvironmentSensor::buildSensorsHeader(char **szTemp) {
+  if (_readings.co2 == 0 && _readings.sensorType < 0) return false;
+
+  char szPart[128];
+  *szTemp = (char *)malloc(1024); // make sure we have enough space, but don't use the stack because it's small
+  (*szTemp)[0] = 0;
+  if (_readings.co2 != 0) { // valid data from SCD4x for CO2, Temperature and Humidity
+    // create the multi-value string to pass as a HTTP header
+    sprintf(*szTemp,
+            "make=Sensirion;model=SCD41;kind=carbon_dioxide;value=%d;unit=parts_per_million;created_at=%d,make="
+            "Sensirion;model=SCD41;kind=temperature;value=%f;unit=celsius;created_at=%d,make=Sensirion;model=SCD41;"
+            "kind=humidity;value=%d;unit=percent;created_at=%d",
+            _readings.co2, _readings.sampledAt, (float)_readings.scdTemperature / 10.0f, _readings.sampledAt,
+            _readings.scdHumidity, _readings.sampledAt);
+    Log_info("Adding SCD41 data to api request: CO2: %d, Temp: %d.%dC, Humidity: %d%%", _readings.co2,
+             _readings.scdTemperature / 10, _readings.scdTemperature % 10, _readings.scdHumidity);
+  }
+  if (_readings.sensorType >= 0 &&
+      _readings.temperature != 0) { // we have data from another bb_temperature supported sensor too; add it
+    if (_readings.co2 != 0) {
+      strcat(*szTemp, ","); // separate from CO2 data
+    } else {
+      (*szTemp)[0] = 0;
+    }
+    Log_info("Adding bb_temperature data to api request: pressure: %d, Temp: %d.%dC, Humidity: %d%%",
+             _readings.pressure, _readings.temperature / 10, _readings.temperature % 10, _readings.humidity);
+    sprintf(szPart, "make=%s;model=%s;kind=temperature;value=%f;unit=celsius;created_at=%d",
+            szMakers[_readings.sensorType], szDevices[_readings.sensorType], (float)_readings.temperature / 10.0f,
+            _readings.sampledAt);
+    strcat(*szTemp, szPart);
+    if (_readings.humidity > 0) { // add humidity
+      sprintf(szPart, ",make=%s;model=%s;kind=humidity;value=%d;unit=percent;created_at=%d",
+              szMakers[_readings.sensorType], szDevices[_readings.sensorType], _readings.humidity, _readings.sampledAt);
+      strcat(*szTemp, szPart);
+    }
+    if (_readings.pressure > 0) {
+      sprintf(szPart, ",make=%s;model=%s;kind=pressure;value=%d;unit=hectopascal;created_at=%d",
+              szMakers[_readings.sensorType], szDevices[_readings.sensorType], _readings.pressure, _readings.sampledAt);
+      strcat(*szTemp, szPart);
+    }
+  }
+  return true;
+}
+
+#endif // INCLUDE_ENV_SENSOR

--- a/src/misc/sensor/sensor.cpp
+++ b/src/misc/sensor/sensor.cpp
@@ -1,0 +1,9 @@
+#include <misc/sensor.h>
+
+#ifdef INCLUDE_ENV_SENSOR
+static EnvironmentSensor sensorInstance(SENSOR_SDA, SENSOR_SCL);
+#else
+static BaseSensor sensorInstance;
+#endif
+
+BaseSensor &sensor() { return sensorInstance; }


### PR DESCRIPTION
This PR reduces `bl.cpp` by 63 LOC, `display.cpp` by 41 LOC, and removes 12 globals.

I tackled this now because it does not conflict with any open PRs.

It's a simple wrapper around the I2C environmental sensor data, with a base implementation that does nothing if the SDA/SCL pins are undefined.