### PR TITLE
Move update_playlist_order into filesystem helpers

### DIFF
--- a/include/filesystem.h
+++ b/include/filesystem.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Arduino.h>
+#include <Preferences.h>
 
 /**
  * @brief Function to delete old versions of plugin images (by comparing the timestamp)
@@ -73,6 +74,17 @@ size_t filesystem_write_to_file(const char *name, uint8_t *in_buffer, size_t siz
  * @return none
  */
 void writeImageToFile(const char *name, uint8_t *in_buffer, size_t size);
+
+/**
+ * @brief Update the X playlist order NVS string after a new image becomes current.
+ *        Refreshes an existing same-plugin entry in place, or inserts after prev_path.
+ *        Drops playlist entries whose files no longer exist (except prev_path).
+ * @param preferences NVS "data" namespace
+ * @param new_path path that is now current
+ * @param prev_path previous current path (may be empty)
+ * @return none
+ */
+void update_playlist_order(Preferences &preferences, const char *new_path, const char *prev_path);
 
 /**
  * @brief Function to shorten a filename (if needed) to fit the SPIFFS file length

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -380,60 +380,6 @@ bool check_corners_gesture()
   return slider_event == IQS323_GESTURE_HOLD && left && right;
 }
 
-static void update_playlist_order(const char *new_path, const char *prev_path) {
-  String order = preferences.getString(PREFERENCES_PLAYLIST_ORDER_KEY, "");
-  String newStr = String(new_path);
-  String prefix = newStr.substring(0, 14); // same-plugin identity (matches purge logic)
-  String prevStr = String(prev_path);
-
-  if (order.isEmpty()) {
-    preferences.putString(PREFERENCES_PLAYLIST_ORDER_KEY, newStr);
-    return;
-  }
-
-  // Scan list: update in-place if prefix matches (refresh), otherwise build a cleaned list
-  // dropping entries whose files no longer exist (except prev_path, which anchors insertion).
-  bool found = false;
-  String result = "";
-  int start = 0;
-  while (start <= (int)order.length()) {
-    int sep = order.indexOf('|', start);
-    String entry = (sep < 0) ? order.substring(start) : order.substring(start, sep);
-    if (!entry.isEmpty()) {
-      if (!found && entry.startsWith(prefix)) {
-        result += (result.isEmpty() ? "" : "|") + newStr;
-        found = true;
-      } else if (entry == prevStr || filesystem_file_exists(entry.c_str())) {
-        result += (result.isEmpty() ? "" : "|") + entry;
-      }
-      // else: file was purged from filesystem — drop from list
-    }
-    if (sep < 0) break;
-    start = sep + 1;
-  }
-  if (found) { preferences.putString(PREFERENCES_PLAYLIST_ORDER_KEY, result); return; }
-
-  // New plugin — insert right after prev_path's position in the cleaned list
-  String result2 = "";
-  bool inserted = false;
-  start = 0;
-  while (start <= (int)result.length()) {
-    int sep = result.indexOf('|', start);
-    String entry = (sep < 0) ? result.substring(start) : result.substring(start, sep);
-    if (!entry.isEmpty()) {
-      result2 += (result2.isEmpty() ? "" : "|") + entry;
-      if (!inserted && entry == prevStr) {
-        result2 += "|" + newStr;
-        inserted = true;
-      }
-    }
-    if (sep < 0) break;
-    start = sep + 1;
-  }
-  if (!inserted) result2 += (result2.isEmpty() ? "" : "|") + newStr;
-  preferences.putString(PREFERENCES_PLAYLIST_ORDER_KEY, result2);
-}
-
 static void show_cached_image_by_offset(int offset) {
   String order = preferences.getString(PREFERENCES_PLAYLIST_ORDER_KEY, "");
 
@@ -1589,7 +1535,7 @@ static https_request_err_e downloadAndShow()
         preferences.putString(PREFERENCES_LAST_PATH_KEY, _curPath);
       preferences.putString(PREFERENCES_CURRENT_PATH_KEY, String(szTemp));
       #ifdef BOARD_TRMNL_X
-      update_playlist_order(szTemp, _curPath.c_str());
+      update_playlist_order(preferences, szTemp, _curPath.c_str());
       #endif
       preferences.putString(PREFERENCES_BROWSE_PATH_KEY, String(szTemp));
       return result;
@@ -1637,7 +1583,7 @@ static https_request_err_e downloadAndShow()
     DisplayedImage::remember(szTemp); // current image becomes the previous image
 
     preferences.putString(PREFERENCES_CURRENT_PATH_KEY, String(szTemp));
-    update_playlist_order(szTemp, _prevPath.c_str());
+    update_playlist_order(preferences, szTemp, _prevPath.c_str());
     preferences.putString(PREFERENCES_BROWSE_PATH_KEY, String(szTemp));
 
 //    new_filename = apiDisplayResult.response.filename;
@@ -1875,7 +1821,7 @@ static https_request_err_e downloadAndShow()
               preferences.putString(PREFERENCES_LAST_PATH_KEY, _curPath);
             preferences.putString(PREFERENCES_CURRENT_PATH_KEY, String(szTemp));
             #ifdef BOARD_TRMNL_X
-            update_playlist_order(szTemp, _curPath.c_str());
+            update_playlist_order(preferences, szTemp, _curPath.c_str());
             #endif
             preferences.putString(PREFERENCES_BROWSE_PATH_KEY, String(szTemp));
           }

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -1,4 +1,6 @@
 #include <Arduino.h>
+#include <Preferences.h>
+#include <config.h>
 #include <filesystem.h>
 #include <inttypes.h>
 #include <trmnl_log.h>
@@ -297,6 +299,66 @@ void writeImageToFile(const char *name, uint8_t *in_buffer, size_t size) {
   } else {
     Log_info("file %s writing success - %d bytes", name, res);
   }
+}
+
+void update_playlist_order(Preferences &preferences, const char *new_path, const char *prev_path) {
+  String order = preferences.getString(PREFERENCES_PLAYLIST_ORDER_KEY, "");
+  String newStr = String(new_path);
+  String prefix = newStr.substring(0, 14); // same-plugin identity (matches purge logic)
+  String prevStr = String(prev_path);
+
+  if (order.isEmpty()) {
+    preferences.putString(PREFERENCES_PLAYLIST_ORDER_KEY, newStr);
+    return;
+  }
+
+  // Scan list: update in-place if prefix matches (refresh), otherwise build a cleaned list
+  // dropping entries whose files no longer exist (except prev_path, which anchors insertion).
+  bool found = false;
+  String result = "";
+  int start = 0;
+  while (start <= (int)order.length()) {
+    int sep = order.indexOf('|', start);
+    String entry = (sep < 0) ? order.substring(start) : order.substring(start, sep);
+    if (!entry.isEmpty()) {
+      if (!found && entry.startsWith(prefix)) {
+        result += (result.isEmpty() ? "" : "|") + newStr;
+        found = true;
+      } else if (entry == prevStr || filesystem_file_exists(entry.c_str())) {
+        result += (result.isEmpty() ? "" : "|") + entry;
+      }
+      // else: file was purged from filesystem — drop from list
+    }
+    if (sep < 0)
+      break;
+    start = sep + 1;
+  }
+  if (found) {
+    preferences.putString(PREFERENCES_PLAYLIST_ORDER_KEY, result);
+    return;
+  }
+
+  // New plugin — insert right after prev_path's position in the cleaned list
+  String result2 = "";
+  bool inserted = false;
+  start = 0;
+  while (start <= (int)result.length()) {
+    int sep = result.indexOf('|', start);
+    String entry = (sep < 0) ? result.substring(start) : result.substring(start, sep);
+    if (!entry.isEmpty()) {
+      result2 += (result2.isEmpty() ? "" : "|") + entry;
+      if (!inserted && entry == prevStr) {
+        result2 += "|" + newStr;
+        inserted = true;
+      }
+    }
+    if (sep < 0)
+      break;
+    start = sep + 1;
+  }
+  if (!inserted)
+    result2 += (result2.isEmpty() ? "" : "|") + newStr;
+  preferences.putString(PREFERENCES_PLAYLIST_ORDER_KEY, result2);
 }
 
 void filesystem_fix_filename(const char *src, char *dest) {

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -329,8 +329,7 @@ void update_playlist_order(Preferences &preferences, const char *new_path, const
       }
       // else: file was purged from filesystem — drop from list
     }
-    if (sep < 0)
-      break;
+    if (sep < 0) break;
     start = sep + 1;
   }
   if (found) {
@@ -352,12 +351,10 @@ void update_playlist_order(Preferences &preferences, const char *new_path, const
         inserted = true;
       }
     }
-    if (sep < 0)
-      break;
+    if (sep < 0) break;
     start = sep + 1;
   }
-  if (!inserted)
-    result2 += (result2.isEmpty() ? "" : "|") + newStr;
+  if (!inserted) result2 += (result2.isEmpty() ? "" : "|") + newStr;
   preferences.putString(PREFERENCES_PLAYLIST_ORDER_KEY, result2);
 }
 


### PR DESCRIPTION
Relocate playlist order NVS maintenance next to writeImageToFile so the download path and future browse code share one owner without pulling gesture logic out of bl.

Take Preferences& explicitly instead of relying on bl-local linkage. Behavior unchanged: same-plugin refresh in place, insert after prev_path, drop missing files from the order string.

Verified: pio run -e trmnl