### PR TITLE
Fix the E1002 build by including stdint.h in spectra6.h

### DIFF
--- a/src/displays/spectra6.h
+++ b/src/displays/spectra6.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <stdint.h>
+
 /**
  * @brief Initializes the SPI interface for the Spectra6 display.
  * @return true if initialization was successful, false otherwise.


### PR DESCRIPTION
`src/displays/spectra6.h` uses `uint8_t` without including anything, and `spectra6.cpp` includes it before `Arduino.h`, so `pio run -e seeed_reTerminal_E1002` fails with `'uint8_t' does not name a type`. It's broken on main today.

This is the build failure from the title of #513. I wrote "Refs" rather than "Fixes" on purpose. The issue body is about the color regression, which #458 already fixed, and the comments also note that no 1.8.11 E1002 binary was ever published, which a code PR can't address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnbEJHrfQMVgshYATiSfMq
