### PR TITLE
Fix BWRY battery reading: measure voltage before turning on panel

### DIFF
--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -925,6 +925,9 @@ void bl_init(void)
       Log_error("SF not saved");
     }
   }
+  // Read the battery voltage BEFORE the display or WiFi is turned on
+  vBatt = battery().readVoltage();
+
   // EPD init
   // EPD clear
   Log.info("%s [%d]: Display init\r\n", __FILE__, __LINE__);
@@ -1004,8 +1007,8 @@ void bl_init(void)
   Log_info("BATTERY CHARGING: %s", battery_charging ? "YES" : "NO");
 
   battery().gaugeInit();
-#endif // BOARD_TRMNL_X
   vBatt = battery().readVoltage(); // Read the battery voltage BEFORE WiFi is turned on
+#endif // BOARD_TRMNL_X
 
   Log_info("Firmware version %s", Messages::firmware_version().c_str());
   Log_info("Arduino version %d.%d.%d", ESP_ARDUINO_VERSION_MAJOR, ESP_ARDUINO_VERSION_MINOR, ESP_ARDUINO_VERSION_PATCH);


### PR DESCRIPTION
While testing, I found that my BWRY would report 2.4V even though it was fully charged or on USB power. This would occur during manual refreshes (button press).

I moved the voltage measurement ahead of the ePaper update, which fixed the issue. I suspect the voltage droops during the refresh.