### PR TITLE
Move X playlist browse helper into touchbar_session

### DIFF
--- a/include/filesystem.h
+++ b/include/filesystem.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Arduino.h>
+#include <Preferences.h>
 
 /**
  * @brief Function to delete old versions of plugin images (by comparing the timestamp)
@@ -73,6 +74,17 @@ size_t filesystem_write_to_file(const char *name, uint8_t *in_buffer, size_t siz
  * @return none
  */
 void writeImageToFile(const char *name, uint8_t *in_buffer, size_t size);
+
+/**
+ * @brief Update the X playlist order NVS string after a new image becomes current.
+ *        Refreshes an existing same-plugin entry in place, or inserts after prev_path.
+ *        Drops playlist entries whose files no longer exist (except prev_path).
+ * @param preferences NVS "data" namespace
+ * @param new_path path that is now current
+ * @param prev_path previous current path (may be empty)
+ * @return none
+ */
+void update_playlist_order(Preferences &preferences, const char *new_path, const char *prev_path);
 
 /**
  * @brief Function to shorten a filename (if needed) to fit the SPIFFS file length

--- a/include/touchbar_session.h
+++ b/include/touchbar_session.h
@@ -1,0 +1,19 @@
+#pragma once
+
+/**
+ * TRMNL X touchbar playlist browse helpers.
+ *
+ * GME: show_cached_image_by_offset for gesture→browse wiring. Confirmation
+ * flows and full gesture processing remain in bl / other PRs as applicable.
+ */
+
+#ifdef BOARD_TRMNL_X
+
+/**
+ * Show a cached playlist image relative to the current browse position.
+ * @param offset -1 previous, +1 next (wraps within playlist_order)
+ * On success displays the image and enters deep sleep via goToSleep().
+ */
+void show_cached_image_by_offset(int offset);
+
+#endif // BOARD_TRMNL_X

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -380,60 +380,6 @@ bool check_corners_gesture()
   return slider_event == IQS323_GESTURE_HOLD && left && right;
 }
 
-static void update_playlist_order(const char *new_path, const char *prev_path) {
-  String order = preferences.getString(PREFERENCES_PLAYLIST_ORDER_KEY, "");
-  String newStr = String(new_path);
-  String prefix = newStr.substring(0, 14); // same-plugin identity (matches purge logic)
-  String prevStr = String(prev_path);
-
-  if (order.isEmpty()) {
-    preferences.putString(PREFERENCES_PLAYLIST_ORDER_KEY, newStr);
-    return;
-  }
-
-  // Scan list: update in-place if prefix matches (refresh), otherwise build a cleaned list
-  // dropping entries whose files no longer exist (except prev_path, which anchors insertion).
-  bool found = false;
-  String result = "";
-  int start = 0;
-  while (start <= (int)order.length()) {
-    int sep = order.indexOf('|', start);
-    String entry = (sep < 0) ? order.substring(start) : order.substring(start, sep);
-    if (!entry.isEmpty()) {
-      if (!found && entry.startsWith(prefix)) {
-        result += (result.isEmpty() ? "" : "|") + newStr;
-        found = true;
-      } else if (entry == prevStr || filesystem_file_exists(entry.c_str())) {
-        result += (result.isEmpty() ? "" : "|") + entry;
-      }
-      // else: file was purged from filesystem — drop from list
-    }
-    if (sep < 0) break;
-    start = sep + 1;
-  }
-  if (found) { preferences.putString(PREFERENCES_PLAYLIST_ORDER_KEY, result); return; }
-
-  // New plugin — insert right after prev_path's position in the cleaned list
-  String result2 = "";
-  bool inserted = false;
-  start = 0;
-  while (start <= (int)result.length()) {
-    int sep = result.indexOf('|', start);
-    String entry = (sep < 0) ? result.substring(start) : result.substring(start, sep);
-    if (!entry.isEmpty()) {
-      result2 += (result2.isEmpty() ? "" : "|") + entry;
-      if (!inserted && entry == prevStr) {
-        result2 += "|" + newStr;
-        inserted = true;
-      }
-    }
-    if (sep < 0) break;
-    start = sep + 1;
-  }
-  if (!inserted) result2 += (result2.isEmpty() ? "" : "|") + newStr;
-  preferences.putString(PREFERENCES_PLAYLIST_ORDER_KEY, result2);
-}
-
 static void show_cached_image_by_offset(int offset) {
   String order = preferences.getString(PREFERENCES_PLAYLIST_ORDER_KEY, "");
 
@@ -1589,7 +1535,7 @@ static https_request_err_e downloadAndShow()
         preferences.putString(PREFERENCES_LAST_PATH_KEY, _curPath);
       preferences.putString(PREFERENCES_CURRENT_PATH_KEY, String(szTemp));
       #ifdef BOARD_TRMNL_X
-      update_playlist_order(szTemp, _curPath.c_str());
+      update_playlist_order(preferences, szTemp, _curPath.c_str());
       #endif
       preferences.putString(PREFERENCES_BROWSE_PATH_KEY, String(szTemp));
       return result;
@@ -1637,7 +1583,7 @@ static https_request_err_e downloadAndShow()
     DisplayedImage::remember(szTemp); // current image becomes the previous image
 
     preferences.putString(PREFERENCES_CURRENT_PATH_KEY, String(szTemp));
-    update_playlist_order(szTemp, _prevPath.c_str());
+    update_playlist_order(preferences, szTemp, _prevPath.c_str());
     preferences.putString(PREFERENCES_BROWSE_PATH_KEY, String(szTemp));
 
 //    new_filename = apiDisplayResult.response.filename;
@@ -1875,7 +1821,7 @@ static https_request_err_e downloadAndShow()
               preferences.putString(PREFERENCES_LAST_PATH_KEY, _curPath);
             preferences.putString(PREFERENCES_CURRENT_PATH_KEY, String(szTemp));
             #ifdef BOARD_TRMNL_X
-            update_playlist_order(szTemp, _curPath.c_str());
+            update_playlist_order(preferences, szTemp, _curPath.c_str());
             #endif
             preferences.putString(PREFERENCES_BROWSE_PATH_KEY, String(szTemp));
           }

--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -115,6 +115,7 @@ void wait_for_serial() {
 }
 #ifdef BOARD_TRMNL_X
 #include <qa.h> // For device turn off feature
+#include <touchbar_session.h>
 // ############################ WAKEUP STUB #############################
 #include "rtc_wake_stub_trmnl_x.h"
 // ############################ WAKEUP STUB #############################
@@ -378,67 +379,6 @@ bool check_corners_gesture()
   }
   Log_info("Hold edges slider mode: event=%d (HOLD=%d) left=%d right=%d", slider_event, IQS323_GESTURE_HOLD, left, right);
   return slider_event == IQS323_GESTURE_HOLD && left && right;
-}
-
-static void show_cached_image_by_offset(int offset) {
-  String order = preferences.getString(PREFERENCES_PLAYLIST_ORDER_KEY, "");
-
-  if (order.isEmpty()) {
-    String path = (offset > 0)
-      ? preferences.getString(PREFERENCES_CURRENT_PATH_KEY, "")
-      : preferences.getString(PREFERENCES_LAST_PATH_KEY, "");
-    if (path.isEmpty()) { Log_info("No cached image for gesture"); return; }
-    int file_size = 0;
-    buffer = display_read_file(path.c_str(), &file_size);
-    if (buffer && file_size > 0) {
-      display_show_image(buffer, file_size, true);
-      DisplayedImage::remember(path.c_str());
-      goToSleep();
-    }
-    return;
-  }
-
-  char images[MAX_CACHED_IMAGES][36];
-  int count = 0;
-  int start = 0;
-  while (start <= (int)order.length() && count < MAX_CACHED_IMAGES) {
-    int sep = order.indexOf('|', start);
-    String entry = (sep < 0) ? order.substring(start) : order.substring(start, sep);
-    if (!entry.isEmpty() && filesystem_file_exists(entry.c_str())) {
-      strncpy(images[count], entry.c_str(), 35);
-      images[count][35] = '\0';
-      count++;
-    }
-    if (sep < 0) break;
-    start = sep + 1;
-  }
-
-  if (count == 0) { Log_info("No cached images available"); return; }
-
-  String browsePath = preferences.getString(PREFERENCES_BROWSE_PATH_KEY, "");
-  if (browsePath.isEmpty()) {
-    // Seed from last_path so first RIGHT shows curr_path (forward) and first LEFT shows older (backward).
-    // Falls back to curr_path if last_path is absent (e.g. only one image cached).
-    String lp = preferences.getString(PREFERENCES_LAST_PATH_KEY, "");
-    browsePath = lp.isEmpty() ? preferences.getString(PREFERENCES_CURRENT_PATH_KEY, "") : lp;
-  }
-
-  int cur_idx = count - 1;
-  for (int i = 0; i < count; i++) {
-    if (browsePath == String(images[i])) { cur_idx = i; break; }
-  }
-
-  int new_idx = (cur_idx + offset + count) % count;
-  Log_info("Playlist browse: %d/%d -> %d (%s)", cur_idx, count, new_idx, images[new_idx]);
-
-  int file_size = 0;
-  buffer = display_read_file(images[new_idx], &file_size);
-  if (!buffer || file_size == 0) { Log_info("Failed to read %s", images[new_idx]); return; }
-
-  preferences.putString(PREFERENCES_BROWSE_PATH_KEY, String(images[new_idx]));
-  display_show_image(buffer, file_size, true);
-  DisplayedImage::remember(images[new_idx]);
-  goToSleep();
 }
 
 void check_channel_states(void)

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -1,4 +1,6 @@
 #include <Arduino.h>
