### PR TITLE
Move goToSleep and button-only sleep into sleep_session

### DIFF
--- a/include/globals.h
+++ b/include/globals.h
@@ -47,6 +47,7 @@ extern int iPrevWakeTime;               // RTC: total wake time of the last cycl
 extern bool bUsedCachedImage;           // RTC: last image displayed was read from cache (for statistics collection)
 extern uint8_t need_to_refresh_display; // RTC
 extern bool otg_state;                  // RTC: OTG state across deep sleep
+extern unsigned long startup_time;      // wake start (ms) for awake-time stats
 
 // --- UI / input ---
 extern bool touchbar_tap_mode; // false = "slide", true = "tap" (default)

--- a/include/sleep_session.h
+++ b/include/sleep_session.h
@@ -1,0 +1,17 @@
+#pragma once
+
+/**
+ * Deep sleep entry and low-power GPIO configuration.
+ *
+ * GME: goToSleep / goToSleepButtonOnly / config_gpio_for_lp. wifiErrorDeepSleep
+ * remains in bl.cpp until a follow-up PR.
+ */
+
+/** Prepare peripherals, enable timer + GPIO wake, enter deep sleep. */
+void goToSleep(void);
+
+/** Deep sleep until button only (no timer); used after Wi-Fi retry limit. */
+void goToSleepButtonOnly(void);
+
+/** Float/tristate GPIOs for low power (TRMNL X panel/I2C pins). */
+void config_gpio_for_lp(void);

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -56,6 +56,7 @@
 #include "messages.h"
 #include "displayed_image.h"
 #include <globals.h>
