### PR TITLE
regression: `BYPASS_BQ27427_SOC` not handled

### DIFF
--- a/include/battery.h
+++ b/include/battery.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <battery_soc.h>
 #include <stdint.h>
 
 //
@@ -7,6 +8,10 @@
 //
 #if defined(BOARD_TRMNL_X)
 #define INCLUDE_BQ27427
+#endif
+
+#if defined(BYPASS_BQ27427_SOC) && !defined(INCLUDE_BQ27427)
+#error "BYPASS_BQ27427_SOC only applies to boards with the BQ27427 gas gauge"
 #endif
 
 /// @brief Abstract battery voltage source.
@@ -62,8 +67,13 @@ public:
   ///        shared I2C bus for the duration.
   void gaugeInit();
 
+#ifdef BYPASS_BQ27427_SOC
+  int readSoc() const { return _voltage > 0 ? batteryVoltageToPercent(_voltage) : -1; }
+  int readHealth() const { return -1; }
+#else
   int readSoc() const { return _soc; }                     // %
   int readHealth() const { return _health; }                // %
+#endif                                                      // BYPASS_BQ27427_SOC
   int readCurrent() const { return _current; }               // mA
   float readTemperature() const { return _temperature; }     // C
   int readCapacityRemain() const { return _capacityRemain; } // mAh

