### PR TITLE
Fixes portrait mode image problem on X

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1351,7 +1351,7 @@ int png_draw(PNGDRAW *pDraw)
     uint8_t ucMask, ucPixel, src, *s, *d;
     int iPitch, iBpp;
 
-    if (y >= bbep.height()) return 0; // image is larger than the display, stop decoding it
+    if (y >= bbep.height() && pDraw->iWidth != bbep.height()) return 0; // image is larger than the display (and not rotated), stop decoding it
     if (pDraw->iPixelType == PNG_PIXEL_INDEXED || pDraw->iBpp > 4) { // need to convert through the palette and/or reduce the bpp
         s = bbep.tempBuffer(); // temp space we can use
         iBpp = (pDraw->iBpp > 4) ? 4 : pDraw->iBpp;


### PR DESCRIPTION
The PNG decode logic was quitting the decode after 'height' lines were decoded. This logic needed to adapt to when the image is 90-degrees rotated and the height is actually the width.