### PR TITLE
Fix trmnl_gen2 build and I2C pin definitions

### DIFF
--- a/dependencies.lock.esp32c5
+++ b/dependencies.lock.esp32c5
@@ -250,7 +250,7 @@ dependencies:
       type: service
     version: 1.0.22~1
   espressif/mdns:
-    component_hash: e81ca7a7f53ea34e78274df054da692c272e1315572876b237b1748e267c013b
+    component_hash: 3ba256ac95e07c274be53cbd73f06cb846c403b61e8fbdf1be57bdb79db7a63e
     dependencies:
     - name: idf
       require: private
@@ -258,7 +258,7 @@ dependencies:
     source:
       registry_url: https://components.espressif.com/
       type: service
-    version: 1.11.3
+    version: 1.12.0
   espressif/network_provisioning:
     component_hash: ef2e10182fd1861e68b821491916327c25416ca7ae70e5a6e43313dbc71fe993
     dependencies:

--- a/platformio.ini
+++ b/platformio.ini
@@ -863,6 +863,15 @@ board_build.embed_txtfiles =
     managed_components/espressif__esp_rainmaker/server_certs/rmaker_claim_service_server.crt
     managed_components/espressif__esp_rainmaker/server_certs/rmaker_ota_server.crt
 
+lib_ldf_mode = deep
+lib_deps =
+	${deps_app.lib_deps}
+lib_ignore =
+	BMA530_SensorAPI
+	IQS323
+	trmnl_x
+	BQ27427
+
 [env:trmnl_gen2_4clr]
 board = esp32c5_n16r8
 board_build.esp-idf.sdkconfig_path = sdkconfigs/sdkconfig.${this.__env__}

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -46,7 +46,7 @@ const TRMNL_DEVICE device_list[] =
 // name            sck   mosi   cs   rst   dc   busy  sda   scl   intr   batt  batt_en, batt_type, panel
   "og",            7,    8,     6,   10,   5,   4,    21,   20,   2,     3,    0xff,    BATT_ADC,  EPD_75,
   "og_4clr",       7,    8,     6,   10,   5,   4,    21,   20,   2,     3,    0xff,    BATT_ADC,  EPD_75_4CLR,
-  "og_gen2",       6,    1,     4,   2,    5,   0,    11,   12,   3,     0xff, 0xff,    BATT_BQ27427,  EPD_75, // fake battery == 0xff
+  "og_gen2",       6,    1,     4,   2,    5,   0,    23,   10,   3,     0xff, 0xff,    BATT_BQ27427,  EPD_75, // fake battery == 0xff
   "og_gen2_4clr",  6,    1,     4,   2,    5,   0,    11,   12,   3,     0xff, 0xff,    BATT_BQ27427,  EPD_75_4CLR, // fake battery == 0xff
   "xteink_x4",     8,    10,    21,  5,    4,   6,    0xff, 0xff, 3,     0xff, 0xff,    BATT_ADC,  EPD_426,
   "waveshare",     13,   14,    15,  26,   27,  25,   0xff, 0xff, 33,    0xff, 0xff,    BATT_ADC,  EPD_75,


### PR DESCRIPTION
Follow-up to #550. This fixes minor breaking changes to the `trmnl_gen2` environment.

1. fix `platformio.ini` with some config that went missing when `trmnl_gen2_4clr` was added
2. fix SDA and SCL pin definitions → gas gauge IC now working