+#include <Preferences.h>
+#include <config.h>
 #include <filesystem.h>
 #include <inttypes.h>
 #include <trmnl_log.h>
@@ -297,6 +299,66 @@ void writeImageToFile(const char *name, uint8_t *in_buffer, size_t size) {
   } else {
     Log_info("file %s writing success - %d bytes", name, res);
   }
+}
+
+void update_playlist_order(Preferences &preferences, const char *new_path, const char *prev_path) {
+  String order = preferences.getString(PREFERENCES_PLAYLIST_ORDER_KEY, "");
+  String newStr = String(new_path);
+  String prefix = newStr.substring(0, 14); // same-plugin identity (matches purge logic)
+  String prevStr = String(prev_path);
+
+  if (order.isEmpty()) {
+    preferences.putString(PREFERENCES_PLAYLIST_ORDER_KEY, newStr);
+    return;
+  }
+
+  // Scan list: update in-place if prefix matches (refresh), otherwise build a cleaned list
+  // dropping entries whose files no longer exist (except prev_path, which anchors insertion).
+  bool found = false;
+  String result = "";
+  int start = 0;
+  while (start <= (int)order.length()) {
+    int sep = order.indexOf('|', start);
+    String entry = (sep < 0) ? order.substring(start) : order.substring(start, sep);
+    if (!entry.isEmpty()) {
+      if (!found && entry.startsWith(prefix)) {
+        result += (result.isEmpty() ? "" : "|") + newStr;
+        found = true;
+      } else if (entry == prevStr || filesystem_file_exists(entry.c_str())) {
+        result += (result.isEmpty() ? "" : "|") + entry;
+      }
+      // else: file was purged from filesystem — drop from list
+    }
+    if (sep < 0)
+      break;
+    start = sep + 1;
+  }
+  if (found) {
+    preferences.putString(PREFERENCES_PLAYLIST_ORDER_KEY, result);
+    return;
+  }
+
+  // New plugin — insert right after prev_path's position in the cleaned list
+  String result2 = "";
+  bool inserted = false;
+  start = 0;
+  while (start <= (int)result.length()) {
+    int sep = result.indexOf('|', start);
+    String entry = (sep < 0) ? result.substring(start) : result.substring(start, sep);
+    if (!entry.isEmpty()) {
+      result2 += (result2.isEmpty() ? "" : "|") + entry;
+      if (!inserted && entry == prevStr) {
+        result2 += "|" + newStr;
+        inserted = true;
+      }
+    }
+    if (sep < 0)
+      break;
+    start = sep + 1;
+  }
+  if (!inserted)
+    result2 += (result2.isEmpty() ? "" : "|") + newStr;
+  preferences.putString(PREFERENCES_PLAYLIST_ORDER_KEY, result2);
 }
 
 void filesystem_fix_filename(const char *src, char *dest) {

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -329,8 +329,7 @@ void update_playlist_order(Preferences &preferences, const char *new_path, const
       }
       // else: file was purged from filesystem — drop from list
     }
-    if (sep < 0)
-      break;
+    if (sep < 0) break;
     start = sep + 1;
   }
   if (found) {
@@ -352,12 +351,10 @@ void update_playlist_order(Preferences &preferences, const char *new_path, const
         inserted = true;
       }
     }
