### PR TITLE
[WIP] Stop devices displaying images the filesystem cut short

### DIFF
--- a/lib/trmnl/include/bmp.h
+++ b/lib/trmnl/include/bmp.h
@@ -9,3 +9,5 @@ enum bmp_err_e {
 };
 
 bmp_err_e parseBMPHeader(uint8_t *data, bool &reserved);
+
+bool bmpIsTruncated(const uint8_t *data, uint32_t length);

--- a/lib/trmnl/src/bmp.cpp
+++ b/lib/trmnl/src/bmp.cpp
@@ -3,6 +3,25 @@
 #include <trmnl_log.h>
 
 /**
+ * @brief Function to tell a whole BMP from one the filesystem cut short
+ *        A BMP carries its own byte count at offset 2, so a file shorter than that count lost
+ *        bytes on the way to flash and decodes as half a picture.
+ * @param data pointer to the buffer
+ * @param length bytes actually in the buffer
+ * @return true if the buffer is a BMP that is missing bytes; false for anything we cannot tell
+ */
+bool bmpIsTruncated(const uint8_t *data, uint32_t length) {
+  if (length < 2 || data[0] != 'B' || data[1] != 'M') return false; // not a BMP, so not ours to judge
+
+  if (length < 6) return true; // too short to even carry its own byte count
+
+  uint32_t declaredLength =
+    (uint32_t)data[2] | ((uint32_t)data[3] << 8) | ((uint32_t)data[4] << 16) | ((uint32_t)data[5] << 24);
+
+  return declaredLength > length;
+}
+
+/**
  * @brief Function to parse .bmp file header
  * @param data pointer to the buffer
  * @param reserved variable address to store parsed color schematic

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1,4 +1,5 @@
 #include <Arduino.h>
+#include <bmp.h>
 #include <display.h>
 #include <power.h>
 #include <PNGdec.h>
@@ -1921,6 +1922,12 @@ uint8_t *buffer;
   }
   f.read(buffer, *file_size);
   f.close();
+  if (bmpIsTruncated(buffer, *file_size)) {
+    Serial.println("File lost bytes on the way to flash!");
+    free(buffer);
+    *file_size = 0;
+    return nullptr;
+  }
   return buffer;
 } /* display_read_file() */
 

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -1,4 +1,5 @@
 #include <Arduino.h>
+#include <bmp.h>
 #include <filesystem.h>
 #include <inttypes.h>
 #include <trmnl_log.h>
@@ -65,8 +66,13 @@ size_t filesystem_read_and_allocate(const char *name, uint8_t **out_buffer) {
         return 0;
       }
       file.readBytes((char *)buffer, size);
-      *out_buffer = buffer;
       file.close();
