### PR TITLE
Exclude WL_STOPPED from trmnl env

### DIFF
--- a/lib/wificaptive/src/wifi-helpers.cpp
+++ b/lib/wificaptive/src/wifi-helpers.cpp
@@ -19,7 +19,9 @@ const char *wifiStatusStr(wl_status_t wifi_status) {
       {"connect_failed", WL_CONNECT_FAILED},
       {"connection_lost", WL_CONNECTION_LOST},
       {"disconnected", WL_DISCONNECTED},
+#if ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(3, 0, 0)
       {"stopped", WL_STOPPED},
+#endif
   };
 
   for (const WifiStatusNode &entry : wifiStatusMap) {


### PR DESCRIPTION
In #619 I added a handler for `WL_STOPPED` but apparently that doesn't exist in older toolchains.