-    if (sep < 0)
-      break;
+    if (sep < 0) break;
     start = sep + 1;
   }
-  if (!inserted)
-    result2 += (result2.isEmpty() ? "" : "|") + newStr;
+  if (!inserted) result2 += (result2.isEmpty() ? "" : "|") + newStr;
   preferences.putString(PREFERENCES_PLAYLIST_ORDER_KEY, result2);
 }
 

--- a/src/touchbar_session.cpp
+++ b/src/touchbar_session.cpp
@@ -1,0 +1,88 @@
+#include <touchbar_session.h>
+
+#ifdef BOARD_TRMNL_X
+
+#include <Arduino.h>
+#include <config.h>
+#include <display.h>
+#include <filesystem.h>
+#include <globals.h>
+#include <trmnl_log.h>
+
+#include "displayed_image.h"
+
+void goToSleep(void);
+
+void show_cached_image_by_offset(int offset) {
+  String order = preferences.getString(PREFERENCES_PLAYLIST_ORDER_KEY, "");
+
+  if (order.isEmpty()) {
+    String path = (offset > 0) ? preferences.getString(PREFERENCES_CURRENT_PATH_KEY, "")
+                               : preferences.getString(PREFERENCES_LAST_PATH_KEY, "");
+    if (path.isEmpty()) {
+      Log_info("No cached image for gesture");
+      return;
+    }
+    int file_size = 0;
+    buffer = display_read_file(path.c_str(), &file_size);
+    if (buffer && file_size > 0) {
+      display_show_image(buffer, file_size, true);
+      DisplayedImage::remember(path.c_str());
+      goToSleep();
+    }
+    return;
+  }
+
+  char images[MAX_CACHED_IMAGES][36];
+  int count = 0;
+  int start = 0;
+  while (start <= (int)order.length() && count < MAX_CACHED_IMAGES) {
+    int sep = order.indexOf('|', start);
+    String entry = (sep < 0) ? order.substring(start) : order.substring(start, sep);
+    if (!entry.isEmpty() && filesystem_file_exists(entry.c_str())) {
+      strncpy(images[count], entry.c_str(), 35);
+      images[count][35] = '\0';
+      count++;
+    }
+    if (sep < 0) break;
+    start = sep + 1;
+  }
+
+  if (count == 0) {
+    Log_info("No cached images available");
+    return;
+  }
+
+  String browsePath = preferences.getString(PREFERENCES_BROWSE_PATH_KEY, "");
+  if (browsePath.isEmpty()) {
+    // Seed from last_path so first RIGHT shows curr_path (forward) and first LEFT shows older (backward).
+    // Falls back to curr_path if last_path is absent (e.g. only one image cached).
+    String lp = preferences.getString(PREFERENCES_LAST_PATH_KEY, "");
+    browsePath = lp.isEmpty() ? preferences.getString(PREFERENCES_CURRENT_PATH_KEY, "") : lp;
+  }
+
+  int cur_idx = count - 1;
+  for (int i = 0; i < count; i++) {
+    if (browsePath == String(images[i])) {
+      cur_idx = i;
+      break;
+    }
+  }
+
+  int new_idx = (cur_idx + offset + count) % count;
+  Log_info("Playlist browse: %d/%d -> %d (%s)", cur_idx, count, new_idx, images[new_idx]);
+
+  int file_size = 0;
+  buffer = display_read_file(images[new_idx], &file_size);
+  if (!buffer || file_size == 0) {
+    Log_info("Failed to read %s", images[new_idx]);
+    return;
+  }
+
+  preferences.putString(PREFERENCES_BROWSE_PATH_KEY, String(images[new_idx]));
+  display_show_image(buffer, file_size, true);
+  DisplayedImage::remember(images[new_idx]);
+  goToSleep();
+}
+
+#endif // BOARD_TRMNL_X


### PR DESCRIPTION
Relocate show_cached_image_by_offset out of bl.cpp so tap/slide gesture handlers call a shared browse API. Uses playlist_order / browse_path NVS and goToSleep after showing the cached image.

Builds on commits to gme/persist-playlist-paths (update_playlist_order in filesystem).
Gesture handlers stay in bl; only the browse implementation moves.
Already on this branch. Behaviour unchanged.

Verified: pio run -e trmnl