--- a/include/display.h
+++ b/include/display.h
@@ -75,12 +75,6 @@ typedef enum {
 
 battery_count_t detect_battery_count();
 
-/// @brief State of charge from the BQ27427 (or estimated from its voltage
-///        reading when BYPASS_BQ27427_SOC is defined). lipo.begin() must have
-///        succeeded first.
-/// @return state of charge, 0-100 %
-int getLipoSOC();
-
 extern "C" {
   void modem_enter_bootloader();
   void modem_reset_target();

--- a/lib/trmnl/include/battery_soc.h
+++ b/lib/trmnl/include/battery_soc.h
@@ -1,0 +1,18 @@
+#pragma once
+
+/// @brief Estimate state of charge from a LiPo cell voltage.
+/// @param voltage cell voltage in Volts
+/// @return estimated state of charge, 0-100 %
+int batteryVoltageToPercent(float voltage);
+
+/// @brief Pack capacities (mAh) to report when charge gauging is bypassed.
+struct BypassCapacity {
+  int full;   // mAh
+  int remain; // mAh
+};
+
+/// @brief Assume a fixed capacity per cell.
+/// @param cellCount number of cells in the pack
+/// @param percent state of charge, 0-100 %
+/// @return the full and remaining capacities to report
+BypassCapacity bypassCapacity(int cellCount, int percent);

--- a/lib/trmnl/src/battery_soc.cpp
+++ b/lib/trmnl/src/battery_soc.cpp
@@ -1,0 +1,23 @@
+#include <battery_soc.h>
+
+/// @brief Per-cell pack capacity (mAh) assumed when charge gauging is bypassed.
+#define BYPASS_CELL_CAPACITY_MAH 6000
+
+int batteryVoltageToPercent(float voltage) {
+  // Mirrors the server's percent_charged_calculation: map 3.0 V onto 0 % at
+  // 0.012 V per percent, with plateaus near full charge (4.08 V follows a
+  // full charge) and a 1 % floor.
+  float pct = (voltage - 3.0f) / 0.012f;
+  if (pct >= 88.0f) return 100;
+  if (pct >= 85.0f) return 95;
+  if (pct >= 83.0f) return 90;
+  if (pct >= 10.0f) return (int)(pct + 0.5f);
+  return 1;
+}
+
+BypassCapacity bypassCapacity(int cellCount, int percent) {
+  BypassCapacity capacity;
+  capacity.full = cellCount * BYPASS_CELL_CAPACITY_MAH;
+  capacity.remain = capacity.full * percent / 100;
+  return capacity;
+}

--- a/src/battery/bq27427_battery.cpp
+++ b/src/battery/bq27427_battery.cpp
@@ -86,6 +86,15 @@ void BQ27427Battery::gaugeInit() {
   } else if (snap.flags & BQ27427_FLAG_DSG) {
     Log_info("BATTERY IS DISCHARGING");
   }
+
+#ifdef BYPASS_BQ27427_SOC
+  // Replace the capacities after logging the raw values.
+  BypassCapacity capacity = bypassCapacity(battery_count, readSoc());
+  _capacityFull = capacity.full;
+  _capacityRemain = capacity.remain;
+  Log_info("BQ27427: gauging bypassed - SoC %d%% from %.2f V, capacity %d/%d mAh", readSoc(), _voltage, _capacityRemain,
+           _capacityFull);
+#endif // BYPASS_BQ27427_SOC
 }
 
 #endif // INCLUDE_BQ27427

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -972,6 +972,17 @@ void bl_init(void)
 
 // #endif
 
+#ifdef BOARD_TRMNL_X
+  // Read the gauge before the panel draws current.
+  battery_count = detect_battery_count();
+  battery_charging = (power().chargingStatus() == ChargingStatus::CHARGING);
+  Log_info("BATTERY COUNT: %d", battery_count);
+  Log_info("BATTERY CHARGING: %s", battery_charging ? "YES" : "NO");
+
+  battery().gaugeInit();
+  vBatt = battery().readVoltage(); // Read the battery voltage BEFORE WiFi is turned on
+#endif // BOARD_TRMNL_X
+
   if (wakeup_reason != ESP_SLEEP_WAKEUP_TIMER)
   {
     Log.info("%s [%d]: Display TRMNL logo start\r\n", __FILE__, __LINE__);
@@ -1000,15 +1011,6 @@ void bl_init(void)
     Log.info("%s [%d]: Display TRMNL logo end\r\n", __FILE__, __LINE__);
     preferences.putString(PREFERENCES_FILENAME_KEY, "");
   }
-#ifdef BOARD_TRMNL_X
-  battery_count = detect_battery_count();
-  battery_charging = (power().chargingStatus() == ChargingStatus::CHARGING);
-  Log_info("BATTERY COUNT: %d", battery_count);
-  Log_info("BATTERY CHARGING: %s", battery_charging ? "YES" : "NO");
-
-  battery().gaugeInit();
-  vBatt = battery().readVoltage(); // Read the battery voltage BEFORE WiFi is turned on
-#endif // BOARD_TRMNL_X
 
   Log_info("Firmware version %s", Messages::firmware_version().c_str());
   Log_info("Arduino version %d.%d.%d", ESP_ARDUINO_VERSION_MAJOR, ESP_ARDUINO_VERSION_MINOR, ESP_ARDUINO_VERSION_PATCH);

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1,4 +1,5 @@
 #include <Arduino.h>
+#include <battery.h>
 #include <display.h>
 #include <power.h>
 #include <PNGdec.h>
@@ -111,8 +112,6 @@ const uint8_t u8_graytable_big[] = {
 /* 15 */ 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 0, 0
 };
 
-#include "BQ27427.h"
-extern BQ27427 lipo; // Use lipo.[] to interact with the library in an Arduino 
 #endif
 
 #include "Group5.h"
@@ -210,25 +209,6 @@ void BQ27427_reset()
 
     bbep.ioWrite(10, HIGH);
     Serial.println("BQ27427 reset performed");
-}
-
-// State of charge (%) from the BQ27427. With BYPASS_BQ27427_SOC the gauge's
-// SoC is ignored and estimated from the measured voltage instead.
-int getLipoSOC() {
-#ifdef BYPASS_BQ27427_SOC
-  // Mirrors the server's percent_charged_calculation: map 3.0 V onto 0 % at
-  // 0.012 V per percent, with plateaus near full charge (4.08 V follows a
-  // full charge) and a 1 % floor.
-  float voltage = lipo.voltage() / 1000.0f;
-  float pct = (voltage - 3.0f) / 0.012f;
-  if (pct >= 88.0f) return 100;
-  if (pct >= 85.0f) return 95;
-  if (pct >= 83.0f) return 90;
-  if (pct >= 10.0f) return (int)(pct + 0.5f);
-  return 1;
-#else
-  return lipo.soc();
-#endif // BYPASS_BQ27427_SOC
 }
 
 void config_tca95535_pins_for_lp()
