### PR TITLE
Extract boot Wi-Fi connect and captive portal from bl_init

### DIFF
--- a/include/wifi_session.h
+++ b/include/wifi_session.h
@@ -1,0 +1,22 @@
+#pragma once
+
+/**
+ * Boot-time Wi-Fi session: hostname, optional X modem prep, connect with
+ * saved credentials, or captive portal.
+ *
+ * Call order from bl_init:
+ *   1. wifiSessionInit()     — early (before SF_ADD_WIFI / portal use)
+ *   2. wifiSessionConnect()  — after display/filesystem/battery init
+ *
+ * On connection failure, wifiSessionConnect shows WIFI_FAILED and deep-sleeps
+ * via wifiErrorDeepSleep (does not return on that path).
+ */
+
+/** Set captive-portal hostname from preferences / friendly ID. */
+void wifiSessionInit(void);
+
+/**
+ * Prepare modem (X), set STA mode, then auto-connect or start captive portal.
+ * Blocks until connected or sleep is entered on failure.
+ */
+void wifiSessionConnect(void);

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -56,6 +56,7 @@
 #include "messages.h"
 #include "displayed_image.h"
 #include <globals.h>
+#include <wifi_session.h>
 const char *szHTTPErrors[] = {
     "HTTPS_NO_ERR",
     "HTTPS_RESET",
@@ -78,15 +79,18 @@ const char *szHTTPErrors[] = {
 static float vBatt;
 static https_request_err_e downloadAndShow(); // download and show the image
 static https_request_err_e handleApiDisplayResponse(ApiDisplayResponse &apiResponse);
-static void resetDeviceCredentials(void);            // reset device credentials API key, Friendly ID, Wi-Fi SSID and password
+// Non-static: used by wifi_session (portal reset / failure paths)
+void resetDeviceCredentials(void);
 void goToSleep(void);                         // sleep preparing
 static void goToSleepButtonOnly(void);               // sleep until button press, no timer
 static void submitStoredLogs(void);
 static void writeSpecialFunction(SPECIAL_FUNCTION function);
 void showMessageWithLogo(MSG message_type);
-static void showMessageWithLogo(MSG message_type, String friendly_id, bool id, const char *fw_version, String message);
+// Non-static: used by wifi_session for WIFI_CONNECT screen
+void showMessageWithLogo(MSG message_type, String friendly_id, bool id, const char *fw_version, String message);
 static void showMessageWithLogo(MSG message_type, const ApiSetupResponse &apiResponse);
-static void wifiErrorDeepSleep();
+// Non-static: used by wifi_session on connect/portal failure
+void wifiErrorDeepSleep();
 static uint8_t *storedLogoOrDefault(int iType);
 static DeviceStatusStamp getDeviceStatusStamp();
 void config_gpio_for_lp();
@@ -360,6 +364,47 @@ void handle_power_off_confirmation()
   Log_info("Entering power-off confirmation mode");
   handle_confirmation_flow(in_power_off_confirmation, POWER_OFF_CONFIRM, confirm_power_off);
 }
+
+#ifdef BOARD_TRMNL_X
+/**
+ * Captive-portal tick: both corners held → power-off confirmation.
+ * Registered by wifi_session while the portal is running.
+ */
+void blWifiPortalTickX(void)
+{
+  if (in_power_off_confirmation)
+    return;
+  if (millis() < s_power_off_cooldown_until)
+    return;
+
+  static uint32_t s_corners_start_ms = 0;
+
+  iqs323_task_i2c_lock();
+  if (iqs323.getRDYStatus()) {
+    iqs323.updateInfoFlags(STOP);
+  }
+  bool left = iqs323.channel_touchState(IQS323_CH0);
+  bool right = iqs323.channel_touchState(IQS323_CH2);
+  if (left && right) {
+    if (!s_corners_detected) {
+      s_corners_start_ms = millis();
+      s_corners_detected = true;
+    } else if (millis() - s_corners_start_ms >= 600) {
+      s_corners_detected = false;
+      handle_power_off_confirmation();
+      // Only reached on cancel — confirmed path calls ESP.restart()
+      s_power_off_cooldown_until = millis() + 2000;
+      iqs323_task_i2c_unlock();
+      showMessageWithLogo(WIFI_CONNECT, "", false, Messages::firmware_version().c_str(),
+                          WifiCaptivePortal.getAPSSID());
+      return;
+    }
+  } else {
+    s_corners_detected = false;
+  }
+  iqs323_task_i2c_unlock();
+}
+#endif // BOARD_TRMNL_X
 
 // Check if both left and right corners are being held
 bool check_corners_gesture()
@@ -738,20 +783,9 @@ void bl_init(void)
 #endif
   Log_info("BL init success");
 
-  WifiCaptivePortal.setHostname(getWifiClientHostname());
+  // Hostname before any captive-portal use (e.g. SF_ADD_WIFI)
+  wifiSessionInit();
 
-#ifdef BOARD_TRMNL_X
-  bool bModemNeeded = false;
-  Log.info("%s [%d]: Checking if we need to use the ESP32-C5 modem...\r\n", __FILE__, __LINE__);
-  if (WifiCaptivePortal.isSaved()) {
-    // WiFi saved, connection
-    WifiCredentials lastCreds = WifiCaptivePortal.getLastCredentials();
-    bModemNeeded = lastCreds.is5GHz;
-  } else {
-    bModemNeeded = true; // captive portal needs modem for 5 GHz
-  }
-  Log.info("%s [%d]: modem needed = %d\n\r", __FILE__, __LINE__, bModemNeeded);
-#endif // X
   pins_init();
   buzzer().init();
   sensor().init();
@@ -1023,165 +1057,9 @@ void bl_init(void)
   // showMessageWithLogo(MSG_FORMAT_ERROR);
   // display_show_msg(storedLogoOrDefault(1), WIFI_CONNECT, "ABCDEF", true, Messages::firmware_version().c_str(), "Hello World!");
   // wifiErrorDeepSleep();
-#ifdef BOARD_TRMNL_X
-  if (bModemNeeded) {
-    modem_reset_target(); // Must be done BEFORE the instantiation of the class since it expects the modem to be ready
-    static Modem modemInstance(115200);
-    if (modemInstance.isInitialized()) {
-      g_modem = &modemInstance;
-    } else {
-      Log_info("Modem init failed — falling back to 2.4 GHz mode");
-      g_modem = nullptr;
-    }
-  } else {
-    g_modem = nullptr;
-  }
-    
-  // Only scan when no credentials are saved (i.e. captive portal will be shown). 
-  if (g_modem && !WifiCaptivePortal.isSaved())
-  {
-    // The modem is a separate radio and can see the device's own captive-portal
-    // SoftAP over the air; exclude it so it never shows up as a connectable network.
-    String ownApSsid = WifiCaptivePortal.getAPSSID();
 
-    Log_info("No saved credentials — scanning networks via modem...");
-    auto modemNets = g_modem->scanNetworks();
-    Log_info("Modem found %d network(s)", modemNets.size());
-    std::vector<ExternalNetwork> nets;
-    for (auto& n : modemNets) {
-      if (n.ssid == ownApSsid) continue;
-      nets.push_back({n.ssid, n.rssi, n.open, n.is5GHz});
-    }
-    WifiCaptivePortal.setNetworks(nets);
-
-    // Register callback so captive portal can connect 5 GHz networks via modem
-    WifiCaptivePortal.setModemConnectCallback([](const String& ssid, const String& pass) {
-      return g_modem->connectToNetwork(ssid, pass, getWifiClientHostname());
-    });
-
-    // Register callback so the captive portal's Refresh button can trigger a fresh modem scan
-    WifiCaptivePortal.setModemScanCallback([ownApSsid]() {
-      auto modemNets = g_modem->scanNetworks();
-      Log_info("Modem re-scan found %d network(s)", modemNets.size());
-      std::vector<ExternalNetwork> nets;
-      for (auto& n : modemNets) {
-        if (n.ssid == ownApSsid) continue;
-        nets.push_back({n.ssid, n.rssi, n.open, n.is5GHz});
-      }
-      return nets;
-    });
-
-    String modemMac = g_modem->getMacAddress();
-    if (!modemMac.isEmpty()) {
-      WifiCaptivePortal.setModemMac(modemMac);
-    }
-  }
-#endif // BOARD_TRMNL_X
-
-  WiFi.mode(WIFI_STA); // explicitly set mode, esp defaults to STA+AP
-
-  MSG current_msg = NONE;
-
-// uncdcomment this to hardcode WiFi credentials (useful for testing wifi errors, etc.)
-// #define HARDCODED_WIFI
-#ifdef HARDCODED_WIFI
-  WifiCredentials hardcodedCreds = {.ssid = "ssid-goes-here", .pswd = "password-goes-here"};
-  Log_info("Hardcoded WiFi: connecting to SSID '%s'", hardcodedCreds.ssid.c_str());
-  auto connectResult = WifiCaptivePortal.connect(hardcodedCreds);
-  Log_info("Hardcoded WiFi: connect result '%s'", wifiStatusStr(connectResult));
-// goToSleep();
-#else
-
-  if (WifiCaptivePortal.isSaved())
-  {
-    // WiFi saved, connection
-    Log.info("%s [%d]: WiFi saved\r\n", __FILE__, __LINE__);
-    int connection_res = connectWithSavedCredentials() ? 1 : 0;
-
-    Log.info("%s [%d]: Connection result: %d, WiFI Status: %d\r\n", __FILE__, __LINE__, connection_res, WiFi.status());
-
-    // Check if connected
-    if (connection_res)
-    {
-      String ip = String(WiFi.localIP());
-      Log.info("%s [%d]:wifi_connection [DEBUG]: Connected: %s\r\n", __FILE__, __LINE__, ip.c_str());
-      preferences.putInt(PREFERENCES_CONNECT_WIFI_RETRY_COUNT, 1);
-    }
-    else
-    {
-      if (current_msg != WIFI_FAILED)
-      {
-        showMessageWithLogo(WIFI_FAILED);
-        current_msg = WIFI_FAILED;
-      }
-
-      Log_fatal_submit("Connection failed! WL Status: %d", WiFi.status());
-
-      wifiErrorDeepSleep();
-    }
-  }
-  else
-  {
-    // WiFi credentials are not saved - start captive portal
-    Log.info("%s [%d]: WiFi NOT saved\r\n", __FILE__, __LINE__);
-
-    Log_info("FW version %s", Messages::firmware_version().c_str());
-
-    showMessageWithLogo(WIFI_CONNECT, "", false, Messages::firmware_version().c_str(), WifiCaptivePortal.getAPSSID());
-#ifdef BOARD_TRMNL_X
-    // set TAP mode as default
-    iqs323_task_i2c_lock();
-    iqs323.setGestureConfig(true, STOP);
-    iqs323_task_i2c_unlock();
-    touchbar_tap_mode = true;
-
-    static uint32_t s_corners_start_ms = 0;
-    WifiCaptivePortal.setPortalTickCallback([]() {
-      if (in_power_off_confirmation) return;
-      if (millis() < s_power_off_cooldown_until) return;
-      iqs323_task_i2c_lock();
-      if (iqs323.getRDYStatus()) {
-        iqs323.updateInfoFlags(STOP);
-      }
-      bool left  = iqs323.channel_touchState(IQS323_CH0);
-      bool right = iqs323.channel_touchState(IQS323_CH2);
-      if (left && right) {
-        if (!s_corners_detected) {
-          s_corners_start_ms = millis();
-          s_corners_detected = true;
-        } else if (millis() - s_corners_start_ms >= 600) {
-          s_corners_detected = false;
-          handle_power_off_confirmation();
-          // Only reached on cancel — confirmed path calls ESP.restart()
-          s_power_off_cooldown_until = millis() + 2000;
-          iqs323_task_i2c_unlock();
-          showMessageWithLogo(WIFI_CONNECT, "", false, Messages::firmware_version().c_str(), WifiCaptivePortal.getAPSSID());
-          return;
-        }
-      } else {
-        s_corners_detected = false;
-      }
-      iqs323_task_i2c_unlock();
-    });
-#endif
-    WifiCaptivePortal.setResetSettingsCallback(resetDeviceCredentials);
-    res = WifiCaptivePortal.startPortal();
-    if (!res)
-    {
-      WiFi.disconnect(true);
-
-      showMessageWithLogo(WIFI_FAILED);
-
-      Log_error("Failed to connect or hit timeout");
-
-      // Go to deep sleep
-      wifiErrorDeepSleep();
-    }
-    Log.info("%s [%d]: WiFi connected\r\n", __FILE__, __LINE__);
-    preferences.putInt(PREFERENCES_CONNECT_WIFI_RETRY_COUNT, 1);
-  }
-
-#endif
+  // Modem prep (X), STA mode, saved credentials or captive portal
+  wifiSessionConnect();
 
   // clock synchronization
   if (systemClock().setTimeFromNTP())
@@ -1256,7 +1134,8 @@ void bl_init(void)
     preferences.putInt(PREFERENCES_CONNECT_API_RETRY_COUNT, 1);
   }
 
