### PR TITLE
Fix battery gauge graphic with estimated SOC

### DIFF
--- a/src/battery/bq27427_battery.cpp
+++ b/src/battery/bq27427_battery.cpp
@@ -24,27 +24,6 @@ static bool connectAndRead(bool oneCellPack, BQ27427Snapshot &snap) {
   // SoC comes from the voltage and capacity from a fixed per-cell pack size.
   (void)oneCellPack;
 
-// State of charge (%) from the BQ27427. With BYPASS_BQ27427_SOC the gauge's
-// SoC is ignored and estimated from the measured voltage instead.
-
-  // Mirrors the server's percent_charged_calculation: map 3.0 V onto 0 % at
-  // 0.012 V per percent, with plateaus near full charge (4.08 V follows a
-  // full charge) and a 1 % floor.
-
-  int soc;
-  float voltage = lipo.voltage() / 1000.0f;
-  float pct = (voltage - 3.0f) / 0.012f;
-  if (pct >= 88.0f)
-    soc = 100;
-  else if (pct >= 85.0f)
-    soc = 95;
-  else if (pct >= 83.0f)
-    soc = 90;
-  else if (pct >= 10.0f)
-    soc = (int)(pct + 0.5f);
-  else
-    soc = 1;
-
   if (!lipo.begin(PIN_INTERNAL_SDA, PIN_INTERNAL_SCL)) return false;
   lipo._initialized = true;
   snap.flags = lipo.flags();
@@ -52,7 +31,23 @@ static bool connectAndRead(bool oneCellPack, BQ27427Snapshot &snap) {
   snap.voltage = lipo.voltage();                                     // mV
   snap.current = lipo.current(AVG);                                  // mA
   snap.temperature = float(lipo.temperature(BATTERY) - 2732) / 10.0; // C
-  snap.soc = soc;
+
+  // Estimate SoC from the voltage just read. Mirrors the server's
+  // percent_charged_calculation: map 3.0 V onto 0 % at 0.012 V per percent,
+  // with plateaus near full charge (4.08 V follows a full charge) and a
+  // 1 % floor.
+  float voltage = snap.voltage / 1000.0f;
+  float pct = (voltage - 3.0f) / 0.012f;
+  if (pct >= 88.0f)
+    snap.soc = 100;
+  else if (pct >= 85.0f)
+    snap.soc = 95;
+  else if (pct >= 83.0f)
+    snap.soc = 90;
+  else if (pct >= 10.0f)
+    snap.soc = (int)(pct + 0.5f);
+  else
+    snap.soc = 1;
   snap.capacityFull = battery_count * BQ27427_BYPASS_CELL_CAPACITY_MAH;
   snap.capacityRemain = snap.capacityFull * snap.soc / 100;
   snap.health = -1; // State-of-health unavailable without gauging

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -973,6 +973,18 @@ void bl_init(void)
 
 // #endif
 
+#ifdef BOARD_TRMNL_X
+  // Read the gauge before the panel draws load current, and before the logo
+  // is drawn so its battery icon has a snapshot to read.
+  battery_count = detect_battery_count();
+  battery_charging = (power().chargingStatus() == ChargingStatus::CHARGING);
+  Log_info("BATTERY COUNT: %d", battery_count);
+  Log_info("BATTERY CHARGING: %s", battery_charging ? "YES" : "NO");
+
+  battery().gaugeInit();
+  vBatt = battery().readVoltage(); // Read the battery voltage BEFORE WiFi is turned on
+#endif // BOARD_TRMNL_X
+
   if (wakeup_reason != ESP_SLEEP_WAKEUP_TIMER)
   {
     Log.info("%s [%d]: Display TRMNL logo start\r\n", __FILE__, __LINE__);
@@ -1001,16 +1013,6 @@ void bl_init(void)
     Log.info("%s [%d]: Display TRMNL logo end\r\n", __FILE__, __LINE__);
     preferences.putString(PREFERENCES_FILENAME_KEY, "");
   }
-#ifdef BOARD_TRMNL_X
-  battery_count = detect_battery_count();
-  battery_charging = (power().chargingStatus() == ChargingStatus::CHARGING);
-  Log_info("BATTERY COUNT: %d", battery_count);
-  Log_info("BATTERY CHARGING: %s", battery_charging ? "YES" : "NO");
-
-  battery().gaugeInit();
-  vBatt = battery().readVoltage(); // Read the battery voltage BEFORE WiFi is turned on
-#endif // BOARD_TRMNL_X
-
   Log_info("Firmware version %s", Messages::firmware_version().c_str());
   Log_info("Arduino version %d.%d.%d", ESP_ARDUINO_VERSION_MAJOR, ESP_ARDUINO_VERSION_MINOR, ESP_ARDUINO_VERSION_PATCH);
   Log_info("ESP-IDF version %d.%d.%d", ESP_IDF_VERSION_MAJOR, ESP_IDF_VERSION_MINOR, ESP_IDF_VERSION_PATCH);

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1802,8 +1802,8 @@ void display_show_image(uint8_t *image_buffer, int data_size, bool bWait, bool b
                 y = bbep.height() - 120;
                 bbep.loadG5Image(battery_hollow, 40, y, BBEP_WHITE, BBEP_BLACK);
                 Log_info("Displaying 'battery charge level' icon");
-                if (lipo.begin(PIN_INTERNAL_SDA, PIN_INTERNAL_SCL)) { // only report SoC if battery was detected and BQ27427 initialized successfully
-                    int batt_percent = battery().readSoc();
+                int batt_percent = battery().readSoc(); // -1 if no battery or the gauge reading failed
+                if (batt_percent >= 0) {
                     if (batt_percent >= 97) batt_percent = 100; // can sometimes report 98% when full
                     // Draw a black rectangle to represent the battery charge level
                     bbep.fillRect(40+10, y+18, (97 * batt_percent)/100, 39, BBEP_BLACK);


### PR DESCRIPTION
Continuing the X battery saga: #558 → #574

Previous PR broke the battery graphic on the interstitial screen.