### PR TITLE
Fixes code regression of device_simplified branch merge

### DIFF
--- a/src/bl.cpp
+++ b/src/bl.cpp
@@ -930,7 +930,7 @@ void bl_init(void)
     }
   }
   // Read the battery voltage BEFORE the display or WiFi is turned on
-  vBatt = battery().readVoltage();
+  vBatt = battery().readVoltage(pDevice);
 
   // EPD init
   // EPD clear


### PR DESCRIPTION
During the merge of the device_simplified branch into main, this line of code regressed and caused all ADC battery measurements to be 0.