-  if (request_result != HTTPS_SUCCESS && request_result != HTTPS_NO_ERR && request_result != HTTPS_NO_REGISTER && request_result != HTTPS_RESET && request_result != HTTPS_PLUGIN_NOT_ATTACHED && current_msg != WIFI_FAILED)
+  // WIFI_FAILED path sleeps inside wifiSessionConnect and does not return here
+  if (request_result != HTTPS_SUCCESS && request_result != HTTPS_NO_ERR && request_result != HTTPS_NO_REGISTER && request_result != HTTPS_RESET && request_result != HTTPS_PLUGIN_NOT_ATTACHED)
   {
     uint8_t retries = preferences.getInt(PREFERENCES_CONNECT_API_RETRY_COUNT);
     iqs323_task_i2c_lock();
@@ -2574,7 +2453,7 @@ https_request_err_e handleApiDisplayResponse(ApiDisplayResponse &apiResponse)
  * @param url Server URL address
  * @return none
  */
-static void resetDeviceCredentials(void)
+void resetDeviceCredentials(void)
 {
   Log.info("%s [%d]: The device will be reset now...\r\n", __FILE__, __LINE__);
   Log.info("%s [%d]: WiFi resetting...\r\n", __FILE__, __LINE__);
@@ -2860,7 +2739,7 @@ static void writeSpecialFunction(SPECIAL_FUNCTION function)
   }
 }
 
