### PR TITLE
Rely on WiFi event handlers for connection completion/failure

### DIFF
--- a/lib/wificaptive/src/connect.cpp
+++ b/lib/wificaptive/src/connect.cpp
@@ -123,6 +123,7 @@ static void setWiFiBand(const WifiCredentials &credentials) {
 void captureEventData(WiFiEvent_t event, WiFiEventInfo_t info, WifiEventData *eventData) {
   switch (event) {
   case ARDUINO_EVENT_WIFI_STA_GOT_IP:
+    eventData->gotIp = true;
     Log_info("Wifi: Event STA_GOT_IP, IP: %s, Gateway: %s", (IPAddress(info.got_ip.ip_info.ip.addr)).toString().c_str(),
              (IPAddress(info.got_ip.ip_info.gw.addr)).toString().c_str());
     break;
@@ -146,16 +147,19 @@ void captureEventData(WiFiEvent_t event, WiFiEventInfo_t info, WifiEventData *ev
 WifiConnectionResult initiateConnectionAndWaitForOutcome(const WifiCredentials credentials) {
   WifiEventData eventData;
 
+  // To clear any prior event state before WiFi.begin(), so that the connection attempt starts with a clean slate
+  auto resetEventData = [&eventData]() {
+    eventData.gotIp = false;
+    eventData.disconnected = false;
+    eventData.disconnectReason = wifi_err_reason_t::WIFI_REASON_UNSPECIFIED;
+  };
+
     // Register WiFi event handlers and remember each registration id.
   std::vector<wifi_event_id_t> handlerIds;
   for (int i = ARDUINO_EVENT_WIFI_READY; i < ARDUINO_EVENT_MAX; i++) {
-    wifi_event_id_t id = WiFi.onEvent(
-      [&eventData](WiFiEvent_t event, WiFiEventInfo_t info) {
-        eventData.eventCount++;
-
-        captureEventData(event, info, &eventData);
-      },
-      (arduino_event_id_t)i);
+    wifi_event_id_t id =
+      WiFi.onEvent([&eventData](WiFiEvent_t event, WiFiEventInfo_t info) { captureEventData(event, info, &eventData); },
+                   (arduino_event_id_t)i);
     handlerIds.push_back(id);
   }
 
@@ -256,6 +260,7 @@ WifiConnectionResult initiateConnectionAndWaitForOutcome(const WifiCredentials c
 
     setWiFiBand(credentials);
 
+    resetEventData();
     WiFi.begin(credentials.ssid.c_str());
 
     beginResult = WiFi.status();
@@ -274,11 +279,12 @@ WifiConnectionResult initiateConnectionAndWaitForOutcome(const WifiCredentials c
 
     Log_info("WiFi: hostname set to %s", hostname.c_str());
 
+    resetEventData();
     beginResult = WiFi.begin(credentials.ssid.c_str(), credentials.pswd.c_str());
     Log_info("WiFi: begin (WPA2-Personal), starting from status %s", wifiStatusStr(beginResult));
   }
 
-  auto result = waitForConnectResult(CONNECTION_TIMEOUT);
+  auto result = waitForConnectResult(CONNECTION_TIMEOUT, eventData);
 
     // if connection failed and we were using enterprise, clean up
   if (result != WL_CONNECTED && credentials.isEnterprise) {
@@ -292,25 +298,22 @@ WifiConnectionResult initiateConnectionAndWaitForOutcome(const WifiCredentials c
   return {result, eventData};
 }
 
-wl_status_t waitForConnectResult(uint32_t timeout) {
-
+// Continually poll eventData, which is updated asynchronously by WiFi event handlers. Normalize
+// the result to Arduino type wl_status_t to mirror WiFi.status()
+wl_status_t waitForConnectResult(uint32_t timeout, const WifiEventData &eventData) {
   unsigned long timeoutmillis = millis() + timeout;
-  wl_status_t status = WiFi.status();
 
   while (millis() < timeoutmillis) {
-    wl_status_t newStatus = WiFi.status();
-    if (newStatus != status) {
-      Log_info("WiFi: status changed from %s to %s", wifiStatusStr(status), wifiStatusStr(newStatus));
+    if (eventData.gotIp) {
+      return WL_CONNECTED;
     }
-    status = newStatus;
-    // @todo detect additional states, connect happens, then dhcp then get ip, there is some delay here, make sure not
-    // to timeout if waiting on IP
-    if (status == WL_CONNECTED || status == WL_CONNECT_FAILED) {
-      return status;
+    if (eventData.disconnected) {
+      Log_info("WiFi: connect attempt failed, reason: %s", WiFi.disconnectReasonName(eventData.disconnectReason));
+      return WL_CONNECT_FAILED;
     }
     delay(100);
   }
 
   Log_info("WiFi: connect timed out after %d ms", timeout);
-  return status;
+  return WL_DISCONNECTED;
 }

--- a/lib/wificaptive/src/connect.h
+++ b/lib/wificaptive/src/connect.h
@@ -6,5 +6,5 @@
 #include "wifi-types.h"
 
 WifiConnectionResult initiateConnectionAndWaitForOutcome(const WifiCredentials credentials);
-wl_status_t waitForConnectResult(uint32_t timeout);
+wl_status_t waitForConnectResult(uint32_t timeout, const WifiEventData &eventData);
 void disableWpa2Enterprise();

--- a/lib/wificaptive/src/wifi-types.h
+++ b/lib/wificaptive/src/wifi-types.h
@@ -34,9 +34,9 @@ struct WifiNetwork {
 };
 
 struct WifiEventData {
-  bool disconnected = false;
+  volatile bool gotIp = false;
+  volatile bool disconnected = false;
   wifi_err_reason_t disconnectReason = wifi_err_reason_t::WIFI_REASON_UNSPECIFIED;
-  int eventCount = 0;
 };
 
 struct WifiConnectionResult {


### PR DESCRIPTION
## Problem

This is an attempt to fix the issue on OG where the WiFi retries would be exhausted without actually retrying.

If the first WiFi connection attempt fails with `WL_CONNECT_FAILED`, all subsequent retries on that wake will also fail.

The problem is that `WiFi.status()` contains stale global state from the previous attempt, so we keep detecting that same failure until it eventually gives up and goes to sleep.

## Solution

Don't rely on `WiFi.status()`, since it could contain stale state from a previous connection attempt. Consume the WiFi events ourselves to wait for a good connection.

## Reproduction

Simulate a failure on `attempt == 0` only! On `main`, every subsequent attempt will also fail. On this PR, the second attempt succeeds as desired.

```cpp
bool WifiCaptive::tryConnectWithRetries(const WifiCredentials creds, int last_used_index) {
  for (int attempt = 0; attempt < WIFI_CONNECTION_ATTEMPTS; attempt++) {
    Log_info("Attempt %d to connect to %s (Enterprise: %s, Static IP: %s, IP: %s)", attempt + 1, creds.ssid.c_str(),
             creds.isEnterprise ? "yes" : "no", creds.useStaticIP ? "yes" : "no", creds.staticIP.c_str());
    WifiCredentials attemptCreds = creds;
    if (attempt == 0) {
      attemptCreds.pswd = "deliberately-wrong";
      Log_info("TEST: sabotaging attempt 1 with a wrong password");
    }

    connect(attemptCreds);

    if (attempt == 0) {
      Log_info("TEST: forcing WL_CONNECT_FAILED after failed first attempt");
      WiFiSTAClass::_setStatus(WL_CONNECT_FAILED);
    }
    // ...
```
