### PR TITLE
fixed orientation and partial updates for Seeed Sticky

### DIFF
--- a/include/globals.h
+++ b/include/globals.h
@@ -54,7 +54,7 @@ extern bool otg_message;
 
 // --- Display refresh bookkeeping ---
 extern int iUpdateCount;   // RTC: partial updates since the last full refresh
-extern bool bCanDoPartial; // RTC
+extern RTC_DATA_ATTR bool bCanDoPartial; // RTC
 extern uint32_t iTempProfile;
 
 #ifdef BOARD_TRMNL_X

--- a/platformio.ini
+++ b/platformio.ini
@@ -686,7 +686,7 @@ lib_deps =
 	https://github.com/bitbank2/bb_temperature.git#c660acbdabe25793b560e2546b97440bf7c42016
 	ESP32Async/ESPAsyncWebServer@3.7.7
     https://github.com/thijse/Arduino-Log.git#3f4fcf5a345c1d542e56b88c0ffcb2bd2a5b0bd0
-    https://github.com/bitbank2/bb_epaper.git#7df2bd1e5e70e7ab8966c0111563828ee9ed8912
+    https://github.com/bitbank2/bb_epaper.git#aeb5dbb4cf0efe89490840225409efa90175930c
 
 [env:TRMNL_7inch5_OG_DIY_Kit]
 extends = env:esp32_base

--- a/platformio.ini
+++ b/platformio.ini
@@ -686,7 +686,7 @@ lib_deps =
 	https://github.com/bitbank2/bb_temperature.git#c660acbdabe25793b560e2546b97440bf7c42016
 	ESP32Async/ESPAsyncWebServer@3.7.7
     https://github.com/thijse/Arduino-Log.git#3f4fcf5a345c1d542e56b88c0ffcb2bd2a5b0bd0
-    https://github.com/bitbank2/bb_epaper.git#aeb5dbb4cf0efe89490840225409efa90175930c
+    https://github.com/bitbank2/bb_epaper.git#bfb8dbca98f21e438d8cb23d306b057f516b6819
 
 [env:TRMNL_7inch5_OG_DIY_Kit]
 extends = env:esp32_base


### PR DESCRIPTION
The Seeed Sticky was having some update issues in addition to having the 1-bit 180 degrees rotated from the 2-bit gray mode. This fix uses a newer version of bb_epaper which corrects the errors.
