### PR TITLE
TRMNL X: centre tap force-refreshes the current page

### DIFF
--- a/include/globals.h
+++ b/include/globals.h
@@ -59,6 +59,7 @@ extern uint32_t iTempProfile;
 
 #ifdef BOARD_TRMNL_X
 // --- TRMNL X hardware ---
+extern bool force_refresh_current; // centre tap: re-fetch the current page this wake
 extern Modem *g_modem;
 extern battery_count_t battery_count;
 extern bool battery_charging;

--- a/lib/trmnl/include/api_types.h
+++ b/lib/trmnl/include/api_types.h
@@ -77,6 +77,10 @@ struct ApiDisplayInputs {
   UsbStatus usbStatus;
   bool imageCached;
   int prevWakeTime;
+  // Centre-tap touch refresh: ask the server to re-render the current
+  // playlist item instead of advancing. Sent as the Refresh-Current header;
+  // servers that don't know it simply ignore it.
+  bool forceRefreshCurrent = false;
 };
 
 struct ApiLogInputs {

--- a/lib/trmnl/src/api-client/request_headers.cpp
+++ b/lib/trmnl/src/api-client/request_headers.cpp
@@ -29,6 +29,7 @@ HttpHeaderList buildDisplayHeaders(const ApiDisplayInputs &inputs) {
   if (inputs.firmwareCommit.length() > 0) headers.push_back({"FW-Commit", inputs.firmwareCommit});
   headers.push_back({"Model", String(inputs.model)});
   headers.push_back({"Image-Cached", inputs.imageCached ? "true" : "false"});
+  if (inputs.forceRefreshCurrent) headers.push_back({"Refresh-Current", "true"});
   headers.push_back({"Wake-Time", String(inputs.prevWakeTime)});
   headers.push_back({"RSSI", String(inputs.rssi)});
   if (inputs.wifiBand.length() > 0) headers.push_back({"WiFi-Band", inputs.wifiBand});

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -546,6 +546,11 @@ void check_channel_states(void)
             pending_indicator_side = TOUCHBAR_MIDDLE;
             pending_indicator_filled = false;
             has_pending_indicator = true;
+            // Centre tap = refresh the current page: fall through to the
+            // normal network poll, but mark it so the request carries
+            // Refresh-Current and the current image survives a WiFi failure.
+            force_refresh_current = true;
+            Log_info("FORCE_REFRESH_CURRENT requested by centre tap");
           }
           break;
         case 2:
@@ -578,6 +583,11 @@ void check_channel_states(void)
           case 1:
             display_draw_touchbar_indicator(TOUCHBAR_MIDDLE, slider_event == IQS323_GESTURE_HOLD);
             Log_info("Middle button pressed");
+            if (slider_event == IQS323_GESTURE_TAP) {
+              // Slide mode: a tap on the middle channel = refresh current page
+              force_refresh_current = true;
+              Log_info("FORCE_REFRESH_CURRENT requested by centre tap (slide mode)");
+            }
             // if (otg_state) {
             //   otg_turn_off();
             //   showMessageWithLogo(OTG_TURNED_OFF); otg_state = false;
@@ -976,7 +986,13 @@ void bl_init(void)
 
 #ifdef BOARD_TRMNL_X
 
-    if (!otg_message && WifiCaptivePortal.isSaved()) {
+    if (force_refresh_current) {
+      // Touch refresh: keep the current page on screen while fetching.
+      // DisplayedImage::clear() below still guarantees the fetched image
+      // repaints even if the server returns the same filename.
+      Log_info("Touch refresh: keeping current page, skipping logo screen");
+    }
+    else if (!otg_message && WifiCaptivePortal.isSaved()) {
       display_show_image(storedLogoOrDefault(1), DEFAULT_IMAGE_SIZE, false, true);
       if (has_pending_indicator) {
         display_draw_touchbar_indicator(pending_indicator_side, pending_indicator_filled);
@@ -1104,6 +1120,16 @@ void bl_init(void)
     }
     else
     {
+#ifdef BOARD_TRMNL_X
+      if (force_refresh_current)
+      {
+        // A refresh gesture with no WiFi must not replace the page the user
+        // was looking at with an error screen: repaint the cached current
+        // image and go back to sleep on the normal schedule.
+        Log_info("Touch refresh: WiFi unavailable - keeping current page");
+        showLastImageAndSleep(); // never returns
+      }
+#endif
       if (current_msg != WIFI_FAILED)
       {
         showMessageWithLogo(WIFI_FAILED);
@@ -1417,6 +1443,14 @@ ApiDisplayInputs loadApiDisplayInputs(Preferences &preferences)
   {
     inputs.updateSource = "unknown";
   }
+
+#ifdef BOARD_TRMNL_X
+  if (force_refresh_current)
+  {
+    inputs.forceRefreshCurrent = true;
+    inputs.updateSource = "touch-refresh";
+  }
+#endif
 
   if (preferences.isKey(PREFERENCES_API_KEY))
   {

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -40,6 +40,9 @@ uint32_t iTempProfile;
 
 #ifdef BOARD_TRMNL_X
 // --- TRMNL X hardware ---
+// Set by the centre-tap gesture during process_iqs323_data(); read when the
+// /api/display request is built. Per-boot only — deep sleep resets it.
+bool force_refresh_current = false;
 // Set once during bl_init, used by download helpers and getWiFiStatus()
 Modem *g_modem = nullptr;
 battery_count_t battery_count = BATTERY_NONE;

--- a/test/test_request_headers/request_headers.test.cpp
+++ b/test/test_request_headers/request_headers.test.cpp
@@ -121,6 +121,20 @@ void test_display_headers_image_cached_reflects_input(void) {
   TEST_ASSERT_EQUAL_STRING("true", valueOf(headers, "Image-Cached").c_str());
 }
 
+void test_display_headers_refresh_current_omitted_by_default(void) {
+  auto inputs = makeDisplayInputs();
+  auto headers = buildDisplayHeaders(inputs);
+  TEST_ASSERT_FALSE(has(headers, "Refresh-Current"));
+}
+
+void test_display_headers_refresh_current_present_when_set(void) {
+  auto inputs = makeDisplayInputs();
+  inputs.forceRefreshCurrent = true;
+  auto headers = buildDisplayHeaders(inputs);
+  TEST_ASSERT_TRUE(has(headers, "Refresh-Current"));
+  TEST_ASSERT_EQUAL_STRING("true", valueOf(headers, "Refresh-Current").c_str());
+}
+
 void test_display_headers_special_function_omitted_when_none(void) {
   auto inputs = makeDisplayInputs();
   inputs.specialFunction = SF_NONE;
@@ -213,6 +227,8 @@ void process() {
   RUN_TEST(test_display_headers_core_values);
   RUN_TEST(test_display_headers_include_update_source_and_temperature_profile);
   RUN_TEST(test_display_headers_image_cached_reflects_input);
+  RUN_TEST(test_display_headers_refresh_current_omitted_by_default);
+  RUN_TEST(test_display_headers_refresh_current_present_when_set);
   RUN_TEST(test_display_headers_special_function_omitted_when_none);
   RUN_TEST(test_display_headers_special_function_present_when_set);
   RUN_TEST(test_display_headers_wifi_band_2_4);


### PR DESCRIPTION
A centre tap (both touchbar modes) now marks the wake as a touch refresh: the request carries Refresh-Current: true and Update-Source: touch-refresh, the logo splash is skipped so the current page stays visible while fetching, and a WiFi failure repaints the cached current image instead of the error screen. Left/right navigation, hold gestures, and scheduled refreshes are byte-identical to stock.