### PR TITLE
Fix status-202 (no content): stop false 'unable to connect' and always show the pairing code

### DIFF
--- a/lib/trmnl/include/pairing.h
+++ b/lib/trmnl/include/pairing.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string.h>
+
+// Decide whether to (re)paint the pairing-code screen for a NO_REGISTER
+// (/api/display HTTP 200 body status 202, or otherwise unregistered) response.
+//
+// Repaint when the device is unregistered AND either a repaint is forced
+// (power-on, or content just cleared the last-shown tracker) or the stored
+// friendly id differs from the code we last painted. This surfaces the pairing
+// code after a server-side device deletion without e-ink thrash on fast polls.
+inline bool shouldShowPairingCode(bool no_register, bool force_refresh, const char *stored_friendly_id,
+                                  const char *last_shown_id) {
+  if (!no_register) return false;
+  if (force_refresh) return true;
+  return strcmp(stored_friendly_id ? stored_friendly_id : "", last_shown_id ? last_shown_id : "") != 0;
+}

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -1649,6 +1649,23 @@ static https_request_err_e downloadAndShow()
   }
 #endif // BOARD_TRMNL_X
 
+  // Nothing new to fetch: `status` is only set when the response carried a new
+  // image_url, and `filename` is left empty otherwise. This happens for an
+  // HTTP 200 body of status 202 (device registered but no content/plugin/
+  // playlist assigned) and for a status 0 response with no image_url. Falling
+  // through here would call withHttp("") on the empty URL; https.begin("")
+  // fails to parse it and returns false, which the download path misreports as
+  // HTTPS_UNABLE_TO_CONNECT ("unable to connect to internet") - a misleading
+  // network error for what is really a "no content yet" state. Skip the
+  // download and return the already-handled result (e.g. HTTPS_NO_REGISTER for
+  // a 202) so the device keeps its current screen and fast-polls until content
+  // is assigned.
+  if (!status || strlen(filename) == 0)
+  {
+    Log_info("No image URL to download (status=%d, url_len=%u); skipping image fetch", status, (unsigned)strlen(filename));
+    return result;
+  }
+
   result = withHttp(
       filename,
       [&](HTTPClient *httpsp, HttpError error) -> https_request_err_e

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -33,6 +33,7 @@
 #include <refresh_interval.h>
 #include <services/firmware_update.h>
 #include <api_response_parsing.h>
+#include <pairing.h>
 #include "logging_parcers.h"
 #include <SPIFFS.h>
 #include "http_client.h"
@@ -93,6 +94,10 @@ void config_gpio_for_lp();
 int png_to_epd(const uint8_t *pPNG, int iDataSize, bool bPrevious);
 
 static unsigned long startup_time = 0;
+
+// Last pairing code painted on the FRIENDLY_ID screen, kept across deep sleep so
+// a NO_REGISTER (status 202) fast-poll doesn't repaint the same code every wake.
+static RTC_DATA_ATTR char s_last_shown_pairing_id[32] = {0};
 
 #ifndef BOARD_TRMNL_X
 // Create stub functions for the touchbar workaround
@@ -1291,12 +1296,25 @@ void bl_init(void)
 
   submitStoredLogs();
 
-  if (request_result == HTTPS_NO_REGISTER && need_to_refresh_display == 1)
+  if (request_result == HTTPS_NO_REGISTER)
   {
-    // show the image
+    // Unregistered device (HTTP 200 status 202 / no content): always land on the
+    // pairing-code screen so re-pairing after a server-side device deletion
+    // surfaces the code, regardless of the RTC need_to_refresh_display flag, but
+    // dedupe against the last painted code to avoid e-ink thrash on fast polls.
     String friendly_id = preferences.getString(PREFERENCES_FRIENDLY_ID, PREFERENCES_FRIENDLY_ID_DEFAULT);
-    showMessageWithLogo(FRIENDLY_ID, friendly_id, true, "", String(message_buffer));
-    need_to_refresh_display = 0;
+    if (shouldShowPairingCode(true, need_to_refresh_display == 1, friendly_id.c_str(), s_last_shown_pairing_id))
+    {
+      showMessageWithLogo(FRIENDLY_ID, friendly_id, true, "", String(message_buffer));
+      need_to_refresh_display = 0;
+      snprintf(s_last_shown_pairing_id, sizeof(s_last_shown_pairing_id), "%s", friendly_id.c_str());
+    }
+  }
+  else if (request_result == HTTPS_SUCCESS)
+  {
+    // Content is on screen now; forget the last pairing code so a later 202
+    // (e.g. the server device record was removed) re-surfaces the code.
+    s_last_shown_pairing_id[0] = '\0';
   }
 
   // reset checking

--- a/test/test_pairing/pairing.test.cpp
+++ b/test/test_pairing/pairing.test.cpp
@@ -1,0 +1,42 @@
+#include <pairing.h>
+#include <unity.h>
+
+// Registered devices (status != 202) never show the pairing screen.
+void test_pairing_hidden_when_registered(void) {
+  TEST_ASSERT_FALSE(shouldShowPairingCode(false, true, "598364", ""));
+  TEST_ASSERT_FALSE(shouldShowPairingCode(false, false, "598364", ""));
+}
+
+// Power-on / forced refresh always repaints the code.
+void test_pairing_shown_on_force_refresh(void) {
+  TEST_ASSERT_TRUE(shouldShowPairingCode(true, true, "598364", "598364"));
+}
+
+// A device that was showing content (tracker cleared) or whose code changed
+// must repaint - this is the "never shows after server-side deletion" fix.
+void test_pairing_shown_when_code_changed(void) {
+  TEST_ASSERT_TRUE(shouldShowPairingCode(true, false, "598364", ""));
+  TEST_ASSERT_TRUE(shouldShowPairingCode(true, false, "598364", "111111"));
+}
+
+// Fast-poll of the same code with the code already on screen: no repaint (no thrash).
+void test_pairing_deduped_when_same_code(void) {
+  TEST_ASSERT_FALSE(shouldShowPairingCode(true, false, "598364", "598364"));
+}
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void process() {
+  UNITY_BEGIN();
+  RUN_TEST(test_pairing_hidden_when_registered);
+  RUN_TEST(test_pairing_shown_on_force_refresh);
+  RUN_TEST(test_pairing_shown_when_code_changed);
+  RUN_TEST(test_pairing_deduped_when_same_code);
+  UNITY_END();
+}
+
+int main(int argc, char **argv) {
+  process();
+  return 0;
+}

--- a/test/test_parse_api_display/api_display.test.cpp
+++ b/test/test_parse_api_display/api_display.test.cpp
@@ -68,6 +68,24 @@ void test_parseResponse_apiDisplay_treats_unknown_sf_as_none(void) {
   TEST_ASSERT_EQUAL(parsed.special_function, SPECIAL_FUNCTION::SF_NONE);
 }
 
+void test_parseResponse_apiDisplay_status_202_has_no_image_url(void) {
+  // Registered-but-unclaimed / no-content: server replies 200 with body {"status":202}.
+  String input = "{\"status\":202}";
+  auto parsed = parseResponse_apiDisplay(input);
+  TEST_ASSERT_EQUAL(ApiDisplayOutcome::Ok, parsed.outcome);
+  TEST_ASSERT_EQUAL_UINT64(202, parsed.status);
+  TEST_ASSERT_EQUAL_STRING("", parsed.image_url.c_str());
+}
+
+void test_parseResponse_apiDisplay_status_0_empty_image_url(void) {
+  // status 0 with no image_url must not yield a non-empty URL to download.
+  String input = "{\"status\":0}";
+  auto parsed = parseResponse_apiDisplay(input);
+  TEST_ASSERT_EQUAL(ApiDisplayOutcome::Ok, parsed.outcome);
+  TEST_ASSERT_EQUAL_UINT64(0, parsed.status);
+  TEST_ASSERT_EQUAL_STRING("", parsed.image_url.c_str());
+}
+
 void setUp(void) {
   // set stuff up here
 }
@@ -82,6 +100,8 @@ void process() {
   RUN_TEST(test_parseResponse_apiDisplay_deserializationError);
   RUN_TEST(test_parseResponse_apiDisplay_treats_unknown_sf_as_none);
   RUN_TEST(test_parseResponse_apiDisplay_missing_fields);
+  RUN_TEST(test_parseResponse_apiDisplay_status_202_has_no_image_url);
+  RUN_TEST(test_parseResponse_apiDisplay_status_0_empty_image_url);
   UNITY_END();
 }
 


### PR DESCRIPTION
## Problem

For a device whose MAC maps to an unclaimed/no-content record, `/api/display` returns **HTTP 200** with body `{"status":202}` (no `image_url`). Two firmware issues surfaced from this:

1. **Misleading "unable to connect".** `downloadAndShow()` still called `withHttp("")`; `https.begin("")` fails to parse the empty URL and the path reported `HTTPS_UNABLE_TO_CONNECT` ("unable connect to API/internet") even though WiFi, DNS, TLS and the API request all succeeded.
2. **Pairing code never (re)shown.** The pairing screen only rendered when the RTC `need_to_refresh_display` flag was `1`. That flag is zeroed after the first paint and after content, so a 202 arriving on a timer wake left a previously-paired device (whose server record was removed) silently fast-polling on stale content, never surfacing its current pairing code.

## Change (firmware-only)

- **Empty-URL guard:** skip the image fetch when there is no new image (`!status` or empty URL) and return the already-handled result instead of attempting `withHttp("")`.
- **Always land on the pairing code:** on `HTTPS_NO_REGISTER`, render the pairing-code screen regardless of `need_to_refresh_display`, deduped against the last painted code (kept in RTC, cleared when content is shown) so re-pairing after a server-side deletion surfaces the code without e-ink thrash on fast polls. The decision is extracted into `shouldShowPairingCode()` (`lib/trmnl/include/pairing.h`) and unit-tested.

## Tests

- `test_parse_api_display`: added cases for `{"status":202}` and `status:0` with empty `image_url` (must parse to no image URL).
- `test_pairing`: unit tests for `shouldShowPairingCode()` (registered vs. unregistered, force-refresh, code-changed, same-code dedupe).
- `pio test -e native` green (80 cases).

## Verified on hardware (reTerminal E1001)

```
status: 202
No image URL to download (status=0, url_len=0); skipping image fetch
request result - HTTPS_NO_REGISTER
display_show_msg2 start / friendly id case   -> pairing code 598364 shown
```

Pairing screen repainted once across two 202 polls (deduped); no "unable to connect". Regression-built `trmnl`, `seeed_reTerminal_E1001`, and `TRMNL_X_E1003`.