@@ -1820,8 +1800,8 @@ void display_show_image(uint8_t *image_buffer, int data_size, bool bWait, bool b
                 y = bbep.height() - 120;
                 bbep.loadG5Image(battery_hollow, 40, y, BBEP_WHITE, BBEP_BLACK);
                 Log_info("Displaying 'battery charge level' icon");
-                if (lipo.begin(PIN_INTERNAL_SDA, PIN_INTERNAL_SCL)) { // only report SoC if battery was detected and BQ27427 initialized successfully
-                    int batt_percent = getLipoSOC();
+                int batt_percent = battery().readSoc();
+                if (batt_percent >= 0) { // negative if no battery or the reading failed
                     if (batt_percent >= 97) batt_percent = 100; // can sometimes report 98% when full
                     // Draw a black rectangle to represent the battery charge level
                     bbep.fillRect(40+10, y+18, (97 * batt_percent)/100, 39, BBEP_BLACK);

--- a/test/test_battery_soc/battery_soc.test.cpp
+++ b/test/test_battery_soc/battery_soc.test.cpp
@@ -1,0 +1,83 @@
+#include <battery_soc.h>
+#include <unity.h>
+
+// Chain the two calls the way gaugeInit() does.
+static BypassCapacity capacityAt(int cellCount, float voltage) {
+  return bypassCapacity(cellCount, batteryVoltageToPercent(voltage));
+}
+
+void test_percent_follows_the_server_curve(void) {
+  TEST_ASSERT_EQUAL_INT(25, batteryVoltageToPercent(3.30f));
+  TEST_ASSERT_EQUAL_INT(42, batteryVoltageToPercent(3.50f));
+  TEST_ASSERT_EQUAL_INT(67, batteryVoltageToPercent(3.80f));
+  TEST_ASSERT_EQUAL_INT(78, batteryVoltageToPercent(3.94f));
+}
+
+// Check both sides of every branch boundary.
+void test_plateau_boundaries(void) {
+  // Float rounding puts this edge one millivolt high.
+  TEST_ASSERT_EQUAL_INT(1, batteryVoltageToPercent(3.120f));
+  TEST_ASSERT_EQUAL_INT(10, batteryVoltageToPercent(3.121f));
+
+  TEST_ASSERT_EQUAL_INT(83, batteryVoltageToPercent(3.995f));
+  TEST_ASSERT_EQUAL_INT(90, batteryVoltageToPercent(3.996f));
+
+  TEST_ASSERT_EQUAL_INT(90, batteryVoltageToPercent(4.019f));
+  TEST_ASSERT_EQUAL_INT(95, batteryVoltageToPercent(4.020f));
+
+  TEST_ASSERT_EQUAL_INT(95, batteryVoltageToPercent(4.055f));
+  TEST_ASSERT_EQUAL_INT(100, batteryVoltageToPercent(4.056f));
+}
+
+// A percentage outside 0-100 would be rejected by the server.
+void test_percent_stays_in_range(void) {
+  TEST_ASSERT_EQUAL_INT(1, batteryVoltageToPercent(0.0f));
+  TEST_ASSERT_EQUAL_INT(1, batteryVoltageToPercent(2.50f));
+  TEST_ASSERT_EQUAL_INT(100, batteryVoltageToPercent(4.20f));
+  TEST_ASSERT_EQUAL_INT(100, batteryVoltageToPercent(5.00f));
+
+  // A negative voltage must not give a negative percentage.
+  TEST_ASSERT_EQUAL_INT(1, batteryVoltageToPercent(-1.0f));
+}
+
+// The curve must never report a rising charge for a falling voltage.
+void test_percent_never_rises_as_voltage_falls(void) {
+  int previous = 101;
+  for (int millivolts = 4300; millivolts >= 2500; millivolts -= 1) {
+    int percent = batteryVoltageToPercent(millivolts / 1000.0f);
+    TEST_ASSERT_TRUE(percent <= previous);
+    previous = percent;
+  }
+}
+
+void test_bypass_capacity_scales_with_cell_count(void) {
+  TEST_ASSERT_EQUAL_INT(6000, bypassCapacity(1, 100).full);
+  TEST_ASSERT_EQUAL_INT(12000, bypassCapacity(2, 100).full);
+
+  // The reading that started this.
+  TEST_ASSERT_EQUAL_INT(12000, capacityAt(2, 3.94f).full);
+  TEST_ASSERT_EQUAL_INT(9360, capacityAt(2, 3.94f).remain);
+  TEST_ASSERT_EQUAL_INT(4680, capacityAt(1, 3.94f).remain);
+
+  // A full pack reports its whole capacity, never more.
+  TEST_ASSERT_EQUAL_INT(12000, capacityAt(2, 4.20f).remain);
+}
+
+void setUp(void) {}
+
+void tearDown(void) {}
+
+void process() {
+  UNITY_BEGIN();
+  RUN_TEST(test_percent_follows_the_server_curve);
+  RUN_TEST(test_plateau_boundaries);
+  RUN_TEST(test_percent_stays_in_range);
+  RUN_TEST(test_percent_never_rises_as_voltage_falls);
+  RUN_TEST(test_bypass_capacity_scales_with_cell_count);
+  UNITY_END();
+}
+
+int main(int argc, char **argv) {
+  process();
+  return 0;
+}


### PR DESCRIPTION
This PR makes changes so that every consumer of `battery().readSoc();` gets the same battery calculation logic. Previously `stateOfCharge` which determines the battery percentage was being read from `battery().readSoc();` which  returned the raw gauge value and ignored `BYPASS_BQ27427_SOC` entirely. 

This PR
1. moves the `BYPASS_BQ27427_SOC` logic from `display.cpp` to battery interface.
2. `gaugeInit()` now runs before the logo screen in setup, so the icon has a snapshot to read.