### PR TITLE
Mount LittleFS on parallel ePaper boards

### DIFF
--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -3,7 +3,7 @@
 #include <inttypes.h>
 #include <trmnl_log.h>
 
-#if defined(BOARD_X_CLASS)
+#if defined(PARALLEL_EPD)
 #include <LittleFS.h>
 #define FS LittleFS
 #else


### PR DESCRIPTION
`BOARD_X_CLASS` is no longer used since #550 