+      if (bmpIsTruncated(buffer, size)) {
+        Log_error("File %s lost bytes on the way to flash", name);
+        free(buffer);
+        return 0;
+      }
+      *out_buffer = buffer;
       return size;
     } else {
       Log_error("File %s open error", name);
@@ -111,7 +117,7 @@ void filesystem_purge_old_file(const char *name) {
   uint32_t timestamp;
   time_t now;
   File rootDir;
-  char *s, szTemp[32];
+  char *s, szTemp[36];
   bool bDel;
 
   time(&now); // get the current epoch time
@@ -130,8 +136,7 @@ void filesystem_purge_old_file(const char *name) {
     timestamp = filesystem_extract_timestamp(s);
     bDel = false;
 
-    strcpy(szTemp, "/"); // needed on this file operation
-    strcat(szTemp, file.name());
+    snprintf(szTemp, sizeof(szTemp), "/%s", file.name()); // needed on this file operation
 
     Log_info("Comparing name %s with %s, timestamp %" PRIu32 ", current time %" PRIu32, name, file.name(), timestamp,
              (uint32_t)now);
@@ -153,6 +158,64 @@ void filesystem_purge_old_file(const char *name) {
 } /* filesystem_purge_old_file() */
 
 /**
+ * @brief Function to delete the oldest cached image
+ *        Images with no timestamp are the setup logo and the last displayed image, the only
+ *        picture a device has when it cannot reach the API, so they are left alone.
+ * @param none
+ * @return true if an image was deleted; false if there was nothing we are willing to delete
+ */
+static bool filesystem_evict_oldest_image(void) {
+  char oldest[36] = "";
+  uint32_t oldestTimestamp = 0;
+
+  File rootDir = FS.open("/");
+  while (File file = rootDir.openNextFile()) {
+    uint32_t timestamp = filesystem_extract_timestamp(file.name());
+    if (!file.isDirectory() && timestamp != 0 && (oldest[0] == '\0' || timestamp < oldestTimestamp)) {
+      oldestTimestamp = timestamp;
+      snprintf(oldest, sizeof(oldest), "/%s", file.name());
+    }
+    file.close();
+  }
+  rootDir.close();
+
+  if (oldest[0] == '\0') {
+    Log_info("Nothing left to evict");
+    return false;
+  }
+
+  Log_info("Evicting %s", oldest);
+  return FS.remove(oldest);
+} /* filesystem_evict_oldest_image() */
+
+/**
+ * @brief Function to write a buffer to a file in chunks, without any recovery
+ * @param name filename
+ * @param in_buffer pointer to input buffer
+ * @param size size of the input buffer
+ * @return size of written bytes, less than size if the filesystem ran out of room
+ */
+static size_t filesystem_write_chunks(const char *name, uint8_t *in_buffer, size_t size) {
+  File file = FS.open(name, FILE_WRITE, true);
+  if (!file) {
+    Log_error("File open ERROR");
+    return 0;
+  }
+
+  size_t bytesWritten = 0;
+  while (bytesWritten < size) {
+    size_t chunkSize = _min(4096, size - bytesWritten);
+    if (file.write(in_buffer + bytesWritten, chunkSize) != chunkSize) {
+      break;
+    }
+    bytesWritten += chunkSize;
+  }
+
+  file.close();
+  return bytesWritten;
+} /* filesystem_write_chunks() */
+
+/**
  * @brief Function to write data to file
  * @param name filename
  * @param in_buffer pointer to input buffer
@@ -172,35 +235,27 @@ size_t filesystem_write_to_file(const char *name, uint8_t *in_buffer, size_t siz
     Log_info("file %s doesn't exist.", name);
   }
 //    delay(100);
-  File file = FS.open(name, FILE_WRITE, true);
-  if (file) {
-        // Write the buffer in chunks
-    size_t bytesWritten = 0;
-    while (bytesWritten < size) {
-
-      size_t diff = size - bytesWritten;
-      size_t chunkSize = _min(4096, diff);
-      uint16_t res = file.write(in_buffer + bytesWritten, chunkSize);
-      if (res != chunkSize) {
-        file.close();
-
-        Log_info("Erasing FS...");
-        if (FS.format()) {
-          Log_info("FS erased successfully.");
-        } else {
-          Log_error("Error erasing FS.");
-        }
-
-        return bytesWritten;
-      }
-      bytesWritten += chunkSize;
+  // SPIFFS hands out well under what it reports free, by an amount that moves with fragmentation
+  // (measured on an OG: a 12K write refused with 22K free), so make room by trying rather than by
+  // predicting. Formatting stays as the last resort, once there is nothing left to evict.
+  for (;;) {
+    size_t bytesWritten = filesystem_write_chunks(name, in_buffer, size);
+    if (bytesWritten == size) {
+      Log_info("file %s writing success - %d bytes", name, bytesWritten);
+      return bytesWritten;
     }
-    Log_info("file %s writing success - %d bytes", name, bytesWritten);
-    file.close();
-    return bytesWritten;
-  } else {
-    Log_error("File open ERROR");
-    return 0;
+
+    FS.remove(name); // the partial file is dead weight, and its space is worth reclaiming
+
+    if (!filesystem_evict_oldest_image()) {
+      Log_info("Erasing FS...");
+      if (FS.format()) {
+        Log_info("FS erased successfully.");
+      } else {
+        Log_error("Error erasing FS.");
+      }
+      return bytesWritten;
+    }
   }
 }
 
@@ -310,7 +365,7 @@ void filesystem_fix_filename(const char *src, char *dest) {
     strcpy(&dest[8],
            &src[iLen - 17]); // get the prefix name and unique id plus timestamp (e.g. mashup-066cc3-1771674964)
   } else {
-    strncpy(&dest[1], src, 31); // use it as-is
+    strcpy(&dest[1], src); // use it as-is; strncpy left a 31 character name unterminated
   }
 } /* filesystem_fix_filename() */
 

--- a/test/integration/test_all/all.test.cpp
+++ b/test/integration/test_all/all.test.cpp
@@ -6,6 +6,7 @@
 // declare it in tests.h, and call it from setup() between UNITY_BEGIN/END.
 
 #include <Arduino.h>
+#include <ArduinoLog.h>
 #include <Preferences.h>
 #include <device_id.h>
 #include <unity.h>
@@ -24,10 +25,14 @@ void setup_bl() {
 
 void setup() {
   Serial.begin(115200);
+  // bl_init() normally does this; without it every Log_* in the code under test is dropped.
+  Log.begin(LOG_LEVEL_VERBOSE, &Serial);
 
   setup_bl();
 
   UNITY_BEGIN();
+
+  test_filesystem(); // needs no network, so it reports before anything can fail on WiFi
 
   RUN_TEST(connect_to_wifi);
 

--- a/test/integration/test_all/api_display_tests.cpp
+++ b/test/integration/test_all/api_display_tests.cpp
@@ -11,6 +11,7 @@
 #include <api-client/setup.h>
 #include <config.h>  // FW_VERSION_STRING, DEVICE_MODEL
 #include <display.h> // display_width(), display_height()
+#include <refresh_interval.h>
 #include <special_function.h>
 #include <test_helpers.h>
 #include <unity.h>

--- a/test/integration/test_all/filesystem_tests.cpp
+++ b/test/integration/test_all/filesystem_tests.cpp
@@ -1,0 +1,193 @@
+// Cache eviction against real SPIFFS. The native suite covers the eviction policy; only
+// hardware can show how much slack SPIFFS needs before it refuses to allocate, and whether
+// evicting actually spares the filesystem from being formatted.
+
+#include <Arduino.h>
+#include <SPIFFS.h>
+#include <filesystem.h>
+#include <unity.h>
+
+#include "tests.h"
+
+static const size_t IMAGE_BYTES = 12000; // what a dithered OG screen compresses to
+static const int MAX_FILL_IMAGES = 60;
+static uint8_t *image_buffer = nullptr;
+
+static void image_name(char *out, size_t out_size, int index) {
+  snprintf(out, out_size, "/plugin-%06d-%010u", index, 1786700000u + (unsigned)index);
+}
+
+/// Writes straight to SPIFFS, chunked the way filesystem_write_to_file does, so that filling
+/// the filesystem does not go through the eviction we are trying to test.
+static bool write_image_directly(const char *name) {
+  File file = SPIFFS.open(name, FILE_WRITE, true);
+  if (!file) {
+    return false;
+  }
+
+  size_t written = 0;
+  while (written < IMAGE_BYTES) {
+    size_t chunk = _min(4096, IMAGE_BYTES - written);
+    if (file.write(image_buffer + written, chunk) != chunk) {
+      file.close();
+      return false;
+    }
+    written += chunk;
+  }
+  file.close();
+  return true;
+}
+
+static uint32_t free_bytes() { return SPIFFS.totalBytes() - SPIFFS.usedBytes(); }
+
+static int count_files() {
+  int files = 0;
+  File rootDir = SPIFFS.open("/");
+  while (File file = rootDir.openNextFile()) {
+    if (!file.isDirectory()) {
+      files++;
+    }
+    file.close();
+  }
+  rootDir.close();
+  return files;
+}
+
+// The number this test prints is what FS_WRITE_HEADROOM_BYTES has to cover.
+static void test_spiffs_refuses_to_allocate_while_it_still_reports_free_space(void) {
+  TEST_ASSERT_TRUE(SPIFFS.format());
+
+  char name[36];
+  uint32_t free_at_failure = 0;
+  int images_written = 0;
+
+  for (int i = 0; i < MAX_FILL_IMAGES; i++) {
+    image_name(name, sizeof(name), i);
+    free_at_failure = free_bytes();
+    if (!write_image_directly(name)) {
+      break;
+    }
+    images_written++;
+    free_at_failure = 0;
+  }
+
+  char message[192];
+  snprintf(message, sizeof(message),
+           "SPIFFS total %u bytes, fit %d images of %u, then refused a write with %u bytes still free",
+           (unsigned)SPIFFS.totalBytes(), images_written, (unsigned)IMAGE_BYTES, (unsigned)free_at_failure);
+  TEST_MESSAGE(message);
+
+  TEST_ASSERT_NOT_EQUAL_MESSAGE(0, free_at_failure,
+                                "filesystem never refused a write - raise MAX_FILL_IMAGES or IMAGE_BYTES");
+}
+
+static void test_a_full_filesystem_evicts_the_oldest_image_instead_of_formatting(void) {
+  TEST_ASSERT_TRUE(SPIFFS.format());
+
+  // No timestamp, so this stands in for the setup logo and the last displayed image: the only
+  // picture a device has when it cannot reach the API. Eviction must leave it alone.
+  File fallback = SPIFFS.open("/current.bmp", FILE_WRITE, true);
+  TEST_ASSERT_TRUE(fallback);
+  fallback.write(image_buffer, 1024);
+  fallback.close();
+
+  char oldest[36];
+  image_name(oldest, sizeof(oldest), 0);
+
+  char name[36];
+  int filled = 0;
+  while (free_bytes() > IMAGE_BYTES && filled < MAX_FILL_IMAGES) {
+    image_name(name, sizeof(name), filled);
+    if (!write_image_directly(name)) {
+      break;
+    }
+    filled++;
+  }
+  TEST_ASSERT_GREATER_THAN_MESSAGE(2, filled, "did not fit enough images to have anything to evict");
+
+  uint32_t free_before = free_bytes();
+  int files_before = count_files();
+
+  char arrival[36];
+  image_name(arrival, sizeof(arrival), 999);
+  size_t written = filesystem_write_to_file(arrival, image_buffer, IMAGE_BYTES);
+
+  char report[224];
+  snprintf(report, sizeof(report), "filled %d; before: %d files %u free; wrote %u of %u; after: %d files %u free",
+           filled, files_before, (unsigned)free_before, (unsigned)written, (unsigned)IMAGE_BYTES, count_files(),
+           (unsigned)free_bytes());
+  TEST_MESSAGE(report);
+
+  TEST_ASSERT_EQUAL_MESSAGE(IMAGE_BYTES, written, report);
+  TEST_ASSERT_TRUE_MESSAGE(SPIFFS.exists("/current.bmp"),
+                           "offline fallback is gone - the filesystem was formatted after all");
+  TEST_ASSERT_FALSE_MESSAGE(SPIFFS.exists(oldest), "oldest image survived - eviction chose the wrong file");
+  TEST_ASSERT_TRUE_MESSAGE(SPIFFS.exists(arrival), "the image we just wrote is not on the filesystem");
+}
+
+// Keeps the pre-existing recovery honest: with nothing evictable the write must still fail
+// rather than silently report success.
+static void test_a_filesystem_with_nothing_evictable_still_falls_back(void) {
+  TEST_ASSERT_TRUE(SPIFFS.format());
+
+  char name[36];
+  for (int i = 0; i < MAX_FILL_IMAGES; i++) {
+    snprintf(name, sizeof(name), "/logo-%02d.bmp", i); // no trailing epoch, so never evictable
+    if (!write_image_directly(name)) {
+      break;
+    }
+  }
+
+  TEST_ASSERT_NOT_EQUAL_MESSAGE(IMAGE_BYTES, filesystem_write_to_file("/plugin-abcdef-1786799999", image_buffer,
+                                                                     IMAGE_BYTES),
+                                "write reported success on a filesystem with no room and nothing to evict");
+}
+
+// A partial write used to survive on flash, and the cached-image path read it back and decoded
+// half a picture. Reading has to refuse it so the caller deletes it and downloads again.
+static void test_a_truncated_image_is_refused_rather_than_returned(void) {
+  TEST_ASSERT_TRUE(SPIFFS.format());
+
+  const uint32_t declared = IMAGE_BYTES;
+  image_buffer[0] = 'B';
+  image_buffer[1] = 'M';
+  image_buffer[2] = (uint8_t)declared;
+  image_buffer[3] = (uint8_t)(declared >> 8);
+  image_buffer[4] = (uint8_t)(declared >> 16);
+  image_buffer[5] = (uint8_t)(declared >> 24);
+
+  const char *cut_short = "/plugin-000001-1786700001";
+  File file = SPIFFS.open(cut_short, FILE_WRITE, true);
+  TEST_ASSERT_TRUE(file);
+  file.write(image_buffer, IMAGE_BYTES / 2); // the filesystem ran out of room half way through
+  file.close();
+
+  uint8_t *buffer = nullptr;
+  TEST_ASSERT_EQUAL_MESSAGE(0, filesystem_read_and_allocate(cut_short, &buffer),
+                            "a half-written image was handed back for display");
+
+  const char *whole = "/plugin-000002-1786700002";
+  TEST_ASSERT_TRUE(write_image_directly(whole));
+
+  buffer = nullptr;
+  TEST_ASSERT_EQUAL_MESSAGE(IMAGE_BYTES, filesystem_read_and_allocate(whole, &buffer),
+                            "a complete image was refused");
+  free(buffer);
+}
+
+void test_filesystem(void) {
+  image_buffer = (uint8_t *)malloc(IMAGE_BYTES);
+  TEST_ASSERT_NOT_NULL_MESSAGE(image_buffer, "could not allocate the test image buffer");
+  memset(image_buffer, 0xA5, IMAGE_BYTES);
+
+  TEST_ASSERT_TRUE(filesystem_init());
+
+  RUN_TEST(test_spiffs_refuses_to_allocate_while_it_still_reports_free_space);
+  RUN_TEST(test_a_full_filesystem_evicts_the_oldest_image_instead_of_formatting);
+  RUN_TEST(test_a_filesystem_with_nothing_evictable_still_falls_back);
+  RUN_TEST(test_a_truncated_image_is_refused_rather_than_returned);
+
+  SPIFFS.format(); // leave the bench board with a clean filesystem
+  free(image_buffer);
+  image_buffer = nullptr;
+}

--- a/test/integration/test_all/tests.h
+++ b/test/integration/test_all/tests.h
@@ -5,6 +5,7 @@
 // runs them all. all.test.cpp drives the suite by calling these in order
 // between UNITY_BEGIN() and UNITY_END().
 
+void test_filesystem(void);  // filesystem_tests.cpp
 void test_smoke(void);       // smoke_tests.cpp
 void test_wifi(void);        // wifi_tests.cpp
 void test_api_setup(void);   // api_setup_tests.cpp

--- a/test/integration/test_all/tls_resume_tests.cpp
+++ b/test/integration/test_all/tls_resume_tests.cpp
@@ -20,6 +20,7 @@
 #include <api-client/setup.h>
 #include <config.h>
 #include <display.h>
+#include <refresh_interval.h>
 #include <resumable_wifi_client_secure.h>
 #include <special_function.h>
 #include <test_helpers.h>

--- a/test/integration/test_all/wifi_tests.cpp
+++ b/test/integration/test_all/wifi_tests.cpp
@@ -23,7 +23,7 @@ static void test_wifi_connects_with_valid_credentials(void) {
   disconnect_and_settle();
 
   WifiCredentials creds(TEST_WIFI_SSID, TEST_WIFI_PASSWORD);
-  wl_status_t status = WifiCaptivePortal.connect(creds);
+  wl_status_t status = WifiCaptivePortal.connect(creds).status;
 
   TEST_ASSERT_EQUAL_MESSAGE(WL_CONNECTED, status, "Expected WL_CONNECTED after connect() with valid credentials");
   TEST_ASSERT_TRUE_MESSAGE(WiFi.isConnected(), "WiFi.isConnected() should be true after a successful connect()");
@@ -33,7 +33,7 @@ static void test_wifi_fails_with_wrong_password(void) {
   disconnect_and_settle();
 
   WifiCredentials creds(TEST_WIFI_SSID, "definitely-not-the-real-password");
-  wl_status_t status = WifiCaptivePortal.connect(creds);
+  wl_status_t status = WifiCaptivePortal.connect(creds).status;
 
   TEST_ASSERT_NOT_EQUAL_MESSAGE(WL_CONNECTED, status, "connect() should not return WL_CONNECTED with a wrong password");
   TEST_ASSERT_FALSE_MESSAGE(WiFi.isConnected(), "WiFi.isConnected() should be false after a failed connect()");
@@ -43,7 +43,7 @@ static void test_wifi_fails_with_wrong_ssid(void) {
   disconnect_and_settle();
 
   WifiCredentials creds("definitely-not-the-real-ssid", "definitely-not-the-real-password");
-  wl_status_t status = WifiCaptivePortal.connect(creds);
+  wl_status_t status = WifiCaptivePortal.connect(creds).status;
 
   TEST_ASSERT_NOT_EQUAL_MESSAGE(WL_CONNECTED, status, "connect() should not return WL_CONNECTED with a wrong SSID");
   TEST_ASSERT_FALSE_MESSAGE(WiFi.isConnected(), "WiFi.isConnected() should be false after a failed connect()");

--- a/test/test_bmp/bmp.test.cpp
+++ b/test/test_bmp/bmp.test.cpp
@@ -92,6 +92,44 @@ void test_parseBMPHeader_BMP_INVALID_OFFSET(void) {
   TEST_ASSERT_EQUAL(BMP_INVALID_OFFSET, parseBMPHeader(bmp_data.data(), image_reverse));
 }
 
+void test_bmpIsTruncated_whole_file(void) {
+  auto bmp_data = readBMPFile("./test.bmp");
+
+  TEST_ASSERT_FALSE(bmpIsTruncated(bmp_data.data(), bmp_data.size()));
+}
+
+void test_bmpIsTruncated_short_of_declared_length(void) {
+  auto bmp_data = readBMPFile("./test.bmp");
+
+  TEST_ASSERT_TRUE(bmpIsTruncated(bmp_data.data(), bmp_data.size() - 1));
+}
+
+// A partial write that stopped on a 4096-byte chunk boundary, which is how the filesystem cuts them.
+void test_bmpIsTruncated_first_chunk_only(void) {
+  auto bmp_data = readBMPFile("./test.bmp");
+
+  TEST_ASSERT_TRUE(bmpIsTruncated(bmp_data.data(), 4096));
+}
+
+void test_bmpIsTruncated_too_short_to_carry_its_length(void) {
+  uint8_t stub[4] = {'B', 'M', 0x00, 0x00};
+
+  TEST_ASSERT_TRUE(bmpIsTruncated(stub, sizeof(stub)));
+}
+
+// PNG and JPEG caches go through the same guard, and nothing in them declares a length.
+void test_bmpIsTruncated_ignores_other_formats(void) {
+  uint8_t png[8] = {0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A};
+
+  TEST_ASSERT_FALSE(bmpIsTruncated(png, sizeof(png)));
+}
+
+void test_bmpIsTruncated_accepts_a_zero_declared_length(void) {
+  uint8_t headerless[6] = {'B', 'M', 0x00, 0x00, 0x00, 0x00};
+
+  TEST_ASSERT_FALSE(bmpIsTruncated(headerless, sizeof(headerless)));
+}
+
 void setUp(void) {
   // set stuff up here
 }
@@ -108,6 +146,12 @@ void process() {
   RUN_TEST(test_parseBMPHeader_BMP_BAD_SIZE);
   RUN_TEST(test_parseBMPHeader_BMP_COLOR_SCHEME_FAILED);
   RUN_TEST(test_parseBMPHeader_BMP_INVALID_OFFSET);
+  RUN_TEST(test_bmpIsTruncated_whole_file);
+  RUN_TEST(test_bmpIsTruncated_short_of_declared_length);
+  RUN_TEST(test_bmpIsTruncated_first_chunk_only);
+  RUN_TEST(test_bmpIsTruncated_too_short_to_carry_its_length);
+  RUN_TEST(test_bmpIsTruncated_ignores_other_formats);
+  RUN_TEST(test_bmpIsTruncated_accepts_a_zero_declared_length);
   UNITY_END();
 }
 


### PR DESCRIPTION
[WIP] — the on-device suite has not been run and no X-class target has been built.

Devices show half-rendered screens, the top of the image correct and the bottom noise, and fully black ones. A device that ran out of room mid-write kept the half-written file, because the write path formatted the filesystem and only removed the partial file if the format succeeded. Nothing downstream checked the size, so the cached-image path read those bytes back and decoded half a picture.

usetrmnl/core#4316 made it visible by giving each playlist slot a filename that stopped changing, which turned every stale partial file into a cache hit. That PR is reverted in usetrmnl/core#4326 and needs this to land before it is retried.

- removes the partial file and evicts the oldest timestamped image before retrying a short write, formatting only once there is nothing left to evict
- leaves images with no timestamp alone when evicting, so `/logo.bmp` and `/current.bmp` survive
- adds `bmpIsTruncated`, comparing a buffer against the byte count the BMP header declares at offset 2
- rejects a truncated file in `filesystem_read_and_allocate` and `display_read_file`, both of which return nothing, which every caller already treats as a failure
- widens purge's buffer from 32 to 36 bytes and switches it to `snprintf`, since it was one byte short of the `/` it prepends to a 31 character name
- replaces `strncpy` in `filesystem_fix_filename`, which left a 31 character name unterminated
- adds on-device filesystem tests, and fixes the suite, which has not compiled against `main` since `WifiCaptivePortal.connect()` started returning a struct

SPIFFS hands out less than it reports free, by an amount that moves with fragmentation. On a bench OG, 18 images of 12,000 bytes left 10,793 bytes reported free and a 12,000 byte write still failed after 4,096. A `FS_WRITE_HEADROOM_BYTES` constant at 8192 passed native tests and built clean but still formatted the filesystem on hardware, so the write retries rather than predicts.

Two things found and left alone. `filesystem_purge_old_file` deletes any file whose last 10 characters are not digits, which is exactly the `/logo.bmp` and `/current.bmp` that eviction here keeps, so the two halves of the file now disagree. `parseBMPHeader` reads up to `data[61]` with no length parameter, so a file under 62 bytes over-reads; the new guard makes that harder to reach but does not close it.

80 native tests pass, six of them new for `bmpIsTruncated` against the real `test.bmp`, and `pio run -e trmnl` builds clean. Still to run: the on-device suite on a bench OG, the only place the eviction and truncation behaviour is proven against real flash, and it only builds with a board attached. No X-class target builds here — every ESP-IDF env fails on `ModuleNotFoundError: No module named 'fatfs'`, thrown in the platformio builder before any project source is read, so the change is unverified on LittleFS.