-static void showMessageWithLogo(MSG message_type, String friendly_id, bool id, const char *fw_version, String message)
+void showMessageWithLogo(MSG message_type, String friendly_id, bool id, const char *fw_version, String message)
 {
   display_show_msg(storedLogoOrDefault(0), message_type, friendly_id, id, fw_version, message);
   need_to_refresh_display = 1;
@@ -2936,7 +2815,7 @@ static uint8_t *storedLogoOrDefault(int iType)
 // Chop up long names to fit within the SPIFFS 31 character limit
 
 
-static void wifiErrorDeepSleep()
+void wifiErrorDeepSleep()
 {
   if (!preferences.isKey(PREFERENCES_CONNECT_WIFI_RETRY_COUNT))
   {

--- a/src/wifi_session.cpp
+++ b/src/wifi_session.cpp
@@ -1,0 +1,168 @@
+#include <Arduino.h>
+#include <ArduinoLog.h>
+#include <WiFi.h>
+#include <WifiCaptive.h>
+#include <config.h>
+#include <display.h>
+#include <globals.h>
+#include <messages.h>
+#include <trmnl_log.h>
+#include <wifi_network.h>
+#include <wifi_session.h>
+
+#ifdef BOARD_TRMNL_X
+#include <IQS323.h>
+#include <iqs323_task.h>
+#include <modem.h>
+#include <vector>
+#endif
+
+// --- Helpers still owned by bl.cpp ---
+void showMessageWithLogo(MSG message_type);
+void showMessageWithLogo(MSG message_type, String friendly_id, bool id, const char *fw_version, String message);
+void wifiErrorDeepSleep(void);
+void resetDeviceCredentials(void);
+
+#ifdef BOARD_TRMNL_X
+/** Portal-tick power-off corners handler (IQS323); implemented in bl.cpp. */
+void blWifiPortalTickX(void);
+#endif
+
+void wifiSessionInit(void) { WifiCaptivePortal.setHostname(getWifiClientHostname()); }
+
+#ifdef BOARD_TRMNL_X
+static bool wifiSessionModemNeeded(void) {
+  if (WifiCaptivePortal.isSaved()) {
+    WifiCredentials lastCreds = WifiCaptivePortal.getLastCredentials();
+    return lastCreds.is5GHz;
+  }
+  return true; // captive portal needs modem for 5 GHz
+}
+
+static void wifiSessionPrepareModem(void) {
+  const bool bModemNeeded = wifiSessionModemNeeded();
+  Log.info("%s [%d]: Checking if we need to use the ESP32-C5 modem...\r\n", __FILE__, __LINE__);
+  Log.info("%s [%d]: modem needed = %d\n\r", __FILE__, __LINE__, bModemNeeded);
+
+  if (bModemNeeded) {
+    modem_reset_target(); // before Modem ctor — expects modem ready
+    static Modem modemInstance(115200);
+    if (modemInstance.isInitialized()) {
+      g_modem = &modemInstance;
+    } else {
+      Log_info("Modem init failed — falling back to 2.4 GHz mode");
+      g_modem = nullptr;
+    }
+  } else {
+    g_modem = nullptr;
+  }
+
+  // Only scan when no credentials are saved (captive portal will be shown).
+  if (g_modem && !WifiCaptivePortal.isSaved()) {
+    // Modem can see this device's SoftAP; exclude it from connectable list.
+    String ownApSsid = WifiCaptivePortal.getAPSSID();
+
+    Log_info("No saved credentials — scanning networks via modem...");
+    auto modemNets = g_modem->scanNetworks();
+    Log_info("Modem found %d network(s)", modemNets.size());
+    std::vector<ExternalNetwork> nets;
+    for (auto &n : modemNets) {
+      if (n.ssid == ownApSsid) continue;
+      nets.push_back({n.ssid, n.rssi, n.open, n.is5GHz});
+    }
+    WifiCaptivePortal.setNetworks(nets);
+
+    WifiCaptivePortal.setModemConnectCallback([](const String &ssid, const String &pass) {
+      return g_modem->connectToNetwork(ssid, pass, getWifiClientHostname());
+    });
+
+    WifiCaptivePortal.setModemScanCallback([ownApSsid]() {
+      auto modemNets = g_modem->scanNetworks();
+      Log_info("Modem re-scan found %d network(s)", modemNets.size());
+      std::vector<ExternalNetwork> nets;
+      for (auto &n : modemNets) {
+        if (n.ssid == ownApSsid) continue;
+        nets.push_back({n.ssid, n.rssi, n.open, n.is5GHz});
+      }
+      return nets;
+    });
+
+    String modemMac = g_modem->getMacAddress();
+    if (!modemMac.isEmpty()) {
+      WifiCaptivePortal.setModemMac(modemMac);
+    }
+  }
+}
+#endif // BOARD_TRMNL_X
+
+void wifiSessionConnect(void) {
+#ifdef BOARD_TRMNL_X
+  wifiSessionPrepareModem();
+#endif
+
+  WiFi.mode(WIFI_STA); // explicitly set mode, esp defaults to STA+AP
+
+  MSG current_msg = NONE;
+
+// uncomment this to hardcode WiFi credentials (useful for testing wifi errors, etc.)
+// #define HARDCODED_WIFI
+#ifdef HARDCODED_WIFI
+  WifiCredentials hardcodedCreds = {.ssid = "ssid-goes-here", .pswd = "password-goes-here"};
+  Log_info("Hardcoded WiFi: connecting to SSID '%s'", hardcodedCreds.ssid.c_str());
+  auto connectResult = WifiCaptivePortal.connect(hardcodedCreds);
+  Log_info("Hardcoded WiFi: connect result '%s'", wifiStatusStr(connectResult));
+// goToSleep();
+#else
+
+  if (WifiCaptivePortal.isSaved()) {
+    Log.info("%s [%d]: WiFi saved\r\n", __FILE__, __LINE__);
+    int connection_res = connectWithSavedCredentials() ? 1 : 0;
+
+    Log.info("%s [%d]: Connection result: %d, WiFI Status: %d\r\n", __FILE__, __LINE__, connection_res, WiFi.status());
+
+    if (connection_res) {
+      String ip = String(WiFi.localIP());
+      Log.info("%s [%d]:wifi_connection [DEBUG]: Connected: %s\r\n", __FILE__, __LINE__, ip.c_str());
+      preferences.putInt(PREFERENCES_CONNECT_WIFI_RETRY_COUNT, 1);
+    } else {
+      if (current_msg != WIFI_FAILED) {
+        showMessageWithLogo(WIFI_FAILED);
+        current_msg = WIFI_FAILED;
+      }
+
+      Log_fatal_submit("Connection failed! WL Status: %d", WiFi.status());
+
+      wifiErrorDeepSleep();
+    }
+  } else {
+    Log.info("%s [%d]: WiFi NOT saved\r\n", __FILE__, __LINE__);
+
+    Log_info("FW version %s", Messages::firmware_version().c_str());
+
+    showMessageWithLogo(WIFI_CONNECT, "", false, Messages::firmware_version().c_str(), WifiCaptivePortal.getAPSSID());
+#ifdef BOARD_TRMNL_X
+    // set TAP mode as default while portal is up
+    iqs323_task_i2c_lock();
+    iqs323.setGestureConfig(true, STOP);
+    iqs323_task_i2c_unlock();
+    touchbar_tap_mode = true;
+
+    WifiCaptivePortal.setPortalTickCallback([]() { blWifiPortalTickX(); });
+#endif
+    WifiCaptivePortal.setResetSettingsCallback(resetDeviceCredentials);
+    bool portal_ok = WifiCaptivePortal.startPortal();
+    if (!portal_ok) {
+      WiFi.disconnect(true);
+
+      showMessageWithLogo(WIFI_FAILED);
+
+      Log_error("Failed to connect or hit timeout");
+
+      wifiErrorDeepSleep();
+    }
+    Log.info("%s [%d]: WiFi connected\r\n", __FILE__, __LINE__);
+    preferences.putInt(PREFERENCES_CONNECT_WIFI_RETRY_COUNT, 1);
+  }
+
+#endif
+}


### PR DESCRIPTION
Move saved-credentials connect, captive portal start, and X modem scan/callback registration into wifi_session. bl_init calls wifiSessionInit early and wifiSessionConnect after display/battery init.

X portal-tick power-off stays in bl as blWifiPortalTickX. Failure still uses wifiErrorDeepSleep. Behavior unchanged.

Verified: pio run -e trmnl