### PR TITLE
Revert "WiFi fast connect using cached BSSID + channel (#439)"

### DIFF
--- a/lib/wificaptive/src/WifiCaptive.cpp
+++ b/lib/wificaptive/src/WifiCaptive.cpp
@@ -4,7 +4,6 @@
 #include <trmnl_log.h>
 #define _NO_DEV_CONFIG_
 #define UWORD uint16_t
-#include <time.h>
 
 #include "../../../include/display.h"
 #include "../../../include/power.h"
@@ -186,7 +185,7 @@ bool WifiCaptive::startPortal() {
         res = _modemConnectCallback(credentials.ssid, credentials.pswd);
         if (res) connected_via_modem = true;
       } else {
-        res = connect(credentials).status == WL_CONNECTED;
+        res = connect(credentials) == WL_CONNECTED;
       }
 
       if (res) {
@@ -281,9 +280,6 @@ void WifiCaptive::resetSettings() {
     preferences.remove(WIFI_STATIC_SN_KEY(i));
     preferences.remove(WIFI_STATIC_DNS1_KEY(i));
     preferences.remove(WIFI_STATIC_DNS2_KEY(i));
-    preferences.remove(WIFI_BSSID_KEY(i));
-    preferences.remove(WIFI_CHAN_KEY(i));
-    preferences.remove(WIFI_FULLSCAN_KEY(i));
   }
   preferences.end();
 
@@ -298,20 +294,17 @@ void WifiCaptive::resetSettings() {
   WiFi.eraseAP();
 }
 
-WifiConnectionResult WifiCaptive::connect(const WifiCredentials credentials) {
-  if (credentials.ssid == "") {
-    return {WL_NO_SSID_AVAIL, WifiEventData{}, false};
+wl_status_t WifiCaptive::connect(const WifiCredentials credentials) {
+  wl_status_t connRes = WL_NO_SSID_AVAIL;
+
+  if (credentials.ssid != "") {
+    WiFi.enableSTA(true);
+
+    auto result = initiateConnectionAndWaitForOutcome(credentials);
+    connRes = result.status;
   }
 
-    // Credentials/bssid/channel are already durably persisted via our own Preferences calls, so
-    // arduino-esp32's built-in WiFi NVS persistence is redundant - and fast connect can now call
-    // WiFi.begin() twice per wake cycle (fast attempt + full-scan fallback), which would otherwise
-    // double the flash writes to that partition on every fallback.
-  WiFi.persistent(false);
-
-  WiFi.enableSTA(true);
-
-  return initiateConnectionAndWaitForOutcome(credentials);
+  return connRes;
 }
 
 void WifiCaptive::setResetSettingsCallback(std::function<void()> func) { _resetcallback = func; }
@@ -345,9 +338,6 @@ void WifiCaptive::readWifiCredentials() {
     _savedWifis[i].subnet = preferences.getString(WIFI_STATIC_SN_KEY(i), "");
     _savedWifis[i].dns1 = preferences.getString(WIFI_STATIC_DNS1_KEY(i), "");
     _savedWifis[i].dns2 = preferences.getString(WIFI_STATIC_DNS2_KEY(i), "");
-    _savedWifis[i].bssid = preferences.getString(WIFI_BSSID_KEY(i), "");
-    _savedWifis[i].channel = preferences.getUChar(WIFI_CHAN_KEY(i), 0);
-    _savedWifis[i].lastFullScanEpoch = preferences.getUInt(WIFI_FULLSCAN_KEY(i), 0);
   }
 
   int idx = preferences.getInt(WIFI_LAST_INDEX, 0);
@@ -402,9 +392,6 @@ void WifiCaptive::saveWifiCredentials(const WifiCredentials credentials) {
     preferences.putString(WIFI_STATIC_SN_KEY(i), _savedWifis[i].subnet);
     preferences.putString(WIFI_STATIC_DNS1_KEY(i), _savedWifis[i].dns1);
     preferences.putString(WIFI_STATIC_DNS2_KEY(i), _savedWifis[i].dns2);
-    preferences.putString(WIFI_BSSID_KEY(i), _savedWifis[i].bssid);
-    preferences.putUChar(WIFI_CHAN_KEY(i), _savedWifis[i].channel);
-    preferences.putUInt(WIFI_FULLSCAN_KEY(i), _savedWifis[i].lastFullScanEpoch);
   }
   preferences.putInt(WIFI_LAST_INDEX, 0);
   preferences.end();
@@ -673,30 +660,13 @@ bool WifiCaptive::autoConnect() {
   return false;
 }
 
-bool WifiCaptive::tryConnectWithRetries(WifiCredentials creds, int last_used_index) {
+bool WifiCaptive::tryConnectWithRetries(const WifiCredentials creds, int last_used_index) {
   for (int attempt = 0; attempt < WIFI_CONNECTION_ATTEMPTS; attempt++) {
     Log_info("Attempt %d to connect to %s (Enterprise: %s, Static IP: %s, IP: %s)", attempt + 1, creds.ssid.c_str(),
              creds.isEnterprise ? "yes" : "no", creds.useStaticIP ? "yes" : "no", creds.staticIP.c_str());
-    auto connResult = connect(creds);
-    if (connResult.status == WL_CONNECTED) {
+    connect(creds);
+    if (WiFi.status() == WL_CONNECTED) {
       Log_info("Connected to %s", creds.ssid.c_str());
-      if (last_used_index >= 0 && last_used_index < WIFI_MAX_SAVED_CREDS && !creds.isEnterprise) {
-        String connBssid = WiFi.BSSIDstr();
-        uint8_t connChannel = (uint8_t)WiFi.channel();
-        Log_info("Saving fast-connect hint: BSSID %s, channel %d", connBssid.c_str(), connChannel);
-        _savedWifis[last_used_index].bssid = connBssid;
-        _savedWifis[last_used_index].channel = connChannel;
-        Preferences prefs;
-        prefs.begin("wificaptive", false);
-        prefs.putString(WIFI_BSSID_KEY(last_used_index), connBssid);
-        prefs.putUChar(WIFI_CHAN_KEY(last_used_index), connChannel);
-        if (connResult.usedFullScan) {
-          uint32_t nowEpoch = (uint32_t)time(nullptr);
-          _savedWifis[last_used_index].lastFullScanEpoch = nowEpoch;
-          prefs.putUInt(WIFI_FULLSCAN_KEY(last_used_index), nowEpoch);
-        }
-        prefs.end();
-      }
       if (last_used_index >= 0) {
         saveLastUsedWifiIndex(last_used_index);
       }
@@ -709,12 +679,6 @@ bool WifiCaptive::tryConnectWithRetries(WifiCredentials creds, int last_used_ind
       Log_info("Cleaning up WPA2 Enterprise state after failed attempt");
       disableWpa2Enterprise();
     }
-
-    // The cached BSSID/channel just proved unreachable (or connect() already fell back to a
-    // full scan and that failed too) - clear this local copy so remaining retries go straight
-    // to a full scan instead of repeating the same doomed fast-connect probe.
-    creds.bssid = "";
-    creds.channel = 0;
 
     if (attempt < WIFI_CONNECTION_ATTEMPTS - 1) {
       uint32_t backoff_delay = 2000 * (1 << attempt);

--- a/lib/wificaptive/src/WifiCaptive.h
+++ b/lib/wificaptive/src/WifiCaptive.h
@@ -14,50 +14,37 @@
 #include "WifiCaptivePage.h"
 #include "wifi-types.h"
 
-#define WIFI_SSID                   "TRMNL"
-#define WIFI_PASSWORD               NULL
+#define WIFI_SSID                "TRMNL"
+#define WIFI_PASSWORD            NULL
 
 // Define the DNS interval in milliseconds between processing DNS requests
-#define DNS_INTERVAL                60
+#define DNS_INTERVAL             60
 // Define the maximum number of clients that can connect to the server
-#define MAX_CLIENTS                 4
+#define MAX_CLIENTS              4
 // Define the WiFi channel to be used (channel 6 in this case)
-#define WIFI_CHANNEL                6
+#define WIFI_CHANNEL             6
 // Define the maximum number of possible saved credentials
-#define WIFI_MAX_SAVED_CREDS        5
+#define WIFI_MAX_SAVED_CREDS     5
 // Define the maximum number of connection attempts
-#define WIFI_CONNECTION_ATTEMPTS    3
+#define WIFI_CONNECTION_ATTEMPTS 3
 // Define max connection timeout
-#define CONNECTION_TIMEOUT          15000
-// Shorter timeout for fast-connect attempt (specific BSSID+channel); falls back to full scan on expiry
-#define WIFI_FAST_CONNECT_TIMEOUT   5000
+#define CONNECTION_TIMEOUT       15000
 
-#define WIFI_SSID_KEY(i)            ("wifi_" + String(i) + "_ssid").c_str()
-#define WIFI_PSWD_KEY(i)            ("wifi_" + String(i) + "_pswd").c_str()
-#define WIFI_5GHZ_KEY(i)            ("wifi_" + String(i) + "_5g").c_str()
-#define WIFI_ENT_KEY(i)             ("wifi_" + String(i) + "_ent").c_str()
-#define WIFI_USERNAME_KEY(i)        ("wifi_" + String(i) + "_username").c_str()
-#define WIFI_IDENTITY_KEY(i)        ("wifi_" + String(i) + "_identity").c_str()
+#define WIFI_SSID_KEY(i)         ("wifi_" + String(i) + "_ssid").c_str()
+#define WIFI_PSWD_KEY(i)         ("wifi_" + String(i) + "_pswd").c_str()
+#define WIFI_5GHZ_KEY(i)         ("wifi_" + String(i) + "_5g").c_str()
+#define WIFI_ENT_KEY(i)          ("wifi_" + String(i) + "_ent").c_str()
+#define WIFI_USERNAME_KEY(i)     ("wifi_" + String(i) + "_username").c_str()
+#define WIFI_IDENTITY_KEY(i)     ("wifi_" + String(i) + "_identity").c_str()
 // Static IP keys
-#define WIFI_STATIC_IP_KEY(i)       ("wifi_" + String(i) + "_sip").c_str()
-#define WIFI_STATIC_GW_KEY(i)       ("wifi_" + String(i) + "_sgw").c_str()
-#define WIFI_STATIC_SN_KEY(i)       ("wifi_" + String(i) + "_ssn").c_str()
-#define WIFI_STATIC_DNS1_KEY(i)     ("wifi_" + String(i) + "_dns1").c_str()
-#define WIFI_STATIC_DNS2_KEY(i)     ("wifi_" + String(i) + "_dns2").c_str()
-#define WIFI_USE_STATIC_KEY(i)      ("wifi_" + String(i) + "_usip").c_str()
+#define WIFI_STATIC_IP_KEY(i)    ("wifi_" + String(i) + "_sip").c_str()
+#define WIFI_STATIC_GW_KEY(i)    ("wifi_" + String(i) + "_sgw").c_str()
+#define WIFI_STATIC_SN_KEY(i)    ("wifi_" + String(i) + "_ssn").c_str()
+#define WIFI_STATIC_DNS1_KEY(i)  ("wifi_" + String(i) + "_dns1").c_str()
+#define WIFI_STATIC_DNS2_KEY(i)  ("wifi_" + String(i) + "_dns2").c_str()
+#define WIFI_USE_STATIC_KEY(i)   ("wifi_" + String(i) + "_usip").c_str()
 
-#define WIFI_BSSID_KEY(i)           ("wifi_" + String(i) + "_bssid").c_str()
-#define WIFI_CHAN_KEY(i)            ("wifi_" + String(i) + "_chan").c_str()
-#define WIFI_FULLSCAN_KEY(i)        ("wifi_" + String(i) + "_fscan").c_str()
-
-#define WIFI_LAST_INDEX             "wifi_last_index"
-
-// Minimum RSSI (dBm) to keep a fast-connect result; weaker signal triggers a full scan
-#define WIFI_FAST_CONNECT_MIN_RSSI  (-75)
-
-// Force a full channel scan at least this often, even if the cached BSSID still connects fine,
-// so the device can roam to a better AP/channel.
-#define WIFI_FULL_SCAN_INTERVAL_SEC (24UL * 60 * 60)
+#define WIFI_LAST_INDEX          "wifi_last_index"
 
 struct ExternalNetwork {
   String ssid;
@@ -100,13 +87,13 @@ private:
   int readLastUsedWifiIndex();
   void saveApiServer(String url);
   int findSavedWifiIndex(const WifiCredentials credentials);
-  bool tryConnectWithRetries(WifiCredentials creds, int last_used_index);
+  bool tryConnectWithRetries(const WifiCredentials creds, int last_used_index);
   std::vector<WifiCredentials> matchNetworks(std::vector<WifiNetwork> &scanResults, WifiCredentials wifiCredentials[]);
   std::vector<WifiNetwork> getScannedUniqueNetworks(bool runScan);
   std::vector<WifiNetwork> combineNetworks(std::vector<WifiNetwork> &scanResults, WifiCredentials wifiCredentials[]);
 
 public:
-  WifiConnectionResult connect(const WifiCredentials credentials);
+  wl_status_t connect(const WifiCredentials credentials);
 
   /// @brief Starts WiFi configuration portal.
   /// @return True if successfully connected to provided SSID, false otherwise.

--- a/lib/wificaptive/src/connect.cpp
+++ b/lib/wificaptive/src/connect.cpp
@@ -1,7 +1,6 @@
 #include "connect.h"
 
 #include <Preferences.h>
-#include <time.h>
 #include <trmnl_log.h>
 #include <vector>
 
@@ -14,24 +13,6 @@
 #include "esp_wifi.h"
 #include "esp_wpa2.h"
 #include "wifi-helpers.h"
-
-static bool parseBssid(const String &str, uint8_t out[6]) {
-  if (str.length() != 17) return false;
-  for (int i = 0; i < 6; i++) {
-    int pos = i * 3;
-    auto hexVal = [](char c) -> int {
-      if (c >= '0' && c <= '9') return c - '0';
-      if (c >= 'A' && c <= 'F') return c - 'A' + 10;
-      if (c >= 'a' && c <= 'f') return c - 'a' + 10;
-      return -1;
-    };
-    int hi = hexVal(str[pos]);
-    int lo = hexVal(str[pos + 1]);
-    if (hi < 0 || lo < 0) return false;
-    out[i] = (uint8_t)((hi << 4) | lo);
-  }
-  return true;
-}
 
 /**
  * @brief Configure static IP with smart defaults
@@ -162,62 +143,8 @@ void captureEventData(WiFiEvent_t event, WiFiEventInfo_t info, WifiEventData *ev
   }
 }
 
-/**
- * @brief Attempt a fast connect using the cached BSSID+channel, skipping the full channel scan.
- *
- * Skipped when the periodic roam scan is due (WIFI_FULL_SCAN_INTERVAL_SEC) so the device
- * can roam to a better AP/channel even when the cached AP still connects fine (see issue #285).
- * If the fast connect succeeds but the signal is weak (< WIFI_FAST_CONNECT_MIN_RSSI), the
- * connection is dropped so the caller can scan for a better AP.
- *
- * @param credentials WiFi credentials with cached channel/BSSID from a previous connection
- * @return true if connected with acceptable signal strength, false to fall back to a full scan
- */
-static bool tryFastConnect(const WifiCredentials &credentials) {
-  if (credentials.channel == 0 || credentials.bssid.length() == 0) {
-    return false;
-  }
-
-  uint32_t now = (uint32_t)time(nullptr);
-  bool clockLooksValid = credentials.lastFullScanEpoch != 0 && now >= credentials.lastFullScanEpoch;
-  uint32_t secondsSinceLastFullScan = clockLooksValid ? (now - credentials.lastFullScanEpoch) : 0;
-  bool fullScanDue = !clockLooksValid || secondsSinceLastFullScan >= WIFI_FULL_SCAN_INTERVAL_SEC;
-
-  if (fullScanDue) {
-    Log_info("WiFi: Periodic roam scan due (last full scan %us ago), skipping fast connect", secondsSinceLastFullScan);
-    return false;
-  }
-
-  uint8_t bssidBytes[6];
-  if (!parseBssid(credentials.bssid, bssidBytes)) {
-    return false;
-  }
-
-  Log_info("WiFi: Trying fast connect to %s on channel %d (BSSID %s)", credentials.ssid.c_str(), credentials.channel,
-           credentials.bssid.c_str());
-  WiFi.setScanMethod(WIFI_FAST_SCAN);
-  wl_status_t beginResult =
-    WiFi.begin(credentials.ssid.c_str(), credentials.pswd.c_str(), credentials.channel, bssidBytes);
-  Log_info("WiFi: Fast connect begin, status %s", wifiStatusStr(beginResult));
-  auto fastResult = waitForConnectResult(WIFI_FAST_CONNECT_TIMEOUT);
-  if (fastResult == WL_CONNECTED) {
-    int32_t rssi = WiFi.RSSI();
-    Log_info("WiFi: Fast connect succeeded, RSSI %d dBm", rssi);
-    if (rssi >= WIFI_FAST_CONNECT_MIN_RSSI) {
-      return true;
-    }
-    Log_info("WiFi: Weak signal (%d dBm < %d dBm), scanning for better AP", rssi, WIFI_FAST_CONNECT_MIN_RSSI);
-  } else {
-    Log_info("WiFi: Fast connect failed, falling back to full channel scan");
-  }
-  WiFi.disconnect();
-  delay(100);
-  return false;
-}
-
 WifiConnectionResult initiateConnectionAndWaitForOutcome(const WifiCredentials credentials) {
   WifiEventData eventData;
-  bool usedFullScan = false;
 
     // Register WiFi event handlers and remember each registration id.
   std::vector<wifi_event_id_t> handlerIds;
@@ -245,6 +172,16 @@ WifiConnectionResult initiateConnectionAndWaitForOutcome(const WifiCredentials c
     // always start with a clean state - disable any previous configuration
   disableWpa2Enterprise();
 
+  // Pick the strongest AP when an SSID is broadcast by multiple access points
+  // (mesh/roaming networks). The arduino-esp32 default is WIFI_FAST_SCAN, which
+  // associates with the FIRST AP found for the SSID regardless of signal strength,
+  // so the device can latch onto a weak/distant AP. WIFI_ALL_CHANNEL_SCAN scans
+  // every channel first, then WIFI_CONNECT_AP_BY_SIGNAL connects to the AP with the
+  // highest RSSI. Trade-off: a full-channel scan adds ~1-2s to each connect, which is
+  // an acceptable cost for reliably joining the nearest AP. See issue #285.
+  WiFi.setScanMethod(WIFI_ALL_CHANNEL_SCAN);
+  WiFi.setSortMethod(WIFI_CONNECT_AP_BY_SIGNAL);
+
   wl_status_t beginResult;
 
   WiFi.setAutoReconnect(false);
@@ -256,7 +193,7 @@ WifiConnectionResult initiateConnectionAndWaitForOutcome(const WifiCredentials c
       Log_error("WiFi: Enterprise mode requires an identity");
             // clean up event handlers
       removeEventHandlers();
-      return {WL_CONNECT_FAILED, eventData, usedFullScan};
+      return {WL_CONNECT_FAILED, eventData};
     }
 
         // configure WPA2 Enterprise
@@ -307,7 +244,7 @@ WifiConnectionResult initiateConnectionAndWaitForOutcome(const WifiCredentials c
       disableWpa2Enterprise();
             // clean up event handlers
       removeEventHandlers();
-      return {WL_CONNECT_FAILED, eventData, usedFullScan};
+      return {WL_CONNECT_FAILED, eventData};
     }
 
         // Configure static IP if specified (must be before WiFi.begin)
@@ -319,10 +256,6 @@ WifiConnectionResult initiateConnectionAndWaitForOutcome(const WifiCredentials c
 
     setWiFiBand(credentials);
 
-        // Full channel scan to pick the strongest AP (see issue #285)
-    usedFullScan = true;
-    WiFi.setScanMethod(WIFI_ALL_CHANNEL_SCAN);
-    WiFi.setSortMethod(WIFI_CONNECT_AP_BY_SIGNAL);
     WiFi.begin(credentials.ssid.c_str());
 
     beginResult = WiFi.status();
@@ -341,15 +274,6 @@ WifiConnectionResult initiateConnectionAndWaitForOutcome(const WifiCredentials c
 
     Log_info("WiFi: hostname set to %s", hostname.c_str());
 
-    if (tryFastConnect(credentials)) {
-      removeEventHandlers();
-      return {WL_CONNECTED, eventData, usedFullScan};
-    }
-
-        // Full channel scan: find the AP with the strongest signal for this SSID (see issue #285)
-    usedFullScan = true;
-    WiFi.setScanMethod(WIFI_ALL_CHANNEL_SCAN);
-    WiFi.setSortMethod(WIFI_CONNECT_AP_BY_SIGNAL);
     beginResult = WiFi.begin(credentials.ssid.c_str(), credentials.pswd.c_str());
     Log_info("WiFi: begin (WPA2-Personal), starting from status %s", wifiStatusStr(beginResult));
   }
@@ -365,7 +289,7 @@ WifiConnectionResult initiateConnectionAndWaitForOutcome(const WifiCredentials c
     // Clean up Arduino event handlers
   removeEventHandlers();
 
-  return {result, eventData, usedFullScan};
+  return {result, eventData};
 }
 
 wl_status_t waitForConnectResult(uint32_t timeout) {
@@ -381,7 +305,7 @@ wl_status_t waitForConnectResult(uint32_t timeout) {
     status = newStatus;
     // @todo detect additional states, connect happens, then dhcp then get ip, there is some delay here, make sure not
     // to timeout if waiting on IP
-    if (status == WL_CONNECTED || status == WL_CONNECT_FAILED || status == WL_NO_SSID_AVAIL) {
+    if (status == WL_CONNECTED || status == WL_CONNECT_FAILED) {
       return status;
     }
     delay(100);

--- a/lib/wificaptive/src/wifi-types.h
+++ b/lib/wificaptive/src/wifi-types.h
@@ -18,12 +18,6 @@ struct WifiCredentials {
   String subnet;      // e.g., "255.255.255.0" (optional - defaults to 255.255.255.0)
   String dns1;        // optional - defaults to gateway
   String dns2;        // optional - defaults to 8.8.8.8
-    // Fast-connect hint: populated after each successful connection
-  String bssid;        // "AA:BB:CC:DD:EE:FF"; empty if not yet known
-  uint8_t channel = 0; // 0 if not yet known
-    // Epoch (UTC seconds) of the last full channel scan for this network; 0 = never scanned.
-                       // Used to force a periodic roam scan even when the cached BSSID/channel still connects fine.
-  uint32_t lastFullScanEpoch = 0;
   WifiCredentials() : is5GHz(false) {}
   WifiCredentials(String ssid, String pswd, bool is5GHz = false) : ssid(ssid), pswd(pswd), is5GHz(is5GHz) {}
 };
@@ -48,5 +42,4 @@ struct WifiEventData {
 struct WifiConnectionResult {
   wl_status_t status;
   WifiEventData eventData;
-  bool usedFullScan; // true if this attempt performed a full channel scan (not fast connect)
 };

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -1083,7 +1083,7 @@ void bl_init(void)
   WifiCredentials hardcodedCreds = {.ssid = "ssid-goes-here", .pswd = "password-goes-here"};
   Log_info("Hardcoded WiFi: connecting to SSID '%s'", hardcodedCreds.ssid.c_str());
   auto connectResult = WifiCaptivePortal.connect(hardcodedCreds);
-  Log_info("Hardcoded WiFi: connect result '%s'", wifiStatusStr(connectResult.status));
+  Log_info("Hardcoded WiFi: connect result '%s'", wifiStatusStr(connectResult));
 // goToSleep();
 #else
 


### PR DESCRIPTION
This partially reverts commit f6abbaee829d0bc76ef8823b0bace68f6a6eca2d.

We think this is causing devices to fail to connect to Wi-Fi and causing major support burden.

We kept partial screen updates for interstitial loading screen (bSkipClear).

Tested on my X.