### PR TITLE
Fix/spectra6 uint8 header

### DIFF
--- a/src/displays/spectra6.h
+++ b/src/displays/spectra6.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <stdint.h>
+
 /**
  * @brief Initializes the SPI interface for the Spectra6 display.
  * @return true if initialization was successful, false otherwise.


### PR DESCRIPTION
Trying to do `pio run -e seeed_reTerminal_E1002 -t upload` but I get:

```
  In file included from src/displays/spectra6.cpp:2:
  src/displays/spectra6.h:27:40: error: 'uint8_t' does not name a type
   bool spectra6_render_1bpp_bitmap(const uint8_t *bitmap);
                                          ^~~~~~~
  Compiling .pio/build/seeed_reTerminal_E1002/src/main.cpp.o
  Compiling .pio/build/seeed_reTerminal_E1002/src/messages.cpp.o
  Compiling .pio/build/seeed_reTerminal_E1002/src/misc/buzzer/buzzer.cpp.o
  *** [.pio/build/seeed_reTerminal_E1002/src/displays/spectra6.cpp.o] Error 1
```