+#include <sleep_session.h>
 const char *szHTTPErrors[] = {
     "HTTPS_NO_ERR",
     "HTTPS_RESET",
@@ -79,9 +80,9 @@ static float vBatt;
 static https_request_err_e downloadAndShow(); // download and show the image
 static https_request_err_e handleApiDisplayResponse(ApiDisplayResponse &apiResponse);
 static void resetDeviceCredentials(void);            // reset device credentials API key, Friendly ID, Wi-Fi SSID and password
-void goToSleep(void);                         // sleep preparing
-static void goToSleepButtonOnly(void);               // sleep until button press, no timer
-static void submitStoredLogs(void);
+// goToSleep / goToSleepButtonOnly / config_gpio_for_lp → sleep_session
+// Non-static: used by sleep_session before deep sleep
+void submitStoredLogs(void);
 static void writeSpecialFunction(SPECIAL_FUNCTION function);
 void showMessageWithLogo(MSG message_type);
 static void showMessageWithLogo(MSG message_type, String friendly_id, bool id, const char *fw_version, String message);
@@ -89,10 +90,8 @@ static void showMessageWithLogo(MSG message_type, const ApiSetupResponse &apiRes
 static void wifiErrorDeepSleep();
 static uint8_t *storedLogoOrDefault(int iType);
 static DeviceStatusStamp getDeviceStatusStamp();
-void config_gpio_for_lp();
 int png_to_epd(const uint8_t *pPNG, int iDataSize, bool bPrevious);
 
-static unsigned long startup_time = 0;
 
 #ifndef BOARD_TRMNL_X
 // Create stub functions for the touchbar workaround
@@ -2590,165 +2589,6 @@ static void resetDeviceCredentials(void)
 }
 
 /**
- * @brief Function to sleep preparing and go to sleep
- * @param none
- * @return none
- */
-void goToSleep(void)
-{
-  Log.info("%s [%d]: go to sleep\r\n", __FILE__, __LINE__);
-  submitStoredLogs();
-
-// DEBUG - workaround to prevent crash in the WiFi stack of unknown origin
-#ifndef BOARD_X_CLASS
-  if (WiFi.status() == WL_CONNECTED) {
-    WiFi.disconnect();
-  }
-  WiFi.mode(WIFI_OFF); 
-#endif
-
-#if BOARD_TRMNL_X
-  Log_info("Preparing IQS323 for sleep via task...");
-
-  // Use task manager for sleep preparation (sets event mode, checks I2C health)
-  if (!iqs323_task_prepare_sleep(5000)) {
-    Log.warning("IQS323 sleep preparation timeout - proceeding anyway\n");
-  }
-
-  // Configure gesture mode last so prepare_sleep's writeMM() cannot override it
-  iqs323_task_i2c_lock();
-  iqs323.setGestureConfig(touchbar_tap_mode, STOP);
-  iqs323_task_i2c_unlock();
-
-  // Cleanup the task before entering deep sleep
-  iqs323_task_deinit();
-  Log_info("IQS323 is ready for sleep.");
-
-  esp_set_deep_sleep_wake_stub(*wakeup_stub);
-  display_sleep();
-  config_tca95535_pins_for_lp();
-  config_gpio_for_lp();
-#endif
-
-  filesystem_deinit();
-  uint32_t time_to_sleep = refreshInterval.seconds();
-  iPrevWakeTime = millis() - startup_time; // save for statistics
-  Log.info("%s [%d]: total awake time - %d ms\r\n", __FILE__, __LINE__, iPrevWakeTime); 
-  Log.info("%s [%d]: time to sleep - %d\r\n", __FILE__, __LINE__, time_to_sleep);
-  preferences.putUInt(PREFERENCES_LAST_SLEEP_TIME, systemClock().getTime());
-  preferences.end();
-  esp_sleep_enable_timer_wakeup((uint64_t)time_to_sleep * SLEEP_uS_TO_S_FACTOR);
-  // Configure GPIO pin for wakeup
-#if CONFIG_IDF_TARGET_ESP32
-  #define BUTTON_PIN_BITMASK(GPIO) (1ULL << GPIO)  // 2 ^ GPIO_NUMBER in hex
-  esp_sleep_enable_ext1_wakeup(BUTTON_PIN_BITMASK(PIN_INTERRUPT), ESP_EXT1_WAKEUP_ALL_LOW);
-#elif defined(CONFIG_IDF_TARGET_ESP32C3) || defined (CONFIG_IDF_TARGET_ESP32C5)
-  pinMode(PIN_INTERRUPT, INPUT); // needed to not immediately wake up
-  esp_deep_sleep_enable_gpio_wakeup(1 << PIN_INTERRUPT, ESP_GPIO_WAKEUP_GPIO_LOW);
-#elif defined(CONFIG_IDF_TARGET_ESP32S3)
-  esp_sleep_enable_ext0_wakeup((gpio_num_t)PIN_INTERRUPT, 0);
-#else
-#error "Unsupported ESP32 target for GPIO wakeup configuration"
-#endif
-#ifdef BOARD_XTEINK_X4
-// The Xteink X4 has a high current draw in deep sleep (3-4mA), so allow the user to select
-// if they want to completely shut down the power and only update with a physical button press
-// or have short battery life (5-7 days) in the normal TRMNL wakeup mode
-#ifdef X4_WAKE_ON_BUTTON
-  pinMode(13, OUTPUT);
-  digitalWrite(13, 0); // cut off the battery power
-  delay(100); // allow it to settle before going into power-off
-#else // Keep the battery power on and allow timed wakeup
-  gpio_hold_en(GPIO_NUM_13); // MOSFET enabling the battery power
-  gpio_deep_sleep_hold_en(); // Needed to keep the battery power enabled during RTC sleep
-#endif
-#endif
-  esp_deep_sleep_start();
-}
-
-static void goToSleepButtonOnly(void)
-{
-  submitStoredLogs();
-  if (WiFi.status() == WL_CONNECTED) {
-    WiFi.disconnect();
-  }
-  WiFi.mode(WIFI_OFF);
-  filesystem_deinit();
-  preferences.end();
-#if CONFIG_IDF_TARGET_ESP32
-  #define BUTTON_PIN_BITMASK_BTN(GPIO) (1ULL << GPIO)
-  esp_sleep_enable_ext1_wakeup(BUTTON_PIN_BITMASK_BTN(PIN_INTERRUPT), ESP_EXT1_WAKEUP_ALL_LOW);
-#elif defined( CONFIG_IDF_TARGET_ESP32C3 ) || defined ( CONFIG_IDF_TARGET_ESP32C5 )
-  esp_deep_sleep_enable_gpio_wakeup(1 << PIN_INTERRUPT, ESP_GPIO_WAKEUP_GPIO_LOW);
-#elif CONFIG_IDF_TARGET_ESP32S3
-  esp_sleep_enable_ext0_wakeup((gpio_num_t)PIN_INTERRUPT, 0);
-#else
-#error "Unsupported ESP32 target for GPIO wakeup configuration"
-#endif
-#ifdef BOARD_XTEINK_X4
-  gpio_hold_en(GPIO_NUM_13);
-  gpio_deep_sleep_hold_en();
-#endif
-  esp_deep_sleep_start();
-}
-void config_gpio_for_lp() {
-
-#ifdef BOARD_TRMNL_X
-  // XCL
-  pinMode(GPIO_NUM_4, INPUT);
-
-  // Data pins (d8 to d15)
-  pinMode(GPIO_NUM_5, INPUT);
-  pinMode(GPIO_NUM_6, INPUT);
-  pinMode(GPIO_NUM_7, INPUT);
-  pinMode(GPIO_NUM_15, INPUT);
-  pinMode(GPIO_NUM_16, INPUT);
-  pinMode(GPIO_NUM_17, INPUT);
-  pinMode(GPIO_NUM_18, INPUT);
-  pinMode(GPIO_NUM_8, INPUT);
-
-  // D+ D-
-  // pinMode(GPIO_NUM_19, INPUT);
-  // pinMode(GPIO_NUM_20, INPUT);
-
-  // Data pins (d0 to d7)
-  pinMode(GPIO_NUM_9, INPUT);
-  pinMode(GPIO_NUM_10, INPUT);
-  pinMode(GPIO_NUM_11, INPUT);
-  pinMode(GPIO_NUM_12, INPUT);
-  pinMode(GPIO_NUM_13, INPUT);
-  pinMode(GPIO_NUM_14, INPUT);
-  pinMode(GPIO_NUM_21, INPUT);
-  pinMode(GPIO_NUM_47, INPUT);
-
-  // EP_STV
-  pinMode(GPIO_NUM_48, INPUT);
-
-  // CKV
-  pinMode(GPIO_NUM_45, INPUT);
-
-  // BTN1
-  pinMode(GPIO_NUM_0, INPUT);
-
-  // I2C
-  pinMode(GPIO_NUM_39, INPUT); // SDA
-  pinMode(GPIO_NUM_40, INPUT); // SCL
-
-  // XSTL
-  pinMode(GPIO_NUM_41, INPUT);
-
-  // LEH
-  pinMode(GPIO_NUM_42, INPUT);
-
-  // UART0
-  pinMode(GPIO_NUM_43, INPUT); // TXD
-  pinMode(GPIO_NUM_44, INPUT); // RXD
-  pinMode(GPIO_NUM_1, INPUT); // CTS
-  pinMode(GPIO_NUM_2, INPUT); // RTS
-#endif // BOARD_TRMNL_X
-} /* config_gpio_for_lp() */
-
-/**
  * @brief Function to submit a log string to the API
  * @param log_buffer pointer to the buffer that contains log note
  * @return bool true if successful, false if failed
@@ -2791,7 +2631,7 @@ bool storeLogString(const char *log_buffer)
 }
 
 
-static void submitStoredLogs(void)
+void submitStoredLogs(void)
 {
   if (WiFi.isConnected() == false)
   {

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -27,6 +27,7 @@ RTC_DATA_ATTR int iPrevWakeTime = 0;
 RTC_DATA_ATTR bool bUsedCachedImage = false;
 RTC_DATA_ATTR uint8_t need_to_refresh_display = 1;
 RTC_DATA_ATTR bool otg_state = false;
+unsigned long startup_time = 0;
 
 // --- UI / input ---
 bool touchbar_tap_mode = true; // false = "slide", true = "tap" (default)

--- a/src/sleep_session.cpp
+++ b/src/sleep_session.cpp
@@ -1,0 +1,179 @@
+#include <Arduino.h>
+#include <ArduinoLog.h>
+#include <WiFi.h>
+#include <config.h>
+#include <display.h>
+#include <filesystem.h>
+#include <globals.h>
+#include <misc/clock.h>
+#include <sleep_session.h>
+#include <trmnl_log.h>
+
+#include "driver/gpio.h"
+
+#ifdef BOARD_TRMNL_X
+#include <IQS323.h>
+#include <iqs323_task.h>
+
+#include "rtc_wake_stub_trmnl_x.h"
+#endif
+
+// --- Helpers still owned by bl.cpp ---
+void submitStoredLogs(void);
+
+/**
+ * @brief Function to sleep preparing and go to sleep
+ * @param none
+ * @return none
+ */
+void goToSleep(void) {
+  Log.info("%s [%d]: go to sleep\r\n", __FILE__, __LINE__);
+  submitStoredLogs();
+
+// DEBUG - workaround to prevent crash in the WiFi stack of unknown origin
+#ifndef BOARD_X_CLASS
+  if (WiFi.status() == WL_CONNECTED) {
+    WiFi.disconnect();
+  }
+  WiFi.mode(WIFI_OFF);
+#endif
+
+#if BOARD_TRMNL_X
+  Log_info("Preparing IQS323 for sleep via task...");
+
+  // Use task manager for sleep preparation (sets event mode, checks I2C health)
+  if (!iqs323_task_prepare_sleep(5000)) {
+    Log.warning("IQS323 sleep preparation timeout - proceeding anyway\n");
+  }
+
+  // Configure gesture mode last so prepare_sleep's writeMM() cannot override it
+  iqs323_task_i2c_lock();
+  iqs323.setGestureConfig(touchbar_tap_mode, STOP);
+  iqs323_task_i2c_unlock();
+
+  // Cleanup the task before entering deep sleep
+  iqs323_task_deinit();
+  Log_info("IQS323 is ready for sleep.");
+
+  esp_set_deep_sleep_wake_stub(*wakeup_stub);
+  display_sleep();
+  config_tca95535_pins_for_lp();
+  config_gpio_for_lp();
+#endif
+
+  filesystem_deinit();
+  uint32_t time_to_sleep = refreshInterval.seconds();
+  iPrevWakeTime = millis() - startup_time; // save for statistics
+  Log.info("%s [%d]: total awake time - %d ms\r\n", __FILE__, __LINE__, iPrevWakeTime);
+  Log.info("%s [%d]: time to sleep - %d\r\n", __FILE__, __LINE__, time_to_sleep);
+  preferences.putUInt(PREFERENCES_LAST_SLEEP_TIME, systemClock().getTime());
+  preferences.end();
+  esp_sleep_enable_timer_wakeup((uint64_t)time_to_sleep * SLEEP_uS_TO_S_FACTOR);
+  // Configure GPIO pin for wakeup
+#if CONFIG_IDF_TARGET_ESP32
+#define BUTTON_PIN_BITMASK(GPIO) (1ULL << GPIO)  // 2 ^ GPIO_NUMBER in hex
+  esp_sleep_enable_ext1_wakeup(BUTTON_PIN_BITMASK(PIN_INTERRUPT), ESP_EXT1_WAKEUP_ALL_LOW);
+#elif defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32C5)
+  pinMode(PIN_INTERRUPT, INPUT); // needed to not immediately wake up
+  esp_deep_sleep_enable_gpio_wakeup(1 << PIN_INTERRUPT, ESP_GPIO_WAKEUP_GPIO_LOW);
+#elif defined(CONFIG_IDF_TARGET_ESP32S3)
+  esp_sleep_enable_ext0_wakeup((gpio_num_t)PIN_INTERRUPT, 0);
+#else
+#error "Unsupported ESP32 target for GPIO wakeup configuration"
+#endif
+#ifdef BOARD_XTEINK_X4
+// The Xteink X4 has a high current draw in deep sleep (3-4mA), so allow the user to select
+// if they want to completely shut down the power and only update with a physical button press
+// or have short battery life (5-7 days) in the normal TRMNL wakeup mode
+#ifdef X4_WAKE_ON_BUTTON
+  pinMode(13, OUTPUT);
+  digitalWrite(13, 0); // cut off the battery power
+  delay(100); // allow it to settle before going into power-off
+#else // Keep the battery power on and allow timed wakeup
+  gpio_hold_en(GPIO_NUM_13); // MOSFET enabling the battery power
+  gpio_deep_sleep_hold_en(); // Needed to keep the battery power enabled during RTC sleep
+#endif
+#endif
+  esp_deep_sleep_start();
+}
+
+void goToSleepButtonOnly(void) {
+  submitStoredLogs();
+  if (WiFi.status() == WL_CONNECTED) {
+    WiFi.disconnect();
+  }
+  WiFi.mode(WIFI_OFF);
+  filesystem_deinit();
+  preferences.end();
+#if CONFIG_IDF_TARGET_ESP32
+#define BUTTON_PIN_BITMASK_BTN(GPIO) (1ULL << GPIO)
+  esp_sleep_enable_ext1_wakeup(BUTTON_PIN_BITMASK_BTN(PIN_INTERRUPT), ESP_EXT1_WAKEUP_ALL_LOW);
+#elif defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32C5)
+  esp_deep_sleep_enable_gpio_wakeup(1 << PIN_INTERRUPT, ESP_GPIO_WAKEUP_GPIO_LOW);
+#elif CONFIG_IDF_TARGET_ESP32S3
+  esp_sleep_enable_ext0_wakeup((gpio_num_t)PIN_INTERRUPT, 0);
+#else
+#error "Unsupported ESP32 target for GPIO wakeup configuration"
+#endif
+#ifdef BOARD_XTEINK_X4
+  gpio_hold_en(GPIO_NUM_13);
+  gpio_deep_sleep_hold_en();
+#endif
+  esp_deep_sleep_start();
+}
+void config_gpio_for_lp() {
+
+#ifdef BOARD_TRMNL_X
+  // XCL
+  pinMode(GPIO_NUM_4, INPUT);
+
+  // Data pins (d8 to d15)
+  pinMode(GPIO_NUM_5, INPUT);
+  pinMode(GPIO_NUM_6, INPUT);
+  pinMode(GPIO_NUM_7, INPUT);
+  pinMode(GPIO_NUM_15, INPUT);
+  pinMode(GPIO_NUM_16, INPUT);
+  pinMode(GPIO_NUM_17, INPUT);
+  pinMode(GPIO_NUM_18, INPUT);
+  pinMode(GPIO_NUM_8, INPUT);
+
+  // D+ D-
+  // pinMode(GPIO_NUM_19, INPUT);
+  // pinMode(GPIO_NUM_20, INPUT);
+
+  // Data pins (d0 to d7)
+  pinMode(GPIO_NUM_9, INPUT);
+  pinMode(GPIO_NUM_10, INPUT);
+  pinMode(GPIO_NUM_11, INPUT);
+  pinMode(GPIO_NUM_12, INPUT);
+  pinMode(GPIO_NUM_13, INPUT);
+  pinMode(GPIO_NUM_14, INPUT);
+  pinMode(GPIO_NUM_21, INPUT);
+  pinMode(GPIO_NUM_47, INPUT);
+
+  // EP_STV
+  pinMode(GPIO_NUM_48, INPUT);
+
+  // CKV
+  pinMode(GPIO_NUM_45, INPUT);
+
+  // BTN1
+  pinMode(GPIO_NUM_0, INPUT);
+
+  // I2C
+  pinMode(GPIO_NUM_39, INPUT); // SDA
+  pinMode(GPIO_NUM_40, INPUT); // SCL
+
+  // XSTL
+  pinMode(GPIO_NUM_41, INPUT);
+
+  // LEH
+  pinMode(GPIO_NUM_42, INPUT);
+
+  // UART0
+  pinMode(GPIO_NUM_43, INPUT); // TXD
+  pinMode(GPIO_NUM_44, INPUT); // RXD
+  pinMode(GPIO_NUM_1, INPUT); // CTS
+  pinMode(GPIO_NUM_2, INPUT); // RTS
+#endif // BOARD_TRMNL_X
+} /* config_gpio_for_lp() */


### PR DESCRIPTION
Relocate deep-sleep entry (timer + GPIO wake, X IQS prepare/wake stub, config_gpio_for_lp) out of bl.cpp. Move startup_time into globals for awake-time stats. Export submitStoredLogs for the sleep path.

wifiErrorDeepSleep stays in bl for a follow-up. Behavior unchanged.

Verified: pio run -e trmnl