### PR TITLE
Fix devices getting stuck offline after a WiFi failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,14 @@ jobs:
       #- name: build (TRMNL_X)
       #  run: pio run -e TRMNL_X -j ${{ runner.os == 'Windows' && '1' || '4' }} -v
 
+      # Compile only. The suite needs a board to run, so nothing else here catches it drifting
+      # out of sync with the code it tests.
+      - name: build (on-device integration suite)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          cp test/integration/test_config.h.example test/integration/test_config.h
+          pio test -e trmnl_test --without-uploading --without-testing
+
       - name: test
         if: matrix.os != 'windows-latest'
         run: pio test -e native -v

--- a/lib/trmnl/include/refresh_interval.h
+++ b/lib/trmnl/include/refresh_interval.h
@@ -13,6 +13,9 @@ public:
   static constexpr const char *STREAK_KEY = "fast_polls";
 
   static constexpr uint32_t DEFAULT_SECONDS = 900;
+  static constexpr uint32_t WIFI_OFFLINE_SECONDS = 3600;
+  static constexpr uint8_t WIFI_SHORT_ATTEMPTS = 3;
+  static constexpr uint8_t WIFI_OFFLINE_HOURS = 168;
 
   explicit RefreshInterval(Persistence &persistence);
 
@@ -32,8 +35,9 @@ public:
 
   // Retry ladders; attempt is 1-based.
   uint32_t applyApiRetry(uint8_t attempt);  // 15 / 30 / 60, then DEFAULT_SECONDS
-  uint32_t applyWifiRetry(uint8_t attempt); // 60 / 180, then 300
-  uint32_t applyDefault();                  // fixed fallback, e.g. /api/setup 404
+  // 60 / 180 / 300, then hourly for a week, then 0 once the device should stop waking on a timer.
+  uint32_t applyWifiRetry(uint8_t attempt);
+  uint32_t applyDefault(); // fixed fallback, e.g. /api/setup 404
 
 private:
   static uint32_t fastPollSeconds(uint32_t streak);

