### PR TITLE
Fixed the setup screen being replaced by an API error

### DIFF
--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -1649,6 +1649,11 @@ static https_request_err_e downloadAndShow()
   }
 #endif // BOARD_TRMNL_X
 
+  // A 202 carries no image_url, so filename is still empty here. HTTPClient::begin() rejects
+  // that and the fetch below would report it as an API failure over the friendly ID screen.
+  if (filename[0] == '\0')
+    return result;
+
   result = withHttp(
       filename,
       [&](HTTPClient *httpsp, HttpError error) -> https_request_err_e

--- a/test/test_unclaimed_device_response/unclaimed_device_response.test.cpp
+++ b/test/test_unclaimed_device_response/unclaimed_device_response.test.cpp
@@ -5,11 +5,10 @@
 // account yet. Captured from production; the 202 arm of handleApiDisplayResponse() never
 // reads image_url, so the global filename buffer is still empty when downloadAndShow()
 // reaches the image fetch.
-static const char *UNCLAIMED_DEVICE_BODY =
-    "{\"status\":202,\"image_url\":null,\"filename\":null,\"refresh_rate\":908,"
-    "\"reset_firmware\":false,\"update_firmware\":false,\"firmware_url\":\"\","
-    "\"special_function\":\"identify\",\"maximum_compatibility\":false,"
-    "\"temperature_profile\":\"default\"}";
+static const char *UNCLAIMED_DEVICE_BODY = "{\"status\":202,\"image_url\":null,\"filename\":null,\"refresh_rate\":908,"
+                                           "\"reset_firmware\":false,\"update_firmware\":false,\"firmware_url\":\"\","
+                                           "\"special_function\":\"identify\",\"maximum_compatibility\":false,"
+                                           "\"temperature_profile\":\"default\"}";
 
 // The URL check HTTPClient::begin(WiFiClient&, String) runs before it will connect
 // (framework-arduinoespressif32/libraries/HTTPClient/src/HTTPClient.cpp).

--- a/test/test_unclaimed_device_response/unclaimed_device_response.test.cpp
+++ b/test/test_unclaimed_device_response/unclaimed_device_response.test.cpp
@@ -1,0 +1,51 @@
+#include <api_response_parsing.h>
+#include <unity.h>
+
+// What /api/display answers a device that finished setup but has not been claimed to an
+// account yet. Captured from production; the 202 arm of handleApiDisplayResponse() never
+// reads image_url, so the global filename buffer is still empty when downloadAndShow()
+// reaches the image fetch.
+static const char *UNCLAIMED_DEVICE_BODY =
+    "{\"status\":202,\"image_url\":null,\"filename\":null,\"refresh_rate\":908,"
+    "\"reset_firmware\":false,\"update_firmware\":false,\"firmware_url\":\"\","
+    "\"special_function\":\"identify\",\"maximum_compatibility\":false,"
+    "\"temperature_profile\":\"default\"}";
+
+// The URL check HTTPClient::begin(WiFiClient&, String) runs before it will connect
+// (framework-arduinoespressif32/libraries/HTTPClient/src/HTTPClient.cpp).
+static bool http_client_accepts_url(const String &url) {
+  int index = url.indexOf(':');
+  if (index < 0) return false;
+  String protocol = url.substring(0, index);
+  return protocol == "http" || protocol == "https";
+}
+
+void test_unclaimed_device_response_carries_no_image_url(void) {
+  String body(UNCLAIMED_DEVICE_BODY);
+  ApiDisplayResponse response = parseResponse_apiDisplay(body);
+
+  TEST_ASSERT_EQUAL(ApiDisplayOutcome::Ok, response.outcome);
+  TEST_ASSERT_EQUAL_UINT64(202, response.status);
+  TEST_ASSERT_EQUAL_STRING("", response.image_url.c_str());
+}
+
+void test_http_client_rejects_an_empty_image_url(void) {
+  TEST_ASSERT_FALSE(http_client_accepts_url(String("")));
+  TEST_ASSERT_TRUE(http_client_accepts_url(String("https://usetrmnl.com/images/screen.png")));
+}
+
+void setUp(void) {}
+
+void tearDown(void) {}
+
+void process() {
+  UNITY_BEGIN();
+  RUN_TEST(test_unclaimed_device_response_carries_no_image_url);
+  RUN_TEST(test_http_client_rejects_an_empty_image_url);
+  UNITY_END();
+}
+
+int main(int argc, char **argv) {
+  process();
+  return 0;
+}


### PR DESCRIPTION
A device that has finished /api/setup but has not been claimed to an account yet is answered with body status 202, and that response carries no image_url. The 202 arm of `handleApiDisplayResponse` never touches the global `filename` buffer, so it is still empty when `downloadAndShow` reaches the image fetch, which runs regardless. `HTTPClient::begin` rejects the empty URL, and since #570 that failure is assigned back over `result`, so `HTTPS_NO_REGISTER` becomes `HTTPS_UNABLE_TO_CONNECT` and the friendly ID screen is replaced by "WiFi connected, unable connect to API."

- returns early from the image fetch when there is no URL to fetch
- adds a native test covering the production 202 body and the URL check `HTTPClient::begin` runs

`result = withHttp(` is absent from v1.8.11 through v1.8.14 and present in v1.8.15 and on main, so only 1.8.15 devices are affected. It only bites in the window between setup and the device being claimed: after 24 hours the server answers those devices with a body-0 setup screen instead, and claiming the device ends it too, which is why it looks like it resolves on its own.

In production telemetry the "unable to connect" log line went from about one a day to 416 on 26 Aug and 788 on 27 Aug, and 1,205 of those 1,211 lines came from 1.8.15. On 27 Aug 42 devices on 1.8.15 saw a 202 and 40 logged the error. Affected models are TRMNL X and OG 2-bit. One device logged 48 of them over 40 minutes, almost all woken by the touch bar, so each retry repaints the error screen with a full refresh.

Built `pio run -e trmnl` and ran `pio test -e native -f test_unclaimed_device_response`. `TRMNL_X` does not build on my machine (missing `fatfs` python module in the espressif32 builder) and fails the same way on an unmodified checkout, so that one still needs a build from someone whose toolchain is complete.