### PR TITLE
Return unknown for unlisted WiFi status

### DIFF
--- a/lib/wificaptive/src/wifi-helpers.cpp
+++ b/lib/wificaptive/src/wifi-helpers.cpp
@@ -19,6 +19,7 @@ const char *wifiStatusStr(wl_status_t wifi_status) {
       {"connect_failed", WL_CONNECT_FAILED},
       {"connection_lost", WL_CONNECTION_LOST},
       {"disconnected", WL_DISCONNECTED},
+      {"stopped", WL_STOPPED},
   };
 
   for (const WifiStatusNode &entry : wifiStatusMap) {

--- a/lib/wificaptive/src/wifi-helpers.cpp
+++ b/lib/wificaptive/src/wifi-helpers.cpp
@@ -24,7 +24,8 @@ const char *wifiStatusStr(wl_status_t wifi_status) {
   for (const WifiStatusNode &entry : wifiStatusMap) {
     if (wifi_status == entry.value) return entry.name;
   }
-  return nullptr;
+  // Callers strncpy this into a fixed-size log field, so it must never be null.
+  return "unknown";
 }
 
 void applyWifiHostname(const String &hostname) {


### PR DESCRIPTION
I got a crash on my local when WiFi has status code `WL_STOPPED` which is missing in the list. [reference](https://github.com/espressif/arduino-esp32/blob/6048a624f084ea7f645384fd91c57f43e633875d/libraries/WiFi/src/WiFiType.h#L45) 