--- a/lib/trmnl/src/refresh_interval.cpp
+++ b/lib/trmnl/src/refresh_interval.cpp
@@ -45,6 +45,8 @@ uint32_t RefreshInterval::applyApiRetry(uint8_t attempt) {
 }
 
 uint32_t RefreshInterval::applyWifiRetry(uint8_t attempt) {
+  if (attempt > WIFI_SHORT_ATTEMPTS + WIFI_OFFLINE_HOURS) return 0;
+
   uint32_t sleep;
   switch (attempt) {
   case 1:
@@ -53,8 +55,11 @@ uint32_t RefreshInterval::applyWifiRetry(uint8_t attempt) {
   case 2:
     sleep = 180;
     break;
-  default:
+  case 3:
     sleep = 300;
+    break;
+  default:
+    sleep = WIFI_OFFLINE_SECONDS;
     break;
   }
   writeIfChanged(sleep);

--- a/lib/wificaptive/src/connect.cpp
+++ b/lib/wificaptive/src/connect.cpp
@@ -153,8 +153,9 @@ void captureEventData(WiFiEvent_t event, WiFiEventInfo_t info, WifiEventData *ev
   case ARDUINO_EVENT_WIFI_STA_DISCONNECTED:
     eventData->disconnected = true;
     eventData->disconnectReason = (wifi_err_reason_t)info.wifi_sta_disconnected.reason;
-    Log_info("Wifi: Event STA_DISCONNECTED, reason: %s",
-             WiFi.disconnectReasonName((wifi_err_reason_t)info.wifi_sta_disconnected.reason));
+    // ERROR to clear store_submit_threshold; not the _submit variant, this runs in the event handler.
+    Log_error("Wifi: Event STA_DISCONNECTED, reason: %s",
+              WiFi.disconnectReasonName((wifi_err_reason_t)info.wifi_sta_disconnected.reason));
     break;
   default:
     Log_info("Wifi: Event (other): %s", WiFi.eventName((arduino_event_id_t)event));

--- a/lib/wificaptive/src/connect.cpp
+++ b/lib/wificaptive/src/connect.cpp
@@ -372,16 +372,21 @@ wl_status_t waitForConnectResult(uint32_t timeout) {
 
   unsigned long timeoutmillis = millis() + timeout;
   wl_status_t status = WiFi.status();
+  // Neither WiFi.disconnect() nor WiFi.begin() clears the status, so this first read can be the
+  // previous attempt's verdict.
+  bool statusBelongsToThisAttempt = false;
 
   while (millis() < timeoutmillis) {
     wl_status_t newStatus = WiFi.status();
     if (newStatus != status) {
       Log_info("WiFi: status changed from %s to %s", wifiStatusStr(status), wifiStatusStr(newStatus));
+      statusBelongsToThisAttempt = true;
     }
     status = newStatus;
     // @todo detect additional states, connect happens, then dhcp then get ip, there is some delay here, make sure not
     // to timeout if waiting on IP
-    if (status == WL_CONNECTED || status == WL_CONNECT_FAILED || status == WL_NO_SSID_AVAIL) {
+    if (statusBelongsToThisAttempt &&
+        (status == WL_CONNECTED || status == WL_CONNECT_FAILED || status == WL_NO_SSID_AVAIL)) {
       return status;
     }
     delay(100);

--- a/lib/wificaptive/src/connect.cpp
+++ b/lib/wificaptive/src/connect.cpp
@@ -373,8 +373,8 @@ wl_status_t waitForConnectResult(uint32_t timeout) {
 
   unsigned long timeoutmillis = millis() + timeout;
   wl_status_t status = WiFi.status();
-  // Neither WiFi.disconnect() nor WiFi.begin() clears the status, so this first read can be the
-  // previous attempt's verdict.
+  // Neither WiFi.disconnect() nor WiFi.begin() clears the status, so this first read can still
+  // belong to the previous attempt.
   bool statusBelongsToThisAttempt = false;
 
   while (millis() < timeoutmillis) {

--- a/lib/wificaptive/src/connect.cpp
+++ b/lib/wificaptive/src/connect.cpp
@@ -139,6 +139,33 @@ static void setWiFiBand(const WifiCredentials &credentials) {
 #endif
 }
 
+static wifi_err_reason_t lastDisconnectReason = WIFI_REASON_UNSPECIFIED;
+
+const char *lastWifiFailureDescription() {
+  switch (lastDisconnectReason) {
+  case WIFI_REASON_NO_AP_FOUND:
+    return "WiFi network not found.";
+  case WIFI_REASON_AUTH_FAIL:
+  case WIFI_REASON_AUTH_EXPIRE:
+  case WIFI_REASON_HANDSHAKE_TIMEOUT:
+  case WIFI_REASON_4WAY_HANDSHAKE_TIMEOUT:
+    return "WiFi password was refused.";
+  case WIFI_REASON_ASSOC_TOOMANY:
+    return "Router has no room for another device.";
+  case WIFI_REASON_ASSOC_FAIL:
+  case WIFI_REASON_NOT_AUTHED:
+  case WIFI_REASON_NOT_ASSOCED:
+    return "Router refused the connection.";
+  case WIFI_REASON_802_1X_AUTH_FAILED:
+    return "Network login was rejected.";
+  case WIFI_REASON_BEACON_TIMEOUT:
+  case WIFI_REASON_CONNECTION_FAIL:
+    return "WiFi signal is too weak.";
+  default:
+    return "Maximum WiFi retries reached.";
+  }
+}
+
 void captureEventData(WiFiEvent_t event, WiFiEventInfo_t info, WifiEventData *eventData) {
   switch (event) {
   case ARDUINO_EVENT_WIFI_STA_GOT_IP:
@@ -153,6 +180,7 @@ void captureEventData(WiFiEvent_t event, WiFiEventInfo_t info, WifiEventData *ev
   case ARDUINO_EVENT_WIFI_STA_DISCONNECTED:
     eventData->disconnected = true;
     eventData->disconnectReason = (wifi_err_reason_t)info.wifi_sta_disconnected.reason;
+    lastDisconnectReason = (wifi_err_reason_t)info.wifi_sta_disconnected.reason;
     // ERROR to clear store_submit_threshold; not the _submit variant, this runs in the event handler.
     Log_error("Wifi: Event STA_DISCONNECTED, reason: %s",
               WiFi.disconnectReasonName((wifi_err_reason_t)info.wifi_sta_disconnected.reason));

--- a/lib/wificaptive/src/connect.h
+++ b/lib/wificaptive/src/connect.h
@@ -8,3 +8,7 @@
 WifiConnectionResult initiateConnectionAndWaitForOutcome(const WifiCredentials credentials);
 wl_status_t waitForConnectResult(uint32_t timeout);
 void disableWpa2Enterprise();
+
+// What went wrong on the last disconnect, phrased for the screen. An offline device cannot ask the
+// server, so the wording is duplicated from Devices::WifiFailure in core rather than shared.
+const char *lastWifiFailureDescription();

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -2907,25 +2907,23 @@ static void wifiErrorDeepSleep()
 
   Log_info("WIFI connection failed! Retry count: %d \n", retry_count);
 
-  switch (retry_count)
-  {
-  case 1:
-  case 2:
-  case 3:
-    refreshInterval.applyWifiRetry(retry_count);
-    break;
+  uint32_t sleep_seconds = refreshInterval.applyWifiRetry(retry_count);
 
-  default:
-    preferences.putInt(PREFERENCES_CONNECT_WIFI_RETRY_COUNT, 1);
+  // The panel holds its image while asleep, so draw the message once rather than on every wake.
+  if (retry_count == RefreshInterval::WIFI_SHORT_ATTEMPTS + 1)
+  {
     showMessageWithLogo(WIFI_RETRY_LIMIT);
-    display_sleep();
+  }
+
+  display_sleep();
+
+  if (sleep_seconds == 0)
+  {
     goToSleepButtonOnly();
     return;
   }
-  retry_count++;
-  preferences.putInt(PREFERENCES_CONNECT_WIFI_RETRY_COUNT, retry_count);
 
-  display_sleep();
+  preferences.putInt(PREFERENCES_CONNECT_WIFI_RETRY_COUNT, retry_count + 1);
   goToSleep();
 }
 

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1,4 +1,5 @@
 #include <Arduino.h>
+#include <connect.h>
 #include <display.h>
 #include <power.h>
 #include <PNGdec.h>
@@ -2396,7 +2397,7 @@ void display_show_msg(uint8_t *image_buffer, MSG message_type, const char *messa
     break;
     case WIFI_RETRY_LIMIT:
     {
-        const char string1[] = "Maximum WiFi retries reached.";
+        const char *string1 = lastWifiFailureDescription();
         bbep.getStringBox(string1, &rect);
 #ifdef __BB_EPAPER__
         bbep.setCursor((bbep.width() - rect.w) / 2, 340);

--- a/test/integration/test_all/all.test.cpp
+++ b/test/integration/test_all/all.test.cpp
@@ -6,6 +6,7 @@
 // declare it in tests.h, and call it from setup() between UNITY_BEGIN/END.
 
 #include <Arduino.h>
+#include <ArduinoLog.h>
 #include <Preferences.h>
 #include <device_id.h>
 #include <unity.h>
@@ -24,6 +25,8 @@ void setup_bl() {
 
 void setup() {
   Serial.begin(115200);
+  // bl_init() normally does this; without it every Log_* in the code under test is dropped.
+  Log.begin(LOG_LEVEL_VERBOSE, &Serial);
 
   setup_bl();
 
@@ -34,7 +37,7 @@ void setup() {
   test_api_setup();
   test_tls_resume();
   // test_api_display();
-  // test_wifi(); // must be last in the suite, until production bug is fixed
+  test_wifi(); // must be last in the suite, until production bug is fixed
 
   UNITY_END();
 }

--- a/test/integration/test_all/api_display_tests.cpp
+++ b/test/integration/test_all/api_display_tests.cpp
@@ -11,6 +11,7 @@
 #include <api-client/setup.h>
 #include <config.h>  // FW_VERSION_STRING, DEVICE_MODEL
 #include <display.h> // display_width(), display_height()
+#include <refresh_interval.h>
 #include <special_function.h>
 #include <test_helpers.h>
 #include <unity.h>

--- a/test/integration/test_all/tls_resume_tests.cpp
+++ b/test/integration/test_all/tls_resume_tests.cpp
@@ -20,6 +20,7 @@
 #include <api-client/setup.h>
 #include <config.h>
 #include <display.h>
+#include <refresh_interval.h>
 #include <resumable_wifi_client_secure.h>
 #include <special_function.h>
 #include <test_helpers.h>

--- a/test/integration/test_all/wifi_tests.cpp
+++ b/test/integration/test_all/wifi_tests.cpp
@@ -1,5 +1,6 @@
 #include <Arduino.h>
 #include <WiFi.h>
+#include <time.h>
 #include <unity.h>
 
 #include "WifiCaptive.h"
@@ -43,14 +44,34 @@ static void test_wifi_fails_with_wrong_ssid(void) {
   disconnect_and_settle();
 
   WifiCredentials creds("definitely-not-the-real-ssid", "definitely-not-the-real-password");
-  wl_status_t status = WifiCaptivePortal.connect(creds);
+  wl_status_t status = WifiCaptivePortal.connect(creds).status;
 
   TEST_ASSERT_NOT_EQUAL_MESSAGE(WL_CONNECTED, status, "connect() should not return WL_CONNECTED with a wrong SSID");
   TEST_ASSERT_FALSE_MESSAGE(WiFi.isConnected(), "WiFi.isConnected() should be false after a failed connect()");
+}
+
+// Mirrors an AP that moved channel between wakes, leaving the cached hint stale.
+static void test_stale_fast_connect_hint_still_connects(void) {
+  disconnect_and_settle();
+
+  uint32_t now = (uint32_t)time(nullptr);
+  // An unset clock makes tryFastConnect skip itself, so this would pass without exercising the fallback.
+  TEST_ASSERT_GREATER_THAN_MESSAGE(0, now, "System clock must be set or this test proves nothing");
+
+  WifiCredentials creds(TEST_WIFI_SSID, TEST_WIFI_PASSWORD);
+  creds.bssid = "02:00:00:00:00:01"; // locally administered, cannot be on air
+  creds.channel = 1;
+  creds.lastFullScanEpoch = now;
+
+  wl_status_t status = WifiCaptivePortal.connect(creds).status;
+
+  TEST_ASSERT_EQUAL_MESSAGE(WL_CONNECTED, status,
+                            "A stale BSSID must fall back to a full channel scan and still connect");
 }
 
 void test_wifi(void) {
   RUN_TEST(test_wifi_connects_with_valid_credentials);
   RUN_TEST(test_wifi_fails_with_wrong_password);
   RUN_TEST(test_wifi_fails_with_wrong_ssid);
+  RUN_TEST(test_stale_fast_connect_hint_still_connects);
 }

--- a/test/integration/test_all/wifi_tests.cpp
+++ b/test/integration/test_all/wifi_tests.cpp
@@ -69,9 +69,26 @@ static void test_stale_fast_connect_hint_still_connects(void) {
                             "A stale BSSID must fall back to a full channel scan and still connect");
 }
 
+// The stale hint and the network are both gone, so the fallback scan finds nothing either and has
+// to report that rather than hang or inherit the fast connect's answer.
+static void test_stale_fast_connect_hint_on_an_absent_network_fails(void) {
+  disconnect_and_settle();
+
+  WifiCredentials creds("definitely-not-the-real-ssid", "definitely-not-the-real-password");
+  creds.bssid = "02:00:00:00:00:01";
+  creds.channel = 1;
+  creds.lastFullScanEpoch = (uint32_t)time(nullptr);
+
+  wl_status_t status = WifiCaptivePortal.connect(creds).status;
+
+  TEST_ASSERT_NOT_EQUAL_MESSAGE(WL_CONNECTED, status, "connect() should not report a connection it never made");
+  TEST_ASSERT_FALSE_MESSAGE(WiFi.isConnected(), "WiFi.isConnected() should be false after a failed connect()");
+}
+
 void test_wifi(void) {
   RUN_TEST(test_wifi_connects_with_valid_credentials);
   RUN_TEST(test_wifi_fails_with_wrong_password);
   RUN_TEST(test_wifi_fails_with_wrong_ssid);
   RUN_TEST(test_stale_fast_connect_hint_still_connects);
+  RUN_TEST(test_stale_fast_connect_hint_on_an_absent_network_fails);
 }

--- a/test/integration/test_all/wifi_tests.cpp
+++ b/test/integration/test_all/wifi_tests.cpp
@@ -23,7 +23,7 @@ static void test_wifi_connects_with_valid_credentials(void) {
   disconnect_and_settle();
 
   WifiCredentials creds(TEST_WIFI_SSID, TEST_WIFI_PASSWORD);
-  wl_status_t status = WifiCaptivePortal.connect(creds);
+  wl_status_t status = WifiCaptivePortal.connect(creds).status;
 
   TEST_ASSERT_EQUAL_MESSAGE(WL_CONNECTED, status, "Expected WL_CONNECTED after connect() with valid credentials");
   TEST_ASSERT_TRUE_MESSAGE(WiFi.isConnected(), "WiFi.isConnected() should be true after a successful connect()");
@@ -33,7 +33,7 @@ static void test_wifi_fails_with_wrong_password(void) {
   disconnect_and_settle();
 
   WifiCredentials creds(TEST_WIFI_SSID, "definitely-not-the-real-password");
-  wl_status_t status = WifiCaptivePortal.connect(creds);
+  wl_status_t status = WifiCaptivePortal.connect(creds).status;
 
   TEST_ASSERT_NOT_EQUAL_MESSAGE(WL_CONNECTED, status, "connect() should not return WL_CONNECTED with a wrong password");
   TEST_ASSERT_FALSE_MESSAGE(WiFi.isConnected(), "WiFi.isConnected() should be false after a failed connect()");

--- a/test/test_refresh_interval/refresh_interval.test.cpp
+++ b/test/test_refresh_interval/refresh_interval.test.cpp
@@ -120,6 +120,22 @@ void test_wifi_retry_ladder(void) {
   TEST_ASSERT_EQUAL_UINT32(300, refreshInterval.seconds());
 }
 
+void test_wifi_retry_falls_back_to_hourly(void) {
+  MemoryPersistence persistence;
+  RefreshInterval refreshInterval(persistence);
+  TEST_ASSERT_EQUAL_UINT32(3600, refreshInterval.applyWifiRetry(4));
+  TEST_ASSERT_EQUAL_UINT32(3600, refreshInterval.applyWifiRetry(171));
+  TEST_ASSERT_EQUAL_UINT32(3600, refreshInterval.seconds());
+}
+
+void test_wifi_retry_stops_after_a_week_of_hourly_attempts(void) {
+  MemoryPersistence persistence;
+  RefreshInterval refreshInterval(persistence);
+  refreshInterval.applyWifiRetry(171);
+  TEST_ASSERT_EQUAL_UINT32(0, refreshInterval.applyWifiRetry(172));
+  TEST_ASSERT_EQUAL_UINT32(3600, refreshInterval.seconds());
+}
+
 void test_default_fallback_is_fifteen_minutes(void) {
   MemoryPersistence persistence;
   RefreshInterval refreshInterval(persistence);
@@ -154,6 +170,8 @@ void process() {
   RUN_TEST(test_server_rate_writes_when_key_is_absent_even_at_the_default);
   RUN_TEST(test_api_retry_ladder);
   RUN_TEST(test_wifi_retry_ladder);
+  RUN_TEST(test_wifi_retry_falls_back_to_hourly);
+  RUN_TEST(test_wifi_retry_stops_after_a_week_of_hourly_attempts);
   RUN_TEST(test_default_fallback_is_fifteen_minutes);
   RUN_TEST(test_seconds_defaults);
   UNITY_END();


### PR DESCRIPTION
Devices can get stuck offline after a WiFi failure. The fallback scan after a failed fast connect returns immediately instead of scanning, and after four failed wakes the device only wakes again on a button press — two devices in one office lost 113 and 67 hours that way.

- fixes waitForConnectResult returning the previous attempt's status, which aborted the fallback channel scan
- continues the retry ladder hourly for a week before it stops waking on a timer
- draws the retry message once instead of on every hourly wake
- logs the 802.11 disconnect reason at ERROR so it reaches the server, instead of only "WL Status: 4" which covers AUTH_FAIL, ASSOC_FAIL, ASSOC_TOOMANY and a handshake timeout alike
- moves the WiFi ladder into RefreshInterval, putting the week boundary under the native tests
- repairs the on-device integration suite, which hasn't compiled since connect() started returning WifiConnectionResult, and adds a compile-only run of it to CI

A week covers 98.2% of the check-in gaps devices actually recover from, and hourly wakes over that week cost about a quarter of a normal week's battery at the median 15 minute refresh.

Verified on an ESP32-C3: with a stale cached BSSID the fallback failed instantly before and connects after, and with the network also absent it reports failure on the timeout rather than inheriting the fast connect's answer.