### PR TITLE
Move loadApiDisplayInputs out of bl.cpp

### DIFF
--- a/include/display_session.h
+++ b/include/display_session.h
@@ -1,0 +1,17 @@
+#pragma once
+
+/**
+ * Display session helpers for the /api/display refresh path.
+ *
+ * GME step: loadApiDisplayInputs only. downloadAndShow / response handling
+ * remain in bl.cpp until follow-up PRs.
+ */
+
+#include <Preferences.h>
+#include <api_types.h>
+
+/**
+ * Build ApiDisplayInputs from NVS + live device state (globals, Wi-Fi, power,
+ * battery). Uses the pre-WiFi vBatt snapshot when set by bl_init.
+ */
+ApiDisplayInputs loadApiDisplayInputs(Preferences &preferences);

--- a/include/globals.h
+++ b/include/globals.h
@@ -47,6 +47,7 @@ extern int iPrevWakeTime;               // RTC: total wake time of the last cycl
 extern bool bUsedCachedImage;           // RTC: last image displayed was read from cache (for statistics collection)
 extern uint8_t need_to_refresh_display; // RTC
 extern bool otg_state;                  // RTC: OTG state across deep sleep
+extern float vBatt;                     // battery voltage snapshot (prefer pre-WiFi reading)
 
 // --- UI / input ---
 extern bool touchbar_tap_mode; // false = "slide", true = "tap" (default)

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -56,6 +56,7 @@
 #include "messages.h"
 #include "displayed_image.h"
 #include <globals.h>
+#include <display_session.h>
 const char *szHTTPErrors[] = {
     "HTTPS_NO_ERR",
     "HTTPS_RESET",
@@ -75,7 +76,6 @@ const char *szHTTPErrors[] = {
     "HTTPS_OUT_OF_MEMORY"
 };
 
-static float vBatt;
 static https_request_err_e downloadAndShow(); // download and show the image
 static https_request_err_e handleApiDisplayResponse(ApiDisplayResponse &apiResponse);
 static void resetDeviceCredentials(void);            // reset device credentials API key, Friendly ID, Wi-Fi SSID and password
@@ -1403,77 +1403,6 @@ void bl_init(void)
  */
 void bl_process(void)
 {
-}
-
-ApiDisplayInputs loadApiDisplayInputs(Preferences &preferences)
-{
-  ApiDisplayInputs inputs;
-
-  inputs.baseUrl = preferences.getString(PREFERENCES_API_URL, API_BASE_URL);
-
-  Log.info("%s [%d]: baseUrl from preferences: %s\r\n", __FILE__, __LINE__, inputs.baseUrl.c_str());
-
-  char wakeupReasonString[32] = {0};
-  if (parseWakeupReasonToStr(wakeupReasonString, sizeof(wakeupReasonString), (esp_sleep_source_t)wakeup_reason))
-  {
-    inputs.updateSource = String(wakeupReasonString);
-  }
-  else
-  {
-    inputs.updateSource = "unknown";
-  }
-
-  if (preferences.isKey(PREFERENCES_API_KEY))
-  {
-    inputs.apiKey = preferences.getString(PREFERENCES_API_KEY, PREFERENCES_API_KEY_DEFAULT);
-    Log.info("%s [%d]: %s key exists. Value - %s\r\n", __FILE__, __LINE__, PREFERENCES_API_KEY, inputs.apiKey.c_str());
-  }
-  else
-  {
-    Log.info("%s [%d]: %s key not exists.\r\n", __FILE__, __LINE__, PREFERENCES_API_KEY);
-  }
-
-  if (preferences.isKey(PREFERENCES_FRIENDLY_ID))
-  {
-    inputs.friendlyId = preferences.getString(PREFERENCES_FRIENDLY_ID, PREFERENCES_FRIENDLY_ID_DEFAULT);
-    Log.info("%s [%d]: %s key exists. Value - %s\r\n", __FILE__, __LINE__, PREFERENCES_FRIENDLY_ID, inputs.friendlyId);
-  }
-  else
-  {
-    Log.info("%s [%d]: %s key not exists.\r\n", __FILE__, __LINE__, PREFERENCES_FRIENDLY_ID);
-  }
-
-  inputs.refreshRate = refreshInterval.seconds();
-  Log.info("%s [%d]: refresh rate: %d\r\n", __FILE__, __LINE__, inputs.refreshRate);
-
-  inputs.macAddress = device_mac_address();
-  WiFiStatus wifi = getWiFiStatus();
-  inputs.rssi = wifi.rssi;
-  inputs.wifiBand = wifi.band;
-  inputs.batteryVoltage = vBatt;
-  inputs.firmwareVersion = String(FW_VERSION_STRING);
-  inputs.firmwareCommit = String(FW_COMMIT);
-  inputs.displayWidth = display_width();
-  inputs.displayHeight = display_height();
-  inputs.model = DEVICE_MODEL;
-  inputs.specialFunction = special_function;
-  inputs.imageCached = bUsedCachedImage;
-  inputs.prevWakeTime = iPrevWakeTime;
-  inputs.usbStatus = power().usbStatus();
-  inputs.chargingStatus = power().chargingStatus();
-
-#ifdef BOARD_TRMNL_X
-  // These getters already return -1 if the last gaugeInit() didn't produce a valid reading.
-  inputs.batteryCount = battery_count;
-  inputs.stateOfCharge = battery().readSoc();
-  inputs.stateOfHealth = battery().readHealth();
-  inputs.batteryCurrent = battery().readCurrent();
-  inputs.batteryTemperature = battery().readTemperature();
-  inputs.currentBatteryCapacity = battery().readCapacityRemain();
-  inputs.maxBatteryCapacity = battery().readCapacityFull();
-#endif // BOARD_TRMNL_X
-
-  return inputs;
 }
 
 void load_prev_image(void)

--- a/src/display_session.cpp
+++ b/src/display_session.cpp
@@ -1,18 +1,16 @@
-#include <display_session.h>
-
 #include <ArduinoLog.h>
 #include <battery.h>
 #include <config.h>
 #include <device_id.h>
 #include <display.h>
+#include <display_session.h>
 #include <globals.h>
 #include <logging_parcers.h>
 #include <power.h>
 #include <trmnl_log.h>
 #include <wifi_network.h>
 
-ApiDisplayInputs loadApiDisplayInputs(Preferences &preferences)
-{
+ApiDisplayInputs loadApiDisplayInputs(Preferences &preferences) {
   ApiDisplayInputs inputs;
 
   inputs.baseUrl = preferences.getString(PREFERENCES_API_URL, API_BASE_URL);
@@ -20,32 +18,23 @@ ApiDisplayInputs loadApiDisplayInputs(Preferences &preferences)
   Log.info("%s [%d]: baseUrl from preferences: %s\r\n", __FILE__, __LINE__, inputs.baseUrl.c_str());
 
   char wakeupReasonString[32] = {0};
-  if (parseWakeupReasonToStr(wakeupReasonString, sizeof(wakeupReasonString), (esp_sleep_source_t)wakeup_reason))
-  {
+  if (parseWakeupReasonToStr(wakeupReasonString, sizeof(wakeupReasonString), (esp_sleep_source_t)wakeup_reason)) {
     inputs.updateSource = String(wakeupReasonString);
-  }
-  else
-  {
+  } else {
     inputs.updateSource = "unknown";
   }
 
-  if (preferences.isKey(PREFERENCES_API_KEY))
-  {
+  if (preferences.isKey(PREFERENCES_API_KEY)) {
     inputs.apiKey = preferences.getString(PREFERENCES_API_KEY, PREFERENCES_API_KEY_DEFAULT);
     Log.info("%s [%d]: %s key exists. Value - %s\r\n", __FILE__, __LINE__, PREFERENCES_API_KEY, inputs.apiKey.c_str());
-  }
-  else
-  {
+  } else {
     Log.info("%s [%d]: %s key not exists.\r\n", __FILE__, __LINE__, PREFERENCES_API_KEY);
   }
 
-  if (preferences.isKey(PREFERENCES_FRIENDLY_ID))
-  {
+  if (preferences.isKey(PREFERENCES_FRIENDLY_ID)) {
     inputs.friendlyId = preferences.getString(PREFERENCES_FRIENDLY_ID, PREFERENCES_FRIENDLY_ID_DEFAULT);
     Log.info("%s [%d]: %s key exists. Value - %s\r\n", __FILE__, __LINE__, PREFERENCES_FRIENDLY_ID, inputs.friendlyId);
-  }
-  else
-  {
+  } else {
     Log.info("%s [%d]: %s key not exists.\r\n", __FILE__, __LINE__, PREFERENCES_FRIENDLY_ID);
   }
 

--- a/src/display_session.cpp
+++ b/src/display_session.cpp
@@ -1,0 +1,83 @@
+#include <display_session.h>
+
+#include <ArduinoLog.h>
+#include <battery.h>
+#include <config.h>
+#include <device_id.h>
+#include <display.h>
+#include <globals.h>
+#include <logging_parcers.h>
+#include <power.h>
+#include <trmnl_log.h>
+#include <wifi_network.h>
+
+ApiDisplayInputs loadApiDisplayInputs(Preferences &preferences)
+{
+  ApiDisplayInputs inputs;
+
+  inputs.baseUrl = preferences.getString(PREFERENCES_API_URL, API_BASE_URL);
+
+  Log.info("%s [%d]: baseUrl from preferences: %s\r\n", __FILE__, __LINE__, inputs.baseUrl.c_str());
+
+  char wakeupReasonString[32] = {0};
+  if (parseWakeupReasonToStr(wakeupReasonString, sizeof(wakeupReasonString), (esp_sleep_source_t)wakeup_reason))
+  {
+    inputs.updateSource = String(wakeupReasonString);
+  }
+  else
+  {
+    inputs.updateSource = "unknown";
+  }
+
+  if (preferences.isKey(PREFERENCES_API_KEY))
+  {
+    inputs.apiKey = preferences.getString(PREFERENCES_API_KEY, PREFERENCES_API_KEY_DEFAULT);
+    Log.info("%s [%d]: %s key exists. Value - %s\r\n", __FILE__, __LINE__, PREFERENCES_API_KEY, inputs.apiKey.c_str());
+  }
+  else
+  {
+    Log.info("%s [%d]: %s key not exists.\r\n", __FILE__, __LINE__, PREFERENCES_API_KEY);
+  }
+
+  if (preferences.isKey(PREFERENCES_FRIENDLY_ID))
+  {
+    inputs.friendlyId = preferences.getString(PREFERENCES_FRIENDLY_ID, PREFERENCES_FRIENDLY_ID_DEFAULT);
+    Log.info("%s [%d]: %s key exists. Value - %s\r\n", __FILE__, __LINE__, PREFERENCES_FRIENDLY_ID, inputs.friendlyId);
+  }
+  else
+  {
+    Log.info("%s [%d]: %s key not exists.\r\n", __FILE__, __LINE__, PREFERENCES_FRIENDLY_ID);
+  }
+
+  inputs.refreshRate = refreshInterval.seconds();
+  Log.info("%s [%d]: refresh rate: %d\r\n", __FILE__, __LINE__, inputs.refreshRate);
+
+  inputs.macAddress = device_mac_address();
+  WiFiStatus wifi = getWiFiStatus();
+  inputs.rssi = wifi.rssi;
+  inputs.wifiBand = wifi.band;
+  inputs.batteryVoltage = vBatt;
+  inputs.firmwareVersion = String(FW_VERSION_STRING);
+  inputs.firmwareCommit = String(FW_COMMIT);
+  inputs.displayWidth = display_width();
+  inputs.displayHeight = display_height();
+  inputs.model = DEVICE_MODEL;
+  inputs.specialFunction = special_function;
+  inputs.imageCached = bUsedCachedImage;
+  inputs.prevWakeTime = iPrevWakeTime;
+  inputs.usbStatus = power().usbStatus();
+  inputs.chargingStatus = power().chargingStatus();
+
+#ifdef BOARD_TRMNL_X
+  // These getters already return -1 if the last gaugeInit() didn't produce a valid reading.
+  inputs.batteryCount = battery_count;
+  inputs.stateOfCharge = battery().readSoc();
+  inputs.stateOfHealth = battery().readHealth();
+  inputs.batteryCurrent = battery().readCurrent();
+  inputs.batteryTemperature = battery().readTemperature();
+  inputs.currentBatteryCapacity = battery().readCapacityRemain();
+  inputs.maxBatteryCapacity = battery().readCapacityFull();
+#endif // BOARD_TRMNL_X
+
+  return inputs;
+}

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -27,6 +27,7 @@ RTC_DATA_ATTR int iPrevWakeTime = 0;
 RTC_DATA_ATTR bool bUsedCachedImage = false;
 RTC_DATA_ATTR uint8_t need_to_refresh_display = 1;
 RTC_DATA_ATTR bool otg_state = false;
+float vBatt = 0;
 
 // --- UI / input ---
 bool touchbar_tap_mode = true; // false = "slide", true = "tap" (default)


### PR DESCRIPTION
Extract ApiDisplayInputs assembly into display_session so bl.cpp no longer owns preference/wakeup/battery field packing for /api/display.

Move vBatt into globals for the pre-WiFi voltage snapshot shared by the session and device status stamps. Behavior unchanged.

Verified: pio run -e trmnl