### PR TITLE
Spectra 6 faster refresh

### DIFF
--- a/src/displays/spectra6.cpp
+++ b/src/displays/spectra6.cpp
@@ -174,7 +174,7 @@ bool spectra6_update() {
   const uint8_t btst1[] = {0x40, 0x1f, 0x1f, 0x2c};
   const uint8_t btst2[] = {0x6f, 0x1f, 0x17, 0x49};
   const uint8_t btst3[] = {0x6f, 0x1f, 0x1f, 0x22};
-  const uint8_t pll[] = {0x03};
+  const uint8_t pll[] = {0x04}; // previously 0x03; on E1002: 14690ms /refresh vs 19065ms
   const uint8_t cdi[] = {0x3f};
   const uint8_t tcon[] = {0x02, 0x00};
   const uint8_t tres[] = {0x03, 0x20, 0x01, 0xe0};

--- a/src/displays/spectra6.h
+++ b/src/displays/spectra6.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <stdint.h>
+
 /**
  * @brief Initializes the SPI interface for the Spectra6 display.
  * @return true if initialization was successful, false otherwise.


### PR DESCRIPTION
this PR shaves 5s off my E1002 refresh timing. it may also increase panel's temperature sensitivity. according to some literature, if device environment is < 5°C or > 22°C this